### PR TITLE
fix: hamburger menu visible on desktop (CSS layer conflict)

### DIFF
--- a/MANIFEST.json
+++ b/MANIFEST.json
@@ -2,7 +2,7 @@
   "version": "5.0.0",
   "schema": "optimized-lazy-loading",
   "generated": "2025-11-01T23:27:04-04:00",
-  "last_validated": "2026-02-09T18:39:25-04:00",
+  "last_validated": "2026-02-09T18:54:10-04:00",
   "repository": {
     "name": "williamzujkowski.github.io",
     "type": "personal-website",

--- a/src/assets/css/enhancements.css
+++ b/src/assets/css/enhancements.css
@@ -133,12 +133,18 @@ button,
 .btn {
   cursor: pointer;
   transition: all 0.2s ease;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
   gap: 0.5rem;
   text-decoration: none;
   border-radius: 0.5rem;
+}
+
+/* Button layout — only apply to buttons not hidden by Tailwind responsive utilities */
+.btn,
+.btn-primary,
+.btn-secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 button:hover,


### PR DESCRIPTION
## Summary
- The hamburger menu icon was visible at all screen sizes, including desktop, despite having `md:hidden`
- **Root cause**: `enhancements.css` applied `display: inline-flex` to all `button` elements outside any CSS `@layer` — unlayered CSS always beats Tailwind's `@layer utilities` in the cascade
- **Fix**: Moved `display: inline-flex` to only apply to `.btn`, `.btn-primary`, `.btn-secondary` classes, letting Tailwind responsive utilities properly control the hamburger button visibility

## Test plan
- [ ] Verify hamburger menu is hidden on desktop (>768px)
- [ ] Verify hamburger menu appears on mobile (<768px)
- [ ] Verify "Learn more about me" and other `.btn` buttons still display correctly
- [ ] Verify no visual regressions on buttons across the site

🤖 Generated with [Claude Code](https://claude.com/claude-code)