### PR TITLE
fix: improve readability, typography, and responsive layouts

### DIFF
--- a/MANIFEST.json
+++ b/MANIFEST.json
@@ -2,7 +2,7 @@
   "version": "5.0.0",
   "schema": "optimized-lazy-loading",
   "generated": "2025-11-01T23:27:04-04:00",
-  "last_validated": "2026-02-03T00:39:53-04:00",
+  "last_validated": "2026-02-03T00:50:48-04:00",
   "repository": {
     "name": "williamzujkowski.github.io",
     "type": "personal-website",

--- a/src/_includes/layouts/page.njk
+++ b/src/_includes/layouts/page.njk
@@ -22,7 +22,7 @@ layout: base
             {% set lastModified = page.inputPath | gitLastModified %}
             {% if lastModified %}
             <footer role="contentinfo" aria-label="Site footer" class="mt-16 pt-8 border-t border-gray-200 dark:border-gray-800">
-                <p class="text-sm text-gray-500 dark:text-gray-400 text-center italic">
+                <p class="text-sm text-gray-600 dark:text-gray-300 text-center italic">
                     Last updated: {{ lastModified | readableDate }}
                 </p>
             </footer>

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -137,7 +137,7 @@ layout: base
                             <p class="text-sm text-gray-600 dark:text-gray-400 mb-3">
                                 {{ relPost.data.description | truncate(100) }}
                             </p>
-                            <div class="flex items-center justify-between text-xs text-gray-500 dark:text-gray-500">
+                            <div class="flex items-center justify-between text-xs text-gray-600 dark:text-gray-400">
                                 <time datetime="{{ relPost.date | htmlDateString }}">
                                     {{ relPost.date | readableDate }}
                                 </time>

--- a/src/assets/css/tailwind.css
+++ b/src/assets/css/tailwind.css
@@ -196,7 +196,7 @@
     --font-scale-ratio: 1.2;
     --font-size-xs: clamp(0.75rem, 0.7rem + 0.25vw, 0.875rem);
     --font-size-sm: clamp(0.875rem, 0.8rem + 0.375vw, 1rem);
-    --font-size-base: clamp(1rem, 0.9rem + 0.5vw, 1.125rem);
+    --font-size-base: clamp(1rem, 0.9rem + 0.5vw, 1.1875rem);
     --font-size-lg: clamp(1.125rem, 1rem + 0.625vw, 1.25rem);
     --font-size-xl: clamp(1.25rem, 1.1rem + 0.75vw, 1.5rem);
     --font-size-2xl: clamp(1.5rem, 1.3rem + 1vw, 1.875rem);

--- a/src/assets/css/theme-tokens.css
+++ b/src/assets/css/theme-tokens.css
@@ -222,8 +222,8 @@ h3 {
 
 p {
   color: var(--fg-secondary);
-  line-height: 1.75;
-  margin-bottom: var(--space-md);
+  line-height: 1.8;
+  margin-bottom: var(--space-lg);
 }
 
 /* Code blocks with theme support */
@@ -300,12 +300,12 @@ code {
 /* Ensure readability with proper line length */
 .prose {
   max-width: 65ch;
-  font-size: 1.125rem;
-  line-height: 1.75;
+  font-size: 1.1875rem;
+  line-height: 1.8;
 }
 
 .prose > * {
-  margin-bottom: var(--space-md);
+  margin-bottom: var(--space-lg);
 }
 
 /* Responsive adjustments */
@@ -313,5 +313,5 @@ code {
   h1 { font-size: 2rem; }
   h2 { font-size: 1.5rem; margin-top: var(--space-2xl); }
   h3 { font-size: 1.25rem; margin-top: var(--space-xl); }
-  .prose { font-size: 1rem; }
+  .prose { font-size: 1.0625rem; }
 }

--- a/src/index.njk
+++ b/src/index.njk
@@ -80,12 +80,12 @@ eleventyNavigation:
             </p>
         </div>
         
-        <div class="mx-auto mt-16 grid max-w-2xl grid-cols-1 gap-x-8 gap-y-12 lg:mx-0 lg:max-w-none lg:grid-cols-3">
+        <div class="mx-auto mt-16 grid max-w-2xl grid-cols-1 gap-x-8 gap-y-12 md:grid-cols-2 lg:mx-0 lg:max-w-none lg:grid-cols-3">
             {% set posts = collections.posts | reverse %}
             {% if posts.length > 0 %}
                 {% for post in posts | limit(3) %}
                 <article class="group hover-card glass dark:glass-dark rounded-2xl p-8">
-                    <time datetime="{{ post.date | htmlDateString }}" class="text-sm text-gray-500 dark:text-gray-400">
+                    <time datetime="{{ post.date | htmlDateString }}" class="text-sm text-gray-600 dark:text-gray-300">
                         {{ post.date | readableDate }}
                     </time>
                     <h3 class="mt-3 text-lg font-semibold leading-6 text-gray-900 dark:text-gray-100 group-hover:text-primary-600 dark:group-hover:text-primary-400">
@@ -110,7 +110,7 @@ eleventyNavigation:
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
                     </svg>
                     <h3 class="mt-2 text-sm font-semibold text-gray-900 dark:text-gray-100">No posts yet</h3>
-                    <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Get started by creating your first post.</p>
+                    <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">Get started by creating your first post.</p>
                 </div>
             {% endif %}
         </div>
@@ -138,7 +138,7 @@ eleventyNavigation:
         </div>
         
         <div class="mx-auto mt-16 max-w-2xl sm:mt-20 lg:mt-24 lg:max-w-none">
-            <dl class="grid max-w-xl grid-cols-1 gap-x-8 gap-y-16 lg:max-w-none lg:grid-cols-2 xl:grid-cols-4">
+            <dl class="grid max-w-xl grid-cols-1 gap-x-8 gap-y-16 md:max-w-none md:grid-cols-2 xl:grid-cols-4">
                 <div class="flex flex-col">
                     <dt class="text-base font-semibold leading-7 text-gray-900 dark:text-gray-100">
                         <div class="mb-6 flex h-10 w-10 items-center justify-center rounded-lg bg-primary-600">


### PR DESCRIPTION
## Summary
- Increased body font size to 19px desktop / 17px mobile for better readability
- Increased paragraph line-height (1.75 → 1.8) and spacing (1rem → 1.5rem)
- Added `md:grid-cols-2` breakpoint for card grids (smooth 1→2→3/4 column transition)
- Upgraded secondary text contrast (gray-500 → gray-600 light, gray-500/400 → gray-400/300 dark)

## Test plan
- [x] `npm run build` passes
- [x] All 5 unit tests pass
- [x] All 11 pre-commit checks pass
- [x] Visual: text more readable at desktop widths
- [x] Visual: cards reflow properly at tablet breakpoint

Closes #37, Closes #38, Closes #39, Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)