### PR TITLE
perf: optimize compliance-monitor workflow

### DIFF
--- a/.github/workflows/compliance-monitor.yml
+++ b/.github/workflows/compliance-monitor.yml
@@ -54,9 +54,10 @@ jobs:
           http://localhost:8080/about/
         uploadArtifacts: true
         temporaryPublicStorage: true
-        runs: 3
+        runs: 1  # Reduced from 3 to 1 for faster PR checks (was causing 8+ min delays)
         configPath: .lighthouserc.json
       continue-on-error: true
+      timeout-minutes: 5  # Prevent indefinite hanging
 
     - name: Check WCAG Compliance
       run: |

--- a/MANIFEST.json
+++ b/MANIFEST.json
@@ -2,7 +2,7 @@
   "version": "5.0.0",
   "schema": "optimized-lazy-loading",
   "generated": "2025-11-01T23:27:04-04:00",
-  "last_validated": "2025-11-12T12:05:09-04:00",
+  "last_validated": "2025-11-12T12:15:18-04:00",
   "repository": {
     "name": "williamzujkowski.github.io",
     "type": "personal-website",


### PR DESCRIPTION
## Summary

Lighthouse CI was causing 8+ minute delays in PR checks (discovered during PR #24 monitoring).

**Root cause:** 3 runs × 3 URLs = 9 total Lighthouse runs (~60s each = 9 minutes)

**Changes:**
- ✅ Reduced `runs` from 3 to 1 (sufficient for PR validation)
- ✅ Added 5-minute `timeout` to prevent indefinite hanging
- ✅ Kept 3 URL coverage (homepage, posts, about)

**Expected impact:** 8-10 min → 2-3 min for compliance-check job

## Test Plan

- [x] Pre-commit validators passed (10/10)
- [ ] PR checks complete in <3 minutes
- [ ] All other checks still pass
- [ ] Lighthouse scores remain acceptable

## Context

PR #24 had compliance-check pending for 8+ minutes while all other checks passed. Investigation revealed Lighthouse CI running 9 total checks with no timeout, causing excessive delay in PR feedback loop.

This optimization maintains quality (still tests 3 key pages) while dramatically improving CI/CD speed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)