### PR TITLE
fix: mobile navigation and hero layout improvements

### DIFF
--- a/MANIFEST.json
+++ b/MANIFEST.json
@@ -2,7 +2,7 @@
   "version": "5.0.0",
   "schema": "optimized-lazy-loading",
   "generated": "2025-11-01T23:27:04-04:00",
-  "last_validated": "2026-02-03T00:50:48-04:00",
+  "last_validated": "2026-02-03T00:58:31-04:00",
   "repository": {
     "name": "williamzujkowski.github.io",
     "type": "personal-website",

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -130,7 +130,7 @@
             <div class="flex items-center justify-between h-16">
                 <!-- Logo -->
                 <div class="flex-shrink-0">
-                    <a href="/" class="text-xl font-semibold gradient-text">
+                    <a href="/" class="text-base sm:text-xl font-semibold gradient-text">
                         {{ site.title }}
                     </a>
                 </div>

--- a/src/index.njk
+++ b/src/index.njk
@@ -13,7 +13,7 @@ eleventyNavigation:
         <div class="relative left-[calc(50%-11rem)] aspect-[1155/678] w-[36.125rem] -translate-x-1/2 rotate-[30deg] bg-gradient-to-tr from-primary-400 to-primary-600 opacity-20 sm:left-[calc(50%-30rem)] sm:w-[72.1875rem]"></div>
     </div>
     
-    <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-24 sm:py-32 lg:py-40">
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-16 sm:py-24 lg:py-40">
         <div class="mx-auto max-w-5xl">
             <div class="grid grid-cols-1 lg:grid-cols-2 gap-8 lg:gap-12 items-center">
                 <div class="text-center lg:text-left">
@@ -35,8 +35,8 @@ eleventyNavigation:
                         </a>
                     </div>
                 </div>
-                <div class="flex justify-center lg:justify-end animate-fade-in-up animation-delay-200">
-                    <img src="/assets/images/headshot.png" alt="William Zujkowski" class="w-64 h-64 lg:w-80 lg:h-80 rounded-full shadow-2xl ring-4 ring-primary-100 dark:ring-primary-900" loading="eager" width="320" height="320">
+                <div class="flex justify-center lg:justify-end animate-fade-in-up animation-delay-200 order-first lg:order-last">
+                    <img src="/assets/images/headshot.png" alt="William Zujkowski" class="w-48 h-48 sm:w-64 sm:h-64 lg:w-80 lg:h-80 rounded-full shadow-2xl ring-4 ring-primary-100 dark:ring-primary-900" loading="eager" width="320" height="320">
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- Responsive branding text size for small screens (text-base at 320px, text-xl at 640px+)
- Reduced hero section padding on mobile for better content visibility
- Image-first layout on mobile with smaller image size (192px → 256px → 320px)

## Test plan
- [x] `npm run build` passes
- [x] All 5 unit tests pass
- [x] All pre-commit checks pass
- [x] Nav text doesn't wrap at 320px viewport

Closes #41, Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)