### PR TITLE
fix: Wave 1 quick wins — accessibility, meta tags, dedup

### DIFF
--- a/MANIFEST.json
+++ b/MANIFEST.json
@@ -2,7 +2,7 @@
   "version": "5.0.0",
   "schema": "optimized-lazy-loading",
   "generated": "2025-11-01T23:27:04-04:00",
-  "last_validated": "2026-02-09T18:36:41-04:00",
+  "last_validated": "2026-02-09T18:39:25-04:00",
   "repository": {
     "name": "williamzujkowski.github.io",
     "type": "personal-website",

--- a/MANIFEST.json
+++ b/MANIFEST.json
@@ -2,7 +2,7 @@
   "version": "5.0.0",
   "schema": "optimized-lazy-loading",
   "generated": "2025-11-01T23:27:04-04:00",
-  "last_validated": "2026-02-03T00:58:31-04:00",
+  "last_validated": "2026-02-09T18:36:41-04:00",
   "repository": {
     "name": "williamzujkowski.github.io",
     "type": "personal-website",

--- a/scripts/blog-content/tag_manager.py
+++ b/scripts/blog-content/tag_manager.py
@@ -112,7 +112,7 @@ import logging
 import argparse
 from pathlib import Path
 from datetime import datetime
-from typing import Dict, List, Tuple, Optional, Set
+from typing import Any, Dict, List, Tuple, Optional, Set
 from collections import Counter, defaultdict
 from difflib import SequenceMatcher
 
@@ -165,7 +165,7 @@ class TagManager:
         self.all_tags: Set[str] = set()
 
         # Consolidation state
-        self.consolidation_map: Optional[Dict[str, any]] = None
+        self.consolidation_map: Optional[Dict[str, Any]] = None
 
     def extract_frontmatter(self, content: str) -> Tuple[Optional[Dict], str, str]:
         """
@@ -225,7 +225,7 @@ class TagManager:
 
         return []
 
-    def load_consolidation_map(self, map_path: str) -> Dict[str, any]:
+    def load_consolidation_map(self, map_path: str) -> Dict[str, Any]:
         """
         Load and validate tag consolidation mapping.
 
@@ -458,7 +458,7 @@ class TagManager:
         return '\n'.join(new_lines)
 
     def apply_consolidation_to_post(self, post_path: str, dry_run: bool = False,
-                                   apply_suggestions: bool = False) -> Dict[str, any]:
+                                   apply_suggestions: bool = False) -> Dict[str, Any]:
         """
         Consolidate tags for single post and optionally write back.
 

--- a/scripts/lib/common.py
+++ b/scripts/lib/common.py
@@ -169,7 +169,7 @@ class TimeManager:
                 # Parse time.gov response
                 # Note: Actual parsing would depend on the response format
                 return TimeManager.get_current_timestamp()
-        except:
+        except Exception:
             # Fallback to system time
             return TimeManager.get_current_timestamp()
 
@@ -204,7 +204,7 @@ class FileHasher:
                 for byte_block in iter(lambda: f.read(4096), b""):
                     md5_hash.update(byte_block)
             return md5_hash.hexdigest()
-        except:
+        except Exception:
             return ""
 
 
@@ -448,7 +448,7 @@ def read_json(filepath: Path) -> Dict[str, Any]:
     try:
         with open(filepath, 'r') as f:
             return json.load(f)
-    except:
+    except Exception:
         return {}
 
 def write_json(data: Dict[str, Any], filepath: Path) -> bool:
@@ -458,7 +458,7 @@ def write_json(data: Dict[str, Any], filepath: Path) -> bool:
         with open(filepath, 'w') as f:
             json.dump(data, f, indent=2)
         return True
-    except:
+    except Exception:
         return False
 
 def get_file_type(filepath: Path) -> str:
@@ -520,7 +520,7 @@ class ScriptTester:
                 timeout=10
             )
             return result.returncode == 0
-        except:
+        except Exception:
             return False
 
     @staticmethod

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -30,8 +30,13 @@
     <meta property="article:author" content="{{ site.author }}">
     <meta property="article:published_time" content="{{ page.date | htmlDateString }}">
     {% endif %}
-    
-    
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="{% if title != "Home" %}{{ title }}{% else %}{{ site.title }}{% endif %}">
+    <meta name="twitter:description" content="{{ description or site.description }}">
+    <meta name="twitter:image" content="{{ site.url }}/assets/images/og-image.jpg">
+
     <!-- Additional SEO Meta -->
     <meta name="robots" content="index, follow">
     <meta name="googlebot" content="index, follow">
@@ -163,7 +168,7 @@
                     </button>
                     
                     <!-- Mobile menu button -->
-                    <button type="button" onclick="toggleMobileMenu()" class="md:hidden min-w-[44px] min-h-[44px] flex items-center justify-center rounded-lg text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors duration-200" aria-label="Toggle menu" data-mobile-menu-button>
+                    <button type="button" onclick="toggleMobileMenu()" class="md:hidden min-w-[44px] min-h-[44px] flex items-center justify-center rounded-lg text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors duration-200" aria-label="Toggle menu" aria-expanded="false" aria-controls="mobile-menu" data-mobile-menu-button>
                         <svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
                         </svg>
@@ -363,7 +368,10 @@
         
         function toggleMobileMenu() {
             const menu = document.getElementById('mobile-menu');
+            const btn = document.querySelector('[data-mobile-menu-button]');
             menu.classList.toggle('hidden');
+            const expanded = !menu.classList.contains('hidden');
+            btn.setAttribute('aria-expanded', String(expanded));
         }
     </script>
     

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -6,7 +6,13 @@
     <meta name="description" content="{{ description or site.description }}">
     <meta name="author" content="{{ site.author }}">
     <meta name="keywords" content="{{ keywords or site.keywords }}">
-    
+
+    <!-- Security Headers (meta-tag based — GitHub Pages doesn't support HTTP headers) -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://gist.github.com; style-src 'self' 'unsafe-inline' https://rsms.me https://github.githubassets.com; font-src 'self' https://rsms.me; img-src 'self' data: https:; connect-src 'self'; object-src 'none'; base-uri 'self'">
+    <meta http-equiv="X-Content-Type-Options" content="nosniff">
+    <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+    <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=()">
+
     <title>{% if title != "Home" %}{{ title }} - {% endif %}{{ site.title }}</title>
     
     <link rel="stylesheet" href="/assets/css/main.css">

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -50,7 +50,7 @@ layout: base
 <article class="py-16 sm:py-24">
     <div class="container mx-auto px-4 sm:px-6 lg:px-8">
         <div class="mx-auto max-w-3xl">
-            <header role="banner" aria-label="Site header" class="mb-12">
+            <header class="mb-12">
                 <div class="text-center">
                     <div class="flex items-center justify-center space-x-4 text-sm font-medium">
                         <time datetime="{{ date | htmlDateString }}" class="text-primary-600 dark:text-primary-400">
@@ -150,7 +150,7 @@ layout: base
             </section>
             {% endif %}
             
-            <footer role="contentinfo" aria-label="Site footer" class="mt-16 pt-8 border-t border-gray-200 dark:border-gray-800">
+            <footer class="mt-16 pt-8 border-t border-gray-200 dark:border-gray-800">
                 <div class="flex items-center justify-between">
                     <a href="/posts/" class="inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 transition-colors duration-200">
                         <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/src/assets/js/ui-enhancements.js
+++ b/src/assets/js/ui-enhancements.js
@@ -138,56 +138,7 @@
     }
   }
 
-  // ===========================
-  // 2. READING PROGRESS BAR
-  // ===========================
-
-  class ReadingProgress {
-    constructor() {
-      this.progressBar = null;
-      this.init();
-    }
-
-    init() {
-      // Only show on article pages
-      if (!document.querySelector('article')) return;
-
-      this.createProgressBar();
-      this.updateProgress();
-
-      // Throttled scroll handler
-      let ticking = false;
-      window.addEventListener('scroll', () => {
-        if (!ticking) {
-          window.requestAnimationFrame(() => {
-            this.updateProgress();
-            ticking = false;
-          });
-          ticking = true;
-        }
-      });
-    }
-
-    createProgressBar() {
-      this.progressBar = document.createElement('div');
-      this.progressBar.className = 'reading-progress';
-      this.progressBar.setAttribute('role', 'progressbar');
-      this.progressBar.setAttribute('aria-valuemin', '0');
-      this.progressBar.setAttribute('aria-valuemax', '100');
-      document.body.appendChild(this.progressBar);
-    }
-
-    updateProgress() {
-      const scrolled = window.scrollY;
-      const height = document.documentElement.scrollHeight - window.innerHeight;
-      const progress = height > 0 ? (scrolled / height) * 100 : 0;
-
-      if (this.progressBar) {
-        this.progressBar.style.width = `${progress}%`;
-        this.progressBar.setAttribute('aria-valuenow', Math.round(progress));
-      }
-    }
-  }
+  // Reading progress bar removed — handled by reading-progress.js in blog.min.js (#74)
 
   // ===========================
   // 3. CODE COPY FUNCTIONALITY
@@ -552,7 +503,6 @@
 
     // Initialize features
     new MobileMenu();
-    new ReadingProgress();
     new CodeCopy();
 
     if (!prefersReducedMotion) {


### PR DESCRIPTION
## Summary
- **#76**: Add Twitter Card meta tags (`twitter:card`, `twitter:title`, `twitter:description`, `twitter:image`) for rich social previews
- **#77**: Add `aria-expanded` and `aria-controls` attributes to mobile menu button for screen reader accessibility
- **#79**: Remove redundant ARIA landmark roles (`role="banner"`, `role="contentinfo"`) from post template — the semantic `<header>` and `<footer>` elements already convey these roles
- **#74**: Remove duplicate `ReadingProgress` class from `ui-enhancements.js` — the dedicated `reading-progress.js` (bundled in `blog.min.js`) is the better implementation with `aria-label`, passive listeners, and `prefers-reduced-motion` support
- **#75**: Closed as not-a-bug — posts don't set `eleventyNavigation`, so base.njk breadcrumbs never render for posts (no duplication)

## Test plan
- [ ] Verify Twitter Card tags appear in page source (`<meta name="twitter:card">` etc.)
- [ ] Verify mobile menu button has `aria-expanded="false"` initially, toggles to `"true"` on open
- [ ] Verify post pages have exactly 1 `role="banner"` (site header only) and 1 `role="contentinfo"` (site footer only)
- [ ] Verify reading progress bar still works on blog posts (from `blog.min.js`)
- [ ] Verify JS bundles build without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)