### PR TITLE
fix: remove 57 broken hero image references

### DIFF
--- a/src/posts/2024-01-08-writing-secure-code-developers-guide.md
+++ b/src/posts/2024-01-08-writing-secure-code-developers-guide.md
@@ -3,17 +3,6 @@
 date: 2024-01-08
 author: William Zujkowski
 description: 'Master secure code development with input validation, parameterized queries, and secrets management—prevent SQL injection and XSS in production systems.'
-images:
-  hero:
-    alt: 'Writing Secure Code: A Developer''s Guide to Thwarting Security Exploits - Hero Image'
-    caption: 'Visual representation of Writing Secure Code: A Developer''s Guide to Thwarting Security Exploits'
-    height: 630
-    src: /assets/images/blog/hero/2024-01-08-writing-secure-code-developers-guide-hero.jpg
-    width: 1200
-  inline: []
-  og:
-    alt: 'Writing Secure Code: A Developer''s Guide to Thwarting Security Exploits - Social Media Preview'
-    src: /assets/images/blog/hero/2024-01-08-writing-secure-code-developers-guide-og.jpg
 title: 'Writing Secure Code: A Developer''s Guide to Thwarting Security Exploits'
 tags:
   - programming

--- a/src/posts/2024-01-18-demystifying-cryptography-beginners-guide.md
+++ b/src/posts/2024-01-18-demystifying-cryptography-beginners-guide.md
@@ -2,17 +2,6 @@
 
 date: 2024-01-18
 description: "Learn cryptography fundamentals with AES-256, RSA, and SHA-3—implement encryption, hashing, and digital signatures for production security systems."
-images:
-  hero:
-    alt: 'Demystifying Cryptography: A Beginner''s Guide to Encryption, Hashing, and Digital Signatures - Hero Image'
-    caption: 'Visual representation of Demystifying Cryptography: A Beginner''s Guide to Encryption, Hashing, and Digital Signatures'
-    height: 630
-    src: /assets/images/blog/hero/2024-01-18-demystifying-cryptography-beginners-guide-hero.jpg
-    width: 1200
-  inline: []
-  og:
-    alt: 'Demystifying Cryptography: A Beginner''s Guide to Encryption, Hashing, and Digital Signatures - Social Media Preview'
-    src: /assets/images/blog/hero/2024-01-18-demystifying-cryptography-beginners-guide-og.jpg
 title: 'Demystifying Cryptography: A Beginner''s Guide to Encryption, Hashing, and Digital Signatures'
 tags:
   - cryptography

--- a/src/posts/2024-02-09-deepfake-dilemma-ai-deception.md
+++ b/src/posts/2024-02-09-deepfake-dilemma-ai-deception.md
@@ -2,17 +2,6 @@
 
 date: 2024-02-09
 description: Detect AI-generated deepfakes with neural network analysis and authentication methods—combat misinformation with 73% accuracy detection models.
-images:
-  hero:
-    alt: 'The Deepfake Dilemma: Navigating the Threat of AI-Generated Deception - Hero Image'
-    caption: 'Visual representation of The Deepfake Dilemma: Navigating the Threat of AI-Generated Deception'
-    height: 630
-    src: /assets/images/blog/hero/2024-02-09-deepfake-dilemma-ai-deception-hero.jpg
-    width: 1200
-  inline: []
-  og:
-    alt: 'The Deepfake Dilemma: Navigating the Threat of AI-Generated Deception - Social Media Preview'
-    src: /assets/images/blog/hero/2024-02-09-deepfake-dilemma-ai-deception-og.jpg
 title: 'The Deepfake Dilemma: Navigating the Threat of AI-Generated Deception'
 tags:
   - ai

--- a/src/posts/2024-02-22-open-source-vs-proprietary-llms.md
+++ b/src/posts/2024-02-22-open-source-vs-proprietary-llms.md
@@ -1,17 +1,6 @@
 ---
 date: 2024-02-22
 description: Compare open-source vs proprietary LLMs with Llama 3 and GPT-4 benchmarks—understand performance, cost, and customization trade-offs for production.
-images:
-  hero:
-    alt: 'Open-Source vs. Proprietary LLMs: A Battle of Accessibility, Customization, and Community - Hero Image'
-    caption: 'Visual representation of Open-Source vs. Proprietary LLMs: A Battle of Accessibility, Customization, and Community'
-    height: 630
-    src: /assets/images/blog/hero/2024-02-22-open-source-vs-proprietary-llms-hero.jpg
-    width: 1200
-  inline: []
-  og:
-    alt: 'Open-Source vs. Proprietary LLMs: A Battle of Accessibility, Customization, and Community - Social Media Preview'
-    src: /assets/images/blog/hero/2024-02-22-open-source-vs-proprietary-llms-og.jpg
 tags:
 - ai
 - llm

--- a/src/posts/2024-03-05-cloud-migration-journey-guide.md
+++ b/src/posts/2024-03-05-cloud-migration-journey-guide.md
@@ -2,17 +2,6 @@
 date: 2024-03-05
 author: William Zujkowski
 description: Execute cloud migration from on-premises infrastructure with AWS/Azure strategies—reduce costs by 40% and improve scalability with proven patterns.
-images:
-  hero:
-    alt: 'Cloud Migration: A Guide to Navigating Your Journey to the Cloud - Hero Image'
-    caption: 'Visual representation of Cloud Migration: A Guide to Navigating Your Journey to the Cloud'
-    height: 630
-    src: /assets/images/blog/hero/2024-03-05-cloud-migration-journey-guide-hero.jpg
-    width: 1200
-  inline: []
-  og:
-    alt: 'Cloud Migration: A Guide to Navigating Your Journey to the Cloud - Social Media Preview'
-    src: /assets/images/blog/hero/2024-03-05-cloud-migration-journey-guide-og.jpg
 tags:
 - cloud
 - devops

--- a/src/posts/2024-03-20-transformer-architecture-deep-dive.md
+++ b/src/posts/2024-03-20-transformer-architecture-deep-dive.md
@@ -1,17 +1,6 @@
 ---
 date: 2024-03-20
 description: Master transformer architecture with self-attention and positional encoding—understand the foundation of GPT-4, BERT, and modern language models.
-images:
-  hero:
-    alt: 'The Transformer Architecture: A Deep Dive - Hero Image'
-    caption: 'Visual representation of The Transformer Architecture: A Deep Dive'
-    height: 630
-    src: /assets/images/blog/hero/2024-03-20-transformer-architecture-deep-dive-hero.jpg
-    width: 1200
-  inline: []
-  og:
-    alt: 'The Transformer Architecture: A Deep Dive - Social Media Preview'
-    src: /assets/images/blog/hero/2024-03-20-transformer-architecture-deep-dive-og.jpg
 tags:
 - ai
 - llm

--- a/src/posts/2024-04-04-retrieval-augmented-generation-rag.md
+++ b/src/posts/2024-04-04-retrieval-augmented-generation-rag.md
@@ -2,20 +2,6 @@
 
 date: 2024-04-04
 description: Build RAG systems with vector databases and semantic search—eliminate LLM hallucinations and ground responses in verified knowledge for trustworthy AI.
-images:
-  hero:
-    alt: 'Retrieval Augmented Generation (RAG): Enhancing LLMs with External Knowledge
-      - Hero Image'
-    caption: 'Visual representation of Retrieval Augmented Generation (RAG): Enhancing
-      LLMs with External Knowledge'
-    height: 630
-    src: /assets/images/blog/hero/2024-04-04-retrieval-augmented-generation-rag-hero.jpg
-    width: 1200
-  inline: []
-  og:
-    alt: 'Retrieval Augmented Generation (RAG): Enhancing LLMs with External Knowledge
-      - Social Media Preview'
-    src: /assets/images/blog/hero/2024-04-04-retrieval-augmented-generation-rag-og.jpg
 title: 'Retrieval Augmented Generation (RAG): Enhancing LLMs with External Knowledge'
 tags:
   - ai

--- a/src/posts/2024-04-11-ethics-large-language-models.md
+++ b/src/posts/2024-04-11-ethics-large-language-models.md
@@ -2,17 +2,6 @@
 
 date: 2024-04-11
 description: Address LLM ethics including bias, privacy, and accountability—implement responsible AI frameworks for large language model deployment in production.
-images:
-  hero:
-    alt: The Ethics of Large Language Models - Hero Image
-    caption: Visual representation of The Ethics of Large Language Models
-    height: 630
-    src: /assets/images/blog/hero/2024-04-11-ethics-large-language-models-hero.jpg
-    width: 1200
-  inline: []
-  og:
-    alt: The Ethics of Large Language Models - Social Media Preview
-    src: /assets/images/blog/hero/2024-04-11-ethics-large-language-models-og.jpg
 title: The Ethics of Large Language Models
 tags:
   - ai

--- a/src/posts/2024-04-19-mastering-prompt-engineering-llms.md
+++ b/src/posts/2024-04-19-mastering-prompt-engineering-llms.md
@@ -2,17 +2,6 @@
 
 date: 2024-04-19
 description: Master prompt engineering with few-shot learning and chain-of-thought techniques—improve LLM response quality by 40% through systematic optimization.
-images:
-  hero:
-    alt: 'Mastering Prompt Engineering: Unlocking the Full Potential of LLMs - Hero Image'
-    caption: 'Visual representation of Mastering Prompt Engineering: Unlocking the Full Potential of LLMs'
-    height: 630
-    src: /assets/images/blog/hero/2024-04-19-mastering-prompt-engineering-llms-hero.jpg
-    width: 1200
-  inline: []
-  og:
-    alt: 'Mastering Prompt Engineering: Unlocking the Full Potential of LLMs - Social Media Preview'
-    src: /assets/images/blog/hero/2024-04-19-mastering-prompt-engineering-llms-og.jpg
 title: 'Mastering Prompt Engineering: Unlocking the Full Potential of LLMs'
 tags:
   - ai

--- a/src/posts/2024-04-30-quantum-resistant-cryptography-guide.md
+++ b/src/posts/2024-04-30-quantum-resistant-cryptography-guide.md
@@ -2,17 +2,6 @@
 
 date: 2024-04-30
 description: "Implement quantum-resistant cryptography with NIST post-quantum algorithms. Future-proof encryption against quantum attacks using Kyber and Dilithium."
-images:
-  hero:
-    alt: 'Preparing for the Quantum Leap: A Guide to Quantum-Resistant Cryptography - Hero Image'
-    caption: 'Visual representation of Preparing for the Quantum Leap: A Guide to Quantum-Resistant Cryptography'
-    height: 630
-    src: /assets/images/blog/hero/2024-04-30-quantum-resistant-cryptography-guide-hero.jpg
-    width: 1200
-  inline: []
-  og:
-    alt: 'Preparing for the Quantum Leap: A Guide to Quantum-Resistant Cryptography - Social Media Preview'
-    src: /assets/images/blog/hero/2024-04-30-quantum-resistant-cryptography-guide-og.jpg
 title: 'Preparing for the Quantum Leap: A Guide to Quantum-Resistant Cryptography'
 tags:
   - computational-science

--- a/src/posts/2024-05-14-ai-new-frontier-cybersecurity.md
+++ b/src/posts/2024-05-14-ai-new-frontier-cybersecurity.md
@@ -2,17 +2,6 @@
 
 date: 2024-05-14
 description: "Deploy AI-powered cybersecurity with automated threat detection—achieve 73% accuracy in anomaly detection catching attacks SIEM systems miss."
-images:
-  hero:
-    alt: 'AI: The New Frontier in Cybersecurity – Opportunities and Ethical Dilemmas - Hero Image'
-    caption: 'Visual representation of AI: The New Frontier in Cybersecurity – Opportunities and Ethical Dilemmas'
-    height: 630
-    src: /assets/images/blog/hero/2024-05-14-ai-new-frontier-cybersecurity-hero.jpg
-    width: 1200
-  inline: []
-  og:
-    alt: 'AI: The New Frontier in Cybersecurity – Opportunities and Ethical Dilemmas - Social Media Preview'
-    src: /assets/images/blog/hero/2024-05-14-ai-new-frontier-cybersecurity-og.jpg
 title: 'AI: The New Frontier in Cybersecurity – Opportunities and Ethical Dilemmas'
 tags:
   - ai

--- a/src/posts/2024-05-30-ai-learning-resource-constrained.md
+++ b/src/posts/2024-05-30-ai-learning-resource-constrained.md
@@ -2,17 +2,6 @@
 
 date: 2024-05-30
 description: Train AI models on resource-constrained hardware with quantization, pruning, and distillation—run GPT-3 capabilities 100x faster through compression.
-images:
-  hero:
-    alt: AI Learning in Resource-Constrained Environments - Hero Image
-    caption: Visual representation of AI Learning in Resource-Constrained Environments
-    height: 630
-    src: /assets/images/blog/hero/2024-05-30-ai-learning-resource-constrained-hero.jpg
-    width: 1200
-  inline: []
-  og:
-    alt: AI Learning in Resource-Constrained Environments - Social Media Preview
-    src: /assets/images/blog/hero/2024-05-30-ai-learning-resource-constrained-og.jpg
 title: AI Learning in Resource-Constrained Environments
 tags:
   - ai

--- a/src/posts/2024-06-25-designing-resilient-systems.md
+++ b/src/posts/2024-06-25-designing-resilient-systems.md
@@ -2,17 +2,6 @@
 
 date: 2024-06-25
 description: Design resilient systems with circuit breakers, redundancy, and chaos engineering—recover from failures in minutes using proven patterns.
-images:
-  hero:
-    alt: Designing Resilient Systems for an Uncertain World - Hero Image
-    caption: Visual representation of Designing Resilient Systems for an Uncertain World
-    height: 630
-    src: /assets/images/blog/hero/2024-06-25-designing-resilient-systems-hero.jpg
-    width: 1200
-  inline: []
-  og:
-    alt: Designing Resilient Systems for an Uncertain World - Social Media Preview
-    src: /assets/images/blog/hero/2024-06-25-designing-resilient-systems-og.jpg
 title: Designing Resilient Systems for an Uncertain World
 tags:
   - architecture

--- a/src/posts/2024-07-09-zero-trust-architecture-implementation.md
+++ b/src/posts/2024-07-09-zero-trust-architecture-implementation.md
@@ -2,17 +2,6 @@
 
 date: 2024-07-09
 description: "Implement zero trust with identity verification and micro-segmentation—secure networks using never-trust-always-verify principles."
-images:
-  hero:
-    alt: 'Zero Trust Architecture: A Practical Implementation Guide - Hero Image'
-    caption: 'Visual representation of Zero Trust Architecture: A Practical Implementation Guide'
-    height: 630
-    src: /assets/images/blog/hero/2024-07-09-zero-trust-architecture-implementation-hero.jpg
-    width: 1200
-  inline: []
-  og:
-    alt: 'Zero Trust Architecture: A Practical Implementation Guide - Social Media Preview'
-    src: /assets/images/blog/hero/2024-07-09-zero-trust-architecture-implementation-og.jpg
 title: 'Zero Trust Architecture: A Practical Implementation Guide'
 tags:
   - architecture

--- a/src/posts/2024-07-16-sustainable-computing-carbon-footprint.md
+++ b/src/posts/2024-07-16-sustainable-computing-carbon-footprint.md
@@ -2,17 +2,6 @@
 
 date: 2024-07-16
 description: Reduce IT carbon footprint with sustainable computing practices—optimize datacenter energy efficiency and cut ML training costs by 40%.
-images:
-  hero:
-    alt: 'Sustainable Computing: Strategies for Reducing IT''s Carbon Footprint - Hero Image'
-    caption: 'Visual representation of Sustainable Computing: Strategies for Reducing IT''s Carbon Footprint'
-    height: 630
-    src: /assets/images/blog/hero/2024-07-16-sustainable-computing-carbon-footprint-hero.jpg
-    width: 1200
-  inline: []
-  og:
-    alt: 'Sustainable Computing: Strategies for Reducing IT''s Carbon Footprint - Social Media Preview'
-    src: /assets/images/blog/hero/2024-07-16-sustainable-computing-carbon-footprint-og.jpg
 title: 'Sustainable Computing: Strategies for Reducing IT''s Carbon Footprint'
 tags:
   - sustainability

--- a/src/posts/2024-07-24-multimodal-foundation-models.md
+++ b/src/posts/2024-07-24-multimodal-foundation-models.md
@@ -2,17 +2,6 @@
 
 date: 2024-07-24
 description: Build multimodal AI systems with GPT-4 Vision and CLIP—process text, images, and audio together for next-generation foundation model applications.
-images:
-  hero:
-    alt: 'Multimodal Foundation Models: Capabilities, Challenges, and Applications - Hero Image'
-    caption: 'Visual representation of Multimodal Foundation Models: Capabilities, Challenges, and Applications'
-    height: 630
-    src: /assets/images/blog/hero/2024-07-24-multimodal-foundation-models-hero.jpg
-    width: 1200
-  inline: []
-  og:
-    alt: 'Multimodal Foundation Models: Capabilities, Challenges, and Applications - Social Media Preview'
-    src: /assets/images/blog/hero/2024-07-24-multimodal-foundation-models-og.jpg
 title: 'Multimodal Foundation Models: Capabilities, Challenges, and Applications'
 tags:
   - ai

--- a/src/posts/2024-08-02-quantum-computing-leap-forward.md
+++ b/src/posts/2024-08-02-quantum-computing-leap-forward.md
@@ -2,17 +2,6 @@
 
 date: 2024-08-02
 description: "Explore quantum computing with IBM Qiskit and quantum algorithms—quantum advantage, error correction, and real-world applications."
-images:
-  hero:
-    alt: Quantum Computing's Leap Forward - Hero Image
-    caption: Visual representation of Quantum Computing's Leap Forward
-    height: 630
-    src: /assets/images/blog/hero/2024-08-02-quantum-computing-leap-forward-hero.jpg
-    width: 1200
-  inline: []
-  og:
-    alt: Quantum Computing's Leap Forward - Social Media Preview
-    src: /assets/images/blog/hero/2024-08-02-quantum-computing-leap-forward-og.jpg
 title: Quantum Computing's Leap Forward
 tags:
   - computational-science

--- a/src/posts/2024-08-13-high-performance-computing.md
+++ b/src/posts/2024-08-13-high-performance-computing.md
@@ -2,17 +2,6 @@
 
 date: 2024-04-07
 description: Deploy high-performance computing with parallel processing and distributed systems—access supercomputer capabilities through cloud HPC for AI workloads.
-images:
-  hero:
-    alt: 'The Evolution of High-Performance Computing: Key Trends and Innovations - Hero Image'
-    caption: 'Visual representation of The Evolution of High-Performance Computing: Key Trends and Innovations'
-    height: 630
-    src: /assets/images/blog/hero/2024-08-13-high-performance-computing-hero.jpg
-    width: 1200
-  inline: []
-  og:
-    alt: 'The Evolution of High-Performance Computing: Key Trends and Innovations - Social Media Preview'
-    src: /assets/images/blog/hero/2024-08-13-high-performance-computing-og.jpg
 title: 'The Evolution of High-Performance Computing: Key Trends and Innovations'
 tags:
   - ai

--- a/src/posts/2024-08-27-zero-trust-security-principles.md
+++ b/src/posts/2024-08-27-zero-trust-security-principles.md
@@ -2,17 +2,6 @@
 
 date: 2024-04-14
 description: Deploy zero trust security with continuous verification and identity-centric controls—implement never-trust-always-verify for Federal EO 14028 compliance.
-images:
-  hero:
-    alt: 'Implementing Zero Trust Security: Never Trust, Always Verify - Hero Image'
-    caption: 'Visual representation of Implementing Zero Trust Security: Never Trust, Always Verify'
-    height: 630
-    src: /assets/images/blog/hero/2024-08-27-zero-trust-security-principles-hero.jpg
-    width: 1200
-  inline: []
-  og:
-    alt: 'Implementing Zero Trust Security: Never Trust, Always Verify - Social Media Preview'
-    src: /assets/images/blog/hero/2024-08-27-zero-trust-security-principles-og.jpg
 title: 'Implementing Zero Trust Security: Never Trust, Always Verify'
 tags:
   - devops

--- a/src/posts/2024-09-09-embodied-ai-teaching-agents.md
+++ b/src/posts/2024-09-09-embodied-ai-teaching-agents.md
@@ -2,17 +2,6 @@
 
 date: 2024-04-21
 description: Train embodied AI agents with vision, language, and physical interaction—build robots that learn from real environments using reinforcement learning.
-images:
-  hero:
-    alt: 'Teaching AI Agents to Ask for Help: A Breakthrough in Human-Robot Interaction - Hero Image'
-    caption: 'Visual representation of Teaching AI Agents to Ask for Help: A Breakthrough in Human-Robot Interaction'
-    height: 630
-    src: /assets/images/blog/hero/2024-09-09-embodied-ai-teaching-agents-hero.jpg
-    width: 1200
-  inline: []
-  og:
-    alt: 'Teaching AI Agents to Ask for Help: A Breakthrough in Human-Robot Interaction - Social Media Preview'
-    src: /assets/images/blog/hero/2024-09-09-embodied-ai-teaching-agents-og.jpg
 title: 'Teaching AI Agents to Ask for Help: A Breakthrough in Human-Robot Interaction'
 tags:
   - ai

--- a/src/posts/2024-09-15-running-llama-raspberry-pi-pipeload.md
+++ b/src/posts/2024-09-15-running-llama-raspberry-pi-pipeload.md
@@ -5,13 +5,6 @@ date: 2024-09-15
 description: "Run LLaMA 3.1 on Raspberry Pi with PIPELOAD pipeline inference—achieve 90% memory reduction and deploy 7B models on 8GB edge devices at 2.5 tokens/sec."
 author: "William Zujkowski"
 reading_time: 8
-images:
-  hero:
-    src: "/assets/images/blog/hero/2024-09-15-running-llama-raspberry-pi-pipeload-hero.jpg"
-    alt: "Raspberry Pi 4 running LLaMA 3.1 with glowing LEDs and terminal output showing inference speed metrics"
-    caption: "Edge AI inference on a Raspberry Pi 4: 2.5 tokens/sec with 90% memory reduction using PIPELOAD"
-    width: 1200
-    height: 630
 tags:
   - edge-computing
   - homelab

--- a/src/posts/2024-09-19-biomimetic-robotics.md
+++ b/src/posts/2024-09-19-biomimetic-robotics.md
@@ -2,17 +2,6 @@
 
 date: 2024-04-28
 description: Design biomimetic robots inspired by nature—implement gecko adhesion, swarm intelligence, and soft robotics using billions of years of evolution.
-images:
-  hero:
-    alt: 'Learning from Nature: How Biomimetic Robotics is Revolutionizing Engineering - Hero Image'
-    caption: 'Visual representation of Learning from Nature: How Biomimetic Robotics is Revolutionizing Engineering'
-    height: 630
-    src: /assets/images/blog/hero/2024-09-19-biomimetic-robotics-hero.jpg
-    width: 1200
-  inline: []
-  og:
-    alt: 'Learning from Nature: How Biomimetic Robotics is Revolutionizing Engineering - Social Media Preview'
-    src: /assets/images/blog/hero/2024-09-19-biomimetic-robotics-og.jpg
 title: 'Learning from Nature: How Biomimetic Robotics is Revolutionizing Engineering'
 tags:
   - ai

--- a/src/posts/2024-09-25-gvisor-container-sandboxing-security.md
+++ b/src/posts/2024-09-25-gvisor-container-sandboxing-security.md
@@ -5,12 +5,6 @@ date: 2024-09-25
 description: "Secure containers with gVisor sandboxing—prevent kernel exploits in Kubernetes clusters while managing 59% startup overhead for untrusted workloads."
 author: "William Zujkowski"
 reading_time: 9
-images:
-  hero:
-    src: "/assets/images/blog/hero/2024-09-25-gvisor-container-sandboxing-security-hero.jpg"
-    alt: "Diagram showing gVisor's application kernel architecture intercepting container syscalls"
-    width: 1200
-    height: 630
 tags:
   - container-orchestration
   - container-security

--- a/src/posts/2024-10-03-quantum-computing-defense.md
+++ b/src/posts/2024-10-03-quantum-computing-defense.md
@@ -2,17 +2,6 @@
 
 date: 2024-05-05
 description: Prepare for quantum computing threats with post-quantum cryptography—protect RSA and ECC encryption from quantum attacks using NIST-approved algorithms.
-images:
-  hero:
-    alt: 'Quantum Computing and Defense: The Double-Edged Sword of Tomorrow''s Technology - Hero Image'
-    caption: 'Visual representation of Quantum Computing and Defense: The Double-Edged Sword of Tomorrow''s Technology'
-    height: 630
-    src: /assets/images/blog/hero/2024-10-03-quantum-computing-defense-hero.jpg
-    width: 1200
-  inline: []
-  og:
-    alt: 'Quantum Computing and Defense: The Double-Edged Sword of Tomorrow''s Technology - Social Media Preview'
-    src: /assets/images/blog/hero/2024-10-03-quantum-computing-defense-og.jpg
 title: 'Quantum Computing and Defense: The Double-Edged Sword of Tomorrow''s Technology'
 tags:
   - computational-science

--- a/src/posts/2024-10-10-blockchain-beyond-cryptocurrency.md
+++ b/src/posts/2024-10-10-blockchain-beyond-cryptocurrency.md
@@ -2,17 +2,6 @@
 
 date: 2024-10-10
 description: "Deploy blockchain beyond cryptocurrency with Ethereum and smart contracts—build decentralized trust for supply chain and identity verification."
-images:
-  hero:
-    alt: 'Blockchain Beyond Cryptocurrency: Building the Trust Layer of the Internet - Hero Image'
-    caption: 'Visual representation of Blockchain Beyond Cryptocurrency: Building the Trust Layer of the Internet'
-    height: 630
-    src: /assets/images/blog/hero/2024-10-10-blockchain-beyond-cryptocurrency-hero.jpg
-    width: 1200
-  inline: []
-  og:
-    alt: 'Blockchain Beyond Cryptocurrency: Building the Trust Layer of the Internet - Social Media Preview'
-    src: /assets/images/blog/hero/2024-10-10-blockchain-beyond-cryptocurrency-og.jpg
 title: 'Blockchain Beyond Cryptocurrency: Building the Trust Layer of the Internet'
 tags:
   - architecture

--- a/src/posts/2024-10-22-ai-edge-computing.md
+++ b/src/posts/2024-10-22-ai-edge-computing.md
@@ -2,17 +2,6 @@
 
 date: 2024-05-19
 description: Deploy AI edge computing with YOLOv8 and TensorFlow Lite—achieve 15ms latency for real-time inference on Raspberry Pi with local processing for privacy.
-images:
-  hero:
-    alt: 'AI Meets Edge Computing: Transforming Real-Time Intelligence - Hero Image'
-    caption: 'Visual representation of AI Meets Edge Computing: Transforming Real-Time Intelligence'
-    height: 630
-    src: /assets/images/blog/hero/2024-10-22-ai-edge-computing-hero.jpg
-    width: 1200
-  inline: []
-  og:
-    alt: 'AI Meets Edge Computing: Transforming Real-Time Intelligence - Social Media Preview'
-    src: /assets/images/blog/hero/2024-10-22-ai-edge-computing-og.jpg
 title: 'AI Meets Edge Computing: Transforming Real-Time Intelligence'
 tags:
   - ai

--- a/src/posts/2024-11-05-pizza-calculator.md
+++ b/src/posts/2024-11-05-pizza-calculator.md
@@ -3,17 +3,6 @@
 date: 2024-05-26
 author: William Zujkowski
 description: "Optimize team resource planning with data-driven pizza—calculate cost per square inch and maximize developer productivity during sprints."
-images:
-  hero:
-    alt: 'The Pizza Calculator: Optimizing Team Fuel for Critical Development Sprints - Hero Image'
-    caption: 'Visual representation of The Pizza Calculator: Optimizing Team Fuel for Critical Development Sprints'
-    height: 630
-    src: /assets/images/blog/hero/2024-11-05-pizza-calculator-hero.jpg
-    width: 1200
-  inline: []
-  og:
-    alt: 'The Pizza Calculator: Optimizing Team Fuel for Critical Development Sprints - Social Media Preview'
-    src: /assets/images/blog/hero/2024-11-05-pizza-calculator-og.jpg
 title: 'The Pizza Calculator: Optimizing Team Fuel for Critical Development Sprints'
 tags:
   - devops

--- a/src/posts/2024-11-15-gpu-power-monitoring-homelab-ml.md
+++ b/src/posts/2024-11-15-gpu-power-monitoring-homelab-ml.md
@@ -3,16 +3,6 @@
 date: 2024-11-15
 description: Monitor GPU power with NVIDIA SMI and Grafana dashboards—reduce ML training electricity costs by 40% using optimization strategies for RTX 3090.
 title: 'GPU Power Monitoring in My Homelab: When Machine Learning Met My Electricity Bill'
-images:
-  hero:
-    src: /assets/images/blog/hero/2024-11-15-gpu-power-monitoring-homelab-ml-hero.jpg
-    alt: 'artificial intelligence concept diagram for GPU Power Monitoring in My Homelab: When Machine Learning Met My Electricity Bill'
-    caption: 'Visual representation of GPU Power Monitoring in My Homelab: When Machine Learning Met My Electricity Bill'
-    width: 1200
-    height: 630
-  og:
-    src: /assets/images/blog/hero/2024-11-15-gpu-power-monitoring-homelab-ml-og.jpg
-    alt: 'artificial intelligence concept diagram for GPU Power Monitoring in My Homelab: When Machine Learning Met My Electricity Bill'
 tags:
   - ai
   - hardware

--- a/src/posts/2024-11-19-llms-smart-contract-vulnerability.md
+++ b/src/posts/2024-11-19-llms-smart-contract-vulnerability.md
@@ -2,17 +2,6 @@
 
 date: 2024-06-02
 description: Test LLM smart contract security with GPT-4 and Claude—achieve 80% reentrancy detection accuracy but manage 38% false positives in production workflows.
-images:
-  hero:
-    alt: 'Large Language Models for Smart Contract Security: Promise and Limitations - Hero Image'
-    caption: 'Visual representation of Large Language Models for Smart Contract Security: Promise and Limitations'
-    height: 630
-    src: /assets/images/blog/hero/2024-11-19-llms-smart-contract-vulnerability-hero.jpg
-    width: 1200
-  inline: []
-  og:
-    alt: 'Large Language Models for Smart Contract Security: Promise and Limitations - Social Media Preview'
-    src: /assets/images/blog/hero/2024-11-19-llms-smart-contract-vulnerability-og.jpg
 title: 'Large Language Models for Smart Contract Security: Promise and Limitations'
 tags:
   - ai

--- a/src/posts/2024-12-03-context-windows-llms.md
+++ b/src/posts/2024-12-03-context-windows-llms.md
@@ -2,17 +2,6 @@
 
 date: 2024-06-09
 description: Understand LLM context windows from 2K to 2M tokens—optimize model performance and prevent hallucinations at 28K token boundaries.
-images:
-  hero:
-    alt: 'Context Windows in Large Language Models: The Memory That Shapes AI - Hero Image'
-    caption: 'Visual representation of Context Windows in Large Language Models: The Memory That Shapes AI'
-    height: 630
-    src: /assets/images/blog/hero/2024-12-03-context-windows-llms-hero.jpg
-    width: 1200
-  inline: []
-  og:
-    alt: 'Context Windows in Large Language Models: The Memory That Shapes AI - Social Media Preview'
-    src: /assets/images/blog/hero/2024-12-03-context-windows-llms-og.jpg
 title: 'Context Windows in Large Language Models: The Memory That Shapes AI'
 tags:
   - ai

--- a/src/posts/2025-02-10-automating-home-network-security.md
+++ b/src/posts/2025-02-10-automating-home-network-security.md
@@ -3,17 +3,6 @@
 author: William Zujkowski
 date: 2025-02-10
 description: "Automate home network security with Python and Ansible—deploy patching, threat detection, and compliance scanning for homelab infrastructure."
-images:
-  hero:
-    alt: Automating Home Network Security with Python and Open Source Tools - Hero Image
-    caption: Visual representation of Automating Home Network Security with Python and Open Source Tools
-    height: 630
-    src: /assets/images/blog/hero/2025-02-10-automating-home-network-security-hero.jpg
-    width: 1200
-  inline: []
-  og:
-    alt: Automating Home Network Security with Python and Open Source Tools - Social Media Preview
-    src: /assets/images/blog/hero/2025-02-10-automating-home-network-security-og.jpg
 title: Automating Home Network Security with Python and Open Source Tools
 tags:
   - automation

--- a/src/posts/2025-02-24-continuous-learning-cybersecurity.md
+++ b/src/posts/2025-02-24-continuous-learning-cybersecurity.md
@@ -2,17 +2,6 @@
 
 date: 2025-02-24
 description: Master continuous cybersecurity learning with lab exercises, research tracking, and community engagement—stay current without burnout.
-images:
-  hero:
-    alt: 'Continuous Learning in Cybersecurity: Strategies That Work - Hero Image'
-    caption: 'Visual representation of Continuous Learning in Cybersecurity: Strategies That Work'
-    height: 630
-    src: /assets/images/blog/hero/2025-02-24-continuous-learning-cybersecurity-hero.jpg
-    width: 1200
-  inline: []
-  og:
-    alt: 'Continuous Learning in Cybersecurity: Strategies That Work - Social Media Preview'
-    src: /assets/images/blog/hero/2025-02-24-continuous-learning-cybersecurity-og.jpg
 title: 'Continuous Learning in Cybersecurity: Strategies That Work'
 tags:
   - learning

--- a/src/posts/2025-03-10-raspberry-pi-security-projects.md
+++ b/src/posts/2025-03-10-raspberry-pi-security-projects.md
@@ -2,17 +2,6 @@
 
 date: 2025-03-10
 description: Build Raspberry Pi security projects with Pi-hole, VPN gateway, and honeypots—deploy practical network monitoring and threat detection on budget hardware.
-images:
-  hero:
-    alt: Raspberry Pi Security Projects That Actually Solve Problems - Hero Image
-    caption: Visual representation of Raspberry Pi Security Projects That Actually Solve Problems
-    height: 630
-    src: /assets/images/blog/hero/2025-03-10-raspberry-pi-security-projects-hero.jpg
-    width: 1200
-  inline: []
-  og:
-    alt: Raspberry Pi Security Projects That Actually Solve Problems - Social Media Preview
-    src: /assets/images/blog/hero/2025-03-10-raspberry-pi-security-projects-og.jpg
 title: Raspberry Pi Security Projects That Actually Solve Problems
 tags:
   - homelab

--- a/src/posts/2025-03-24-from-it-support-to-senior-infosec-engineer.md
+++ b/src/posts/2025-03-24-from-it-support-to-senior-infosec-engineer.md
@@ -3,17 +3,6 @@
 author: William Zujkowski
 date: 2025-03-24
 description: Navigate IT support to senior InfoSec engineer path—learn from 15+ years securing federal systems with practical career transition advice.
-images:
-  hero:
-    alt: 'From IT Support to Senior InfoSec Engineer: My 15+ Year Journey - Hero Image'
-    caption: 'Visual representation of From IT Support to Senior InfoSec Engineer: My 15+ Year Journey'
-    height: 630
-    src: /assets/images/blog/hero/2025-03-24-from-it-support-to-senior-infosec-engineer-hero.jpg
-    width: 1200
-  inline: []
-  og:
-    alt: 'From IT Support to Senior InfoSec Engineer: My 15+ Year Journey - Social Media Preview'
-    src: /assets/images/blog/hero/2025-03-24-from-it-support-to-senior-infosec-engineer-og.jpg
 title: 'From IT Support to Senior InfoSec Engineer: My 15+ Year Journey'
 tags:
   - learning

--- a/src/posts/2025-04-10-securing-personal-ai-experiments.md
+++ b/src/posts/2025-04-10-securing-personal-ai-experiments.md
@@ -3,17 +3,6 @@
 author: William Zujkowski
 date: 2025-04-10
 description: "Secure personal AI experiments with model isolation and network segmentation—protect LLM deployments using privacy controls and threat modeling."
-images:
-  hero:
-    alt: 'Securing Your Personal AI/ML Experiments: A Practical Guide - Hero Image'
-    caption: 'Visual representation of Securing Your Personal AI/ML Experiments: A Practical Guide'
-    height: 630
-    src: /assets/images/blog/hero/2025-04-10-securing-personal-ai-experiments-hero.jpg
-    width: 1200
-  inline: []
-  og:
-    alt: 'Securing Your Personal AI/ML Experiments: A Practical Guide - Social Media Preview'
-    src: /assets/images/blog/hero/2025-04-10-securing-personal-ai-experiments-og.jpg
 title: 'Securing Your Personal AI/ML Experiments: A Practical Guide'
 tags:
   - ai

--- a/src/posts/2025-04-24-building-secure-homelab-adventure.md
+++ b/src/posts/2025-04-24-building-secure-homelab-adventure.md
@@ -3,17 +3,6 @@
 author: William Zujkowski
 date: 2025-04-24
 description: Build security-focused homelab with Proxmox, VLANs, and IDS/IPS—create testing environment for cybersecurity and family data protection.
-images:
-  hero:
-    alt: 'Building a Security-Focused Homelab: My Journey - Hero Image'
-    caption: 'Visual representation of Building a Security-Focused Homelab: My Journey'
-    height: 630
-    src: /assets/images/blog/hero/2025-04-24-building-secure-homelab-adventure-hero.jpg
-    width: 1200
-  inline: []
-  og:
-    alt: 'Building a Security-Focused Homelab: My Journey - Social Media Preview'
-    src: /assets/images/blog/hero/2025-04-24-building-secure-homelab-adventure-og.jpg
 title: 'Building a Security-Focused Homelab: My Journey'
 tags:
   - homelab

--- a/src/posts/2025-05-10-llm-fine-tuning-homelab-guide.md
+++ b/src/posts/2025-05-10-llm-fine-tuning-homelab-guide.md
@@ -2,17 +2,6 @@
 
 date: '2025-05-10'
 description: Fine-tune LLMs on homelab hardware with QLoRA and 4-bit quantization. Train Llama 3 8B models on RTX 3090 with dataset prep and optimization strategies.
-images:
-  hero:
-    alt: 'Fine-Tuning LLMs in the Homelab: A Practical Guide - Hero Image'
-    caption: 'Visual representation of Fine-Tuning LLMs in the Homelab: A Practical Guide'
-    height: 630
-    src: /assets/images/blog/hero/2025-05-10-llm-fine-tuning-homelab-guide-hero.jpg
-    width: 1200
-  inline: []
-  og:
-    alt: 'Fine-Tuning LLMs in the Homelab: A Practical Guide - Social Media Preview'
-    src: /assets/images/blog/hero/2025-05-10-llm-fine-tuning-homelab-guide-og.jpg
 title: 'Fine-Tuning LLMs in the Homelab: A Practical Guide'
 tags:
   - ai

--- a/src/posts/2025-06-25-local-llm-deployment-privacy-first.md
+++ b/src/posts/2025-06-25-local-llm-deployment-privacy-first.md
@@ -2,17 +2,6 @@
 
 date: 2025-06-25
 description: "Deploy local LLMs for privacy-first AI—run language models on homelab hardware with model selection, optimization, and deployment strategies."
-images:
-  hero:
-    alt: 'Local LLM Deployment: Privacy-First Approach - Hero Image'
-    caption: 'Visual representation of Local LLM Deployment: Privacy-First Approach'
-    height: 630
-    src: /assets/images/blog/hero/2025-06-25-local-llm-deployment-privacy-first-hero.jpg
-    width: 1200
-  inline: []
-  og:
-    alt: 'Local LLM Deployment: Privacy-First Approach - Social Media Preview'
-    src: /assets/images/blog/hero/2025-06-25-local-llm-deployment-privacy-first-og.jpg
 title: 'Local LLM Deployment: Privacy-First Approach'
 tags:
   - ai

--- a/src/posts/2025-07-01-ebpf-security-monitoring-practical-guide.md
+++ b/src/posts/2025-07-01-ebpf-security-monitoring-practical-guide.md
@@ -3,23 +3,6 @@
 author: William Zujkowski
 date: 2025-07-01
 description: Implement eBPF security monitoring for real-time kernel visibility—track syscalls and network activity with production-ready patterns for threat detection.
-images:
-  hero:
-    alt: Futuristic dashboard showing real-time kernel-level security monitoring with eBPF
-    caption: Real-time kernel visibility changes everything in security monitoring
-    height: 630
-    src: /assets/images/blog/hero/2025-07-01-ebpf-security-monitoring-hero.jpg
-    width: 1200
-  inline:
-  - alt: eBPF architecture showing kernel and userspace interaction
-    caption: How eBPF programs interact with the Linux kernel
-    src: /assets/images/blog/inline/ebpf-architecture-visualization.png
-  - alt: Event flow from kernel through eBPF to security analysis
-    caption: Real-time event processing pipeline
-    src: /assets/images/blog/diagrams/ebpf-event-flow.svg
-  og:
-    alt: eBPF Security Monitoring - Kernel-level detection and response
-    src: /assets/images/blog/hero/2025-07-01-ebpf-security-monitoring-og.jpg
 title: 'eBPF for Security Monitoring: A Practical Guide'
 tags:
   - ebpf

--- a/src/posts/2025-07-08-implementing-dns-over-https-home-networks.md
+++ b/src/posts/2025-07-08-implementing-dns-over-https-home-networks.md
@@ -3,17 +3,6 @@
 author: William Zujkowski
 date: 2025-07-08
 description: Deploy DNS-over-HTTPS with Pi-hole and dnscrypt-proxy—encrypt DNS queries for home network privacy and prevent ISP monitoring with DoH implementation.
-images:
-  hero:
-    alt: Implementing DNS-over-HTTPS (DoH) for Home Networks - Hero Image
-    caption: Visual representation of Implementing DNS-over-HTTPS (DoH) for Home Networks
-    height: 630
-    src: /assets/images/blog/hero/2025-07-08-implementing-dns-over-https-home-networks-hero.jpg
-    width: 1200
-  inline: []
-  og:
-    alt: Implementing DNS-over-HTTPS (DoH) for Home Networks - Social Media Preview
-    src: /assets/images/blog/hero/2025-07-08-implementing-dns-over-https-home-networks-og.jpg
 title: Implementing DNS-over-HTTPS (DoH) for Home Networks
 tags:
   - cryptography

--- a/src/posts/2025-07-15-vulnerability-management-scale-open-source.md
+++ b/src/posts/2025-07-15-vulnerability-management-scale-open-source.md
@@ -3,18 +3,6 @@
 author: William Zujkowski
 date: 2025-07-15
 description: "Build enterprise vulnerability management with open source—deploy scanning, remediation tracking, and compliance using Nessus and OpenVAS."
-images:
-  hero:
-    alt: Vulnerability Management at Scale with Open Source Tools - Hero Image
-    caption: Visual representation of Vulnerability Management at Scale with Open
-      Source Tools
-    height: 630
-    src: /assets/images/blog/hero/2025-07-15-vulnerability-management-scale-open-source-hero.jpg
-    width: 1200
-  inline: []
-  og:
-    alt: Vulnerability Management at Scale with Open Source Tools - Social Media Preview
-    src: /assets/images/blog/hero/2025-07-15-vulnerability-management-scale-open-source-og.jpg
 title: Vulnerability Management at Scale with Open Source Tools
 tags:
   - automation

--- a/src/posts/2025-07-22-supercharging-claude-cli-with-standards.md
+++ b/src/posts/2025-07-22-supercharging-claude-cli-with-standards.md
@@ -2,17 +2,6 @@
 
 date: 2025-07-22
 description: "Transform Claude CLI with standards integration—achieve 90% token reduction and automate workflows using context-aware MCP server architecture."
-images:
-  hero:
-    alt: Exploring Claude CLI Context and Compliance with My Standards Repository - Hero Image
-    caption: Visual representation of Exploring Claude CLI Context and Compliance with My Standards Repository
-    height: 630
-    src: /assets/images/blog/hero/2025-07-22-supercharging-claude-cli-with-standards-hero.jpg
-    width: 1200
-  inline: []
-  og:
-    alt: Exploring Claude CLI Context and Compliance with My Standards Repository - Social Media Preview
-    src: /assets/images/blog/hero/2025-07-22-supercharging-claude-cli-with-standards-og.jpg
 title: Exploring Claude CLI Context and Compliance with My Standards Repository
 tags:
   - ai

--- a/src/posts/2025-07-29-building-mcp-standards-server.md
+++ b/src/posts/2025-07-29-building-mcp-standards-server.md
@@ -2,17 +2,6 @@
 
 date: 2025-07-29
 description: "Build MCP standards server for Claude AI—implement Model Context Protocol for intelligent code standards and context-aware workflows."
-images:
-  hero:
-    alt: 'Down the MCP Rabbit Hole: Building a Standards Server - Hero Image'
-    caption: 'Visual representation of Down the MCP Rabbit Hole: Building a Standards Server'
-    height: 630
-    src: /assets/images/blog/hero/2025-07-29-building-mcp-standards-server-hero.jpg
-    width: 1200
-  inline: []
-  og:
-    alt: 'Down the MCP Rabbit Hole: Building a Standards Server - Social Media Preview'
-    src: /assets/images/blog/hero/2025-07-29-building-mcp-standards-server-og.jpg
 title: 'Down the MCP Rabbit Hole: Building a Standards Server'
 tags:
   - ai

--- a/src/posts/2025-08-07-supercharging-development-claude-flow.md
+++ b/src/posts/2025-08-07-supercharging-development-claude-flow.md
@@ -3,17 +3,6 @@
 author: William Zujkowski
 date: 2025-08-03
 description: Deploy Claude-Flow AI agent swarms for development—achieve 84.8% SWE-Bench solve rate with neural learning and multi-agent orchestration for complex tasks.
-images:
-  hero:
-    alt: 'Supercharging Development with Claude-Flow: AI Swarm Intelligence for Modern Engineering - Hero Image'
-    caption: 'Visual representation of Supercharging Development with Claude-Flow: AI Swarm Intelligence for Modern Engineering'
-    height: 630
-    src: /assets/images/blog/hero/2025-08-07-supercharging-development-claude-flow-hero.jpg
-    width: 1200
-  inline: []
-  og:
-    alt: 'Supercharging Development with Claude-Flow: AI Swarm Intelligence for Modern Engineering - Social Media Preview'
-    src: /assets/images/blog/hero/2025-08-07-supercharging-development-claude-flow-og.jpg
 title: 'Supercharging Development with Claude-Flow: AI Swarm Intelligence for Modern Engineering'
 tags:
   - ai

--- a/src/posts/2025-08-09-ai-cognitive-infrastructure.md
+++ b/src/posts/2025-08-09-ai-cognitive-infrastructure.md
@@ -3,16 +3,6 @@
 date: 2025-08-09
 title: 'AI as Cognitive Infrastructure: The Invisible Architecture Reshaping Human Thought'
 description: "Understand AI cognitive infrastructure shaping how billions think—explore societal effects of language models transforming from tools to thought systems."
-images:
-  hero:
-    src: /assets/images/blog/hero/2025-08-09-ai-cognitive-infrastructure-hero.jpg
-    alt: AI as Cognitive Infrastructure - The invisible architecture reshaping human thought
-    caption: Visual representation of AI as the cognitive infrastructure of modern society
-    width: 1200
-    height: 630
-  og:
-    src: /assets/images/blog/hero/2025-08-09-ai-cognitive-infrastructure-og.jpg
-    alt: AI as Cognitive Infrastructure - Social media preview
 tags:
   - ai
   - cognitive-science

--- a/src/posts/2025-08-25-network-traffic-analysis-suricata-homelab.md
+++ b/src/posts/2025-08-25-network-traffic-analysis-suricata-homelab.md
@@ -4,16 +4,6 @@ author: William Zujkowski
 date: 2025-08-25
 description: Deploy Suricata IDS/IPS for real-time network threat detection—configure rule management, performance tuning, and SIEM integration for homelab monitoring.
 title: Building a Network Traffic Analysis Lab with Suricata
-images:
-  hero:
-    src: /assets/images/blog/hero/2025-08-25-network-traffic-analysis-suricata-homelab-hero.jpg
-    alt: network topology and connections for Building a Network Traffic Analysis Lab with Suricata
-    caption: Visual representation of Building a Network Traffic Analysis Lab with Suricata
-    width: 1200
-    height: 630
-  og:
-    src: /assets/images/blog/hero/2025-08-25-network-traffic-analysis-suricata-homelab-og.jpg
-    alt: network topology and connections for Building a Network Traffic Analysis Lab with Suricata
 tags:
   - homelab
   - networking

--- a/src/posts/2025-09-01-self-hosted-bitwarden-migration-guide.md
+++ b/src/posts/2025-09-01-self-hosted-bitwarden-migration-guide.md
@@ -4,16 +4,6 @@ author: William Zujkowski
 date: 2025-09-01
 description: "Migrate to self-hosted Bitwarden—deploy secure vault with backup strategies, SSL certificates, and database encryption for full control."
 title: 'Self-Hosted Password Manager Migration: Bitwarden Deep Dive'
-images:
-  hero:
-    src: /assets/images/blog/hero/2025-09-01-self-hosted-bitwarden-migration-guide-hero.jpg
-    alt: 'cybersecurity concept illustration for Self-Hosted Password Manager Migration: Bitwarden Deep Dive'
-    caption: 'Visual representation of Self-Hosted Password Manager Migration: Bitwarden Deep Dive'
-    width: 1200
-    height: 630
-  og:
-    src: /assets/images/blog/hero/2025-09-01-self-hosted-bitwarden-migration-guide-og.jpg
-    alt: 'cybersecurity concept illustration for Self-Hosted Password Manager Migration: Bitwarden Deep Dive'
 tags:
   - cryptography
   - homelab

--- a/src/posts/2025-09-08-zero-trust-vlan-segmentation-homelab.md
+++ b/src/posts/2025-09-08-zero-trust-vlan-segmentation-homelab.md
@@ -4,16 +4,6 @@ author: William Zujkowski
 date: 2025-09-08
 description: Implement zero trust with VLAN segmentation—secure homelab networks using micro-segmentation and layer 3 firewalls for defense in depth.
 title: Implementing Zero Trust Microsegmentation with VLANs
-images:
-  hero:
-    src: /assets/images/blog/hero/2025-09-08-zero-trust-vlan-segmentation-homelab-hero.jpg
-    alt: network topology and connections for Implementing Zero Trust Microsegmentation with VLANs
-    caption: Visual representation of Implementing Zero Trust Microsegmentation with VLANs
-    width: 1200
-    height: 630
-  og:
-    src: /assets/images/blog/hero/2025-09-08-zero-trust-vlan-segmentation-homelab-og.jpg
-    alt: network topology and connections for Implementing Zero Trust Microsegmentation with VLANs
 tags:
   - homelab
   - networking

--- a/src/posts/2025-09-14-threat-intelligence-mitre-attack-dashboard.md
+++ b/src/posts/2025-09-14-threat-intelligence-mitre-attack-dashboard.md
@@ -4,19 +4,6 @@ title: Building Your Own MITRE ATT&CK Threat Intelligence Dashboard
 date: 2025-09-14
 description: Build MITRE ATT&CK threat intelligence dashboard with Python—track adversary tactics and techniques using open-source threat feeds.
 author: William Zujkowski
-images:
-  hero:
-    src: /assets/images/blog/hero/2025-09-20-threat-intelligence-mitre-attack-dashboard-hero.jpg
-    alt: Python code and development workflow for Building Your Own MITRE ATT&CK Threat
-      Intelligence Dashboard
-    caption: Visual representation of Building Your Own MITRE ATT&CK Threat Intelligence
-      Dashboard
-    width: 1200
-    height: 630
-  og:
-    src: /assets/images/blog/hero/2025-09-20-threat-intelligence-mitre-attack-dashboard-og.jpg
-    alt: Python code and development workflow for Building Your Own MITRE ATT&CK Threat
-      Intelligence Dashboard
 tags:
   - automation
   - monitoring

--- a/src/posts/2025-09-20-iot-security-homelab-owasp.md
+++ b/src/posts/2025-09-20-iot-security-homelab-owasp.md
@@ -4,16 +4,6 @@ title: 'IoT Security in Your Home Lab: Lessons from OWASP IoTGoat'
 date: 2025-09-20
 description: Test IoT security with OWASP IoTGoat—practice firmware extraction, API exploitation, and hardware hacking in secure lab environments.
 author: William Zujkowski
-images:
-  hero:
-    src: /assets/images/blog/hero/2025-09-20-iot-security-homelab-owasp-hero.jpg
-    alt: 'cybersecurity concept illustration for IoT Security in Your Home Lab: Lessons from OWASP IoTGoat'
-    caption: 'Visual representation of IoT Security in Your Home Lab: Lessons from OWASP IoTGoat'
-    width: 1200
-    height: 630
-  og:
-    src: /assets/images/blog/hero/2025-09-20-iot-security-homelab-owasp-og.jpg
-    alt: 'cybersecurity concept illustration for IoT Security in Your Home Lab: Lessons from OWASP IoTGoat'
 tags:
   - homelab
   - iot

--- a/src/posts/2025-09-20-vulnerability-prioritization-epss-kev.md
+++ b/src/posts/2025-09-20-vulnerability-prioritization-epss-kev.md
@@ -4,16 +4,6 @@ title: Building a Smart Vulnerability Prioritization System with EPSS and CISA K
 date: 2025-09-20
 description: Prioritize vulnerabilities with EPSS and CISA KEV catalog—move beyond CVSS scores to risk-based patch management using exploitation probability metrics.
 author: William Zujkowski
-images:
-  hero:
-    src: /assets/images/blog/hero/2025-09-20-vulnerability-prioritization-epss-kev-hero.jpg
-    alt: Hero image illustrating Building a Smart Vulnerability Prioritization System with EPSS and CISA KEV
-    caption: Visual representation of Building a Smart Vulnerability Prioritization System with EPSS and CISA KEV
-    width: 1200
-    height: 630
-  og:
-    src: /assets/images/blog/hero/2025-09-20-vulnerability-prioritization-epss-kev-og.jpg
-    alt: Hero image illustrating Building a Smart Vulnerability Prioritization System with EPSS and CISA KEV
 tags:
   - automation
   - python

--- a/src/posts/2025-09-29-proxmox-high-availability-homelab.md
+++ b/src/posts/2025-09-29-proxmox-high-availability-homelab.md
@@ -4,16 +4,6 @@ author: William Zujkowski
 date: 2025-09-29
 description: Build Proxmox high-availability clusters with shared storage and automated failover—implement live migration for zero-downtime homelab maintenance.
 title: Proxmox High Availability Setup for Homelab Reliability
-images:
-  hero:
-    src: /assets/images/blog/hero/2025-09-29-proxmox-high-availability-homelab-hero.jpg
-    alt: artificial intelligence concept diagram for Proxmox High Availability Setup for Homelab Reliability
-    caption: Visual representation of Proxmox High Availability Setup for Homelab Reliability
-    width: 1200
-    height: 630
-  og:
-    src: /assets/images/blog/hero/2025-09-29-proxmox-high-availability-homelab-og.jpg
-    alt: artificial intelligence concept diagram for Proxmox High Availability Setup for Homelab Reliability
 tags:
   - homelab
   - infrastructure

--- a/src/posts/2025-10-06-automated-security-scanning-pipeline.md
+++ b/src/posts/2025-10-06-automated-security-scanning-pipeline.md
@@ -4,16 +4,6 @@ author: William Zujkowski
 date: 2025-10-06
 description: Build automated security scanning pipelines with Grype, OSV, and Trivy—integrate vulnerability detection into CI/CD workflows with actionable reporting.
 title: Automated Security Scanning Pipeline with Grype and OSV
-images:
-  hero:
-    src: /assets/images/blog/hero/2025-10-06-automated-security-scanning-pipeline-hero.jpg
-    alt: cybersecurity concept illustration for Automated Security Scanning Pipeline with Grype and OSV
-    caption: Visual representation of Automated Security Scanning Pipeline with Grype and OSV
-    width: 1200
-    height: 630
-  og:
-    src: /assets/images/blog/hero/2025-10-06-automated-security-scanning-pipeline-og.jpg
-    alt: cybersecurity concept illustration for Automated Security Scanning Pipeline with Grype and OSV
 tags:
   - automation
   - devops

--- a/src/posts/2025-10-13-embodied-ai-robots-physical-world.md
+++ b/src/posts/2025-10-13-embodied-ai-robots-physical-world.md
@@ -4,16 +4,6 @@ author: William Zujkowski
 date: 2025-10-13
 description: Deploy Vision-Language-Action models for embodied AI robots—integrate physical world interaction with security considerations for homelab automation.
 title: 'From Claude in Your Terminal to Robots in Your Workshop: The Embodied AI Revolution'
-images:
-  hero:
-    src: /assets/images/blog/hero/2025-10-13-embodied-ai-robots-hero.jpg
-    alt: robotic arm controlled by AI in workshop environment
-    caption: Vision-Language-Action models bringing AI into the physical world
-    width: 1200
-    height: 630
-  og:
-    src: /assets/images/blog/hero/2025-10-13-embodied-ai-robots-og.jpg
-    alt: AI-powered robotics and embodied intelligence
 tags:
   - ai
   - automation

--- a/src/posts/2025-10-17-progressive-context-loading-llm-workflows.md
+++ b/src/posts/2025-10-17-progressive-context-loading-llm-workflows.md
@@ -4,15 +4,6 @@ title: 'From 150K to 2K Tokens: How Progressive Context Loading Revolutionizes L
 date: 2025-10-17
 description: Optimize LLM workflows with progressive context loading—achieve 98% token reduction using modular architecture for efficient production deployments.
 author: William Zujkowski
-images:
-  hero:
-    src: /assets/images/blog/hero/2025-10-17-progressive-context-loading-hero.jpg
-    alt: Abstract visualization of token streams being compressed through progressive loading layers, showing 150K tokens reducing to 2K
-    width: 1200
-    height: 630
-  og:
-    src: /assets/images/blog/hero/2025-10-17-progressive-context-loading-og.jpg
-    alt: Progressive context loading reduces LLM token usage by 98%
 tags:
   - ai
   - devops

--- a/src/posts/2025-10-29-post-quantum-cryptography-homelab.md
+++ b/src/posts/2025-10-29-post-quantum-cryptography-homelab.md
@@ -3,16 +3,6 @@ author: "William Zujkowski"
 date: 2025-10-29
 title: 'Preparing Your Homelab for the Quantum Future: Post-Quantum Cryptography Migration'
 description: "Implement post-quantum cryptography with CRYSTALS-Kyber and Dilithium—prepare homelab for quantum threats using NIST-approved algorithms."
-images:
-  hero:
-    src: /assets/images/blog/hero/2025-10-29-post-quantum-cryptography-homelab-hero.jpg
-    alt: Abstract visualization of post-quantum cryptography protecting a homelab server with quantum-safe encryption
-    caption: Preparing personal infrastructure for the quantum computing era
-    width: 1200
-    height: 630
-  og:
-    src: /assets/images/blog/hero/2025-10-29-post-quantum-cryptography-homelab-og.jpg
-    alt: 'Post-quantum cryptography for homelabs: NIST standards and practical migration'
 tags:
   - computational-science
   - cryptography

--- a/src/posts/2025-10-29-privacy-first-ai-lab-local-llms.md
+++ b/src/posts/2025-10-29-privacy-first-ai-lab-local-llms.md
@@ -3,16 +3,6 @@ author: "William Zujkowski"
 date: 2025-10-29
 title: "Building a Privacy-First AI Lab: Deploying Local LLMs Without Sacrificing Ethics"
 description: "Build privacy-first AI lab with local LLMs—run models up to 34B on RTX 3090 (24GB VRAM) with network isolation, traffic monitoring, and real privacy controls."
-images:
-  hero:
-    src: /assets/images/blog/hero/2025-10-29-privacy-first-ai-lab-local-llms-hero.jpg
-    alt: "Secure homelab setup with local LLM deployment featuring network isolation and privacy controls"
-    caption: "Building truly private AI infrastructure beyond just self-hosting"
-    width: 1200
-    height: 630
-  og:
-    src: /assets/images/blog/hero/2025-10-29-privacy-first-ai-lab-local-llms-og.jpg
-    alt: "Privacy-first AI lab: deploying local LLMs with real security"
 tags:
   - ethics
   - homelab


### PR DESCRIPTION
## Summary
- Remove broken `images:` frontmatter blocks from 57 posts that referenced non-existent `/assets/images/blog/hero/*.jpg` files
- Only `welcome.md` retains its images block (files actually exist on disk)
- `BaseLayout.astro` already falls back to `/assets/images/og/default-og.png` for posts without images

## Impact
- Eliminates 114 dead file references (hero + og per post)
- No visual change — layout already handled missing images gracefully
- Cleaner frontmatter, accurate metadata

## Test plan
- [x] Build passes (all 163 pages)
- [x] `welcome.md` images preserved
- [ ] Verify production deploy

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)