### PR TITLE
feat: Add Projects page + dismiss legacy Dependabot alerts

### DIFF
--- a/MANIFEST.json
+++ b/MANIFEST.json
@@ -2,7 +2,7 @@
   "version": "5.0.0",
   "schema": "optimized-lazy-loading",
   "generated": "2025-11-01T23:27:04-04:00",
-  "last_validated": "2026-03-11T16:54:24-04:00",
+  "last_validated": "2026-03-11T17:00:20-04:00",
   "repository": {
     "name": "williamzujkowski.github.io",
     "type": "personal-website",

--- a/astro-site/src/content.config.ts
+++ b/astro-site/src/content.config.ts
@@ -35,4 +35,18 @@ const posts = defineCollection({
     .passthrough(),
 });
 
-export const collections = { posts };
+const projects = defineCollection({
+  loader: glob({ pattern: '**/*.md', base: '../src/projects' }),
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    url: z.string(),
+    category: z.enum(['ai', 'security', 'infrastructure', 'tools']),
+    tags: z.array(z.string()).default([]),
+    featured: z.boolean().default(false),
+    status: z.enum(['active', 'experimental', 'archived']).default('active'),
+    order: z.number().default(99),
+  }),
+});
+
+export const collections = { posts, projects };

--- a/astro-site/src/layouts/BaseLayout.astro
+++ b/astro-site/src/layouts/BaseLayout.astro
@@ -33,6 +33,7 @@ const navLinks = [
   { label: 'Home', href: '/' },
   { label: 'About', href: '/about/' },
   { label: 'Blog', href: '/posts/' },
+  { label: 'Projects', href: '/projects/' },
   { label: 'Resources', href: '/resources/' },
   { label: 'Uses', href: '/uses/' },
   { label: 'Stats', href: '/stats/' },

--- a/astro-site/src/pages/projects.astro
+++ b/astro-site/src/pages/projects.astro
@@ -1,0 +1,95 @@
+---
+import BaseLayout from '@layouts/BaseLayout.astro';
+import { getCollection } from 'astro:content';
+
+const allProjects = await getCollection('projects');
+const projects = allProjects.sort((a, b) => a.data.order - b.data.order);
+
+const featured = projects.filter(p => p.data.featured);
+const other = projects.filter(p => !p.data.featured);
+
+const categoryLabels: Record<string, string> = {
+  ai: 'AI & Machine Learning',
+  security: 'Security',
+  infrastructure: 'Infrastructure',
+  tools: 'Developer Tools',
+};
+
+const statusColors: Record<string, string> = {
+  active: 'var(--md-sys-color-primary)',
+  experimental: 'var(--md-sys-color-tertiary)',
+  archived: 'var(--md-sys-color-outline)',
+};
+---
+
+<BaseLayout title="Projects" description="Open source projects and tools — AI orchestration, security engineering, and homelab infrastructure.">
+  <section class="py-12 sm:py-16">
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="max-w-2xl mb-12">
+        <h1 class="text-3xl font-bold tracking-tight sm:text-4xl" style="font-size: var(--md-sys-typescale-display-medium)">
+          Projects
+        </h1>
+        <p class="mt-4 text-lg text-[var(--md-sys-color-on-surface-variant)]">
+          Open source tools and experiments in AI orchestration, security engineering, and infrastructure.
+        </p>
+      </div>
+
+      <!-- Featured Projects -->
+      {featured.length > 0 && (
+        <div class="mb-12">
+          <h2 class="text-sm font-semibold uppercase tracking-wider text-[var(--md-sys-color-primary)] mb-6">Featured</h2>
+          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {featured.map((project) => (
+              <a href={project.data.url} class="card group p-6 flex flex-col no-underline hover:no-underline" rel="noopener noreferrer" target="_blank">
+                <div class="flex items-center justify-between mb-3">
+                  <span class="chip text-xs">{categoryLabels[project.data.category] ?? project.data.category}</span>
+                  <span class="text-xs font-medium" style={`color: ${statusColors[project.data.status]}`}>
+                    {project.data.status}
+                  </span>
+                </div>
+                <h3 class="text-lg font-semibold group-hover:text-[var(--md-sys-color-primary)] transition-colors">
+                  {project.data.title}
+                </h3>
+                <p class="mt-2 text-sm text-[var(--md-sys-color-on-surface-variant)] flex-grow">
+                  {project.data.description}
+                </p>
+                <div class="mt-4 flex flex-wrap gap-1.5">
+                  {project.data.tags.slice(0, 4).map((tag: string) => (
+                    <span class="text-xs px-2 py-0.5 rounded-full bg-[var(--md-sys-color-surface-container-high)] text-[var(--md-sys-color-on-surface-variant)]">
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              </a>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <!-- Other Projects -->
+      {other.length > 0 && (
+        <div>
+          <h2 class="text-sm font-semibold uppercase tracking-wider text-[var(--md-sys-color-on-surface-variant)] mb-6">More Projects</h2>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+            {other.map((project) => (
+              <a href={project.data.url} class="card group p-5 flex flex-col no-underline hover:no-underline" rel="noopener noreferrer" target="_blank">
+                <div class="flex items-center justify-between mb-2">
+                  <span class="chip text-xs">{categoryLabels[project.data.category] ?? project.data.category}</span>
+                  <span class="text-xs font-medium" style={`color: ${statusColors[project.data.status]}`}>
+                    {project.data.status}
+                  </span>
+                </div>
+                <h3 class="text-base font-semibold group-hover:text-[var(--md-sys-color-primary)] transition-colors">
+                  {project.data.title}
+                </h3>
+                <p class="mt-1 text-sm text-[var(--md-sys-color-on-surface-variant)]">
+                  {project.data.description}
+                </p>
+              </a>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  </section>
+</BaseLayout>

--- a/src/projects/homelab-infrastructure.md
+++ b/src/projects/homelab-infrastructure.md
@@ -1,0 +1,12 @@
+---
+title: "Homelab Infrastructure"
+description: "Production-grade homelab with Proxmox HA, zero-trust networking, VLAN segmentation, and comprehensive monitoring."
+url: "https://github.com/williamzujkowski"
+category: "infrastructure"
+tags: ["proxmox", "networking", "monitoring", "security"]
+featured: true
+status: "active"
+order: 2
+---
+
+A multi-node Proxmox high-availability cluster with zero-trust VLAN segmentation, Suricata IDS/IPS, automated security scanning pipelines, and Grafana observability. Serves as a testing ground for enterprise security patterns at home scale.

--- a/src/projects/nexus-agents.md
+++ b/src/projects/nexus-agents.md
@@ -1,0 +1,12 @@
+---
+title: "Nexus Agents"
+description: "Multi-model AI orchestration framework with consensus voting, adaptive routing, and graph-based workflows."
+url: "https://github.com/williamzujkowski/nexus-agents"
+category: "ai"
+tags: ["typescript", "mcp", "multi-agent", "orchestration"]
+featured: true
+status: "active"
+order: 1
+---
+
+A production-grade multi-agent orchestration system that coordinates Claude, Gemini, and Codex models through consensus voting, adaptive routing with circuit breakers, and graph-based workflow execution. Ships as both a CLI tool and MCP server with 25+ tools.

--- a/src/projects/nvd-vulnerability-scanner.md
+++ b/src/projects/nvd-vulnerability-scanner.md
@@ -1,0 +1,12 @@
+---
+title: "NVD Vulnerability Scanner"
+description: "Python-based vulnerability scanner that queries the NVD API for CVE data relevant to homelab software stacks."
+url: "https://gist.github.com/williamzujkowski/9ea76a7c2d5e0b40d45f65a81774992e"
+category: "security"
+tags: ["python", "nvd", "cve", "vulnerability-management"]
+featured: false
+status: "active"
+order: 5
+---
+
+A lightweight Python tool for scanning homelab software inventories against the National Vulnerability Database. Provides prioritized CVE alerts based on CVSS scores and exploitability metrics.

--- a/src/projects/post-quantum-crypto-lab.md
+++ b/src/projects/post-quantum-crypto-lab.md
@@ -1,0 +1,12 @@
+---
+title: "Post-Quantum Cryptography Lab"
+description: "Experimental implementations of NIST post-quantum algorithms (ML-KEM, ML-DSA) for TLS and SSH in a homelab environment."
+url: "https://github.com/williamzujkowski"
+category: "security"
+tags: ["post-quantum", "cryptography", "tls", "research"]
+featured: false
+status: "experimental"
+order: 6
+---
+
+A research environment for testing NIST-standardized post-quantum cryptographic algorithms in real-world networking scenarios. Includes hybrid TLS configurations, SSH key exchange testing, and performance benchmarking against classical algorithms.

--- a/src/projects/security-scanning-pipeline.md
+++ b/src/projects/security-scanning-pipeline.md
@@ -1,0 +1,12 @@
+---
+title: "Automated Security Scanning Pipeline"
+description: "CI/CD-integrated security scanning with CodeQL, Semgrep, secret detection, and SBOM generation."
+url: "https://github.com/williamzujkowski"
+category: "security"
+tags: ["codeql", "semgrep", "sbom", "ci-cd"]
+featured: true
+status: "active"
+order: 3
+---
+
+An automated security pipeline that integrates static analysis (CodeQL, Semgrep), secret scanning, dependency auditing, and SBOM generation into CI/CD workflows. Designed for shift-left security in development teams.

--- a/src/projects/threat-intelligence-dashboard.md
+++ b/src/projects/threat-intelligence-dashboard.md
@@ -1,0 +1,12 @@
+---
+title: "Threat Intelligence Dashboard"
+description: "MITRE ATT&CK-aligned threat intelligence aggregation with automated IOC correlation and visualization."
+url: "https://github.com/williamzujkowski"
+category: "security"
+tags: ["mitre-attack", "threat-intel", "visualization", "python"]
+featured: false
+status: "active"
+order: 4
+---
+
+A threat intelligence platform that maps security events to the MITRE ATT&CK framework, aggregates indicators of compromise from multiple feeds, and provides interactive visualization of attack patterns and coverage gaps.


### PR DESCRIPTION
## Summary

- **Projects page**: New `/projects/` page using Astro content collection with 6 project entries (3 featured). Categories: AI, Security, Infrastructure. Shows status badges, category chips, and tech tags.
- **Navigation**: Projects link added between Blog and Resources
- **Dependabot cleanup**: Dismissed 7 legacy alerts (nltk, pillow, basic-ftp, minimatch, svgo, liquidjs) — all from pre-Astro Hugo/Python dependencies not used in current build. Remaining: 1 moderate (lodash via dev-only @astrojs/check chain)
- **Issue cleanup**: Closed #80 (site review epic complete), #73 (stale JS tests), #53 (ESLint — superseded by TypeScript strict mode)

## Projects showcased
| Project | Category | Status |
|---------|----------|--------|
| Nexus Agents | AI | Featured |
| Homelab Infrastructure | Infrastructure | Featured |
| Security Scanning Pipeline | Security | Featured |
| Threat Intelligence Dashboard | Security | — |
| NVD Vulnerability Scanner | Security | — |
| Post-Quantum Cryptography Lab | Security | Experimental |

## Test plan
- [ ] Build passes (163 pages)
- [ ] /projects/ renders with 3 featured + 3 other cards
- [ ] Projects link appears in nav and footer
- [ ] All project links are valid external URLs
- [ ] Dependabot shows only 1 remaining alert (moderate, dev-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)