### PR TITLE
feat: Round 7 — Cmd+K search, image a11y, PWA manifest, OG dimensions

### DIFF
--- a/MANIFEST.json
+++ b/MANIFEST.json
@@ -2,7 +2,7 @@
   "version": "5.0.0",
   "schema": "optimized-lazy-loading",
   "generated": "2025-11-01T23:27:04-04:00",
-  "last_validated": "2026-03-11T17:29:08-04:00",
+  "last_validated": "2026-03-11T21:09:54-04:00",
   "repository": {
     "name": "williamzujkowski.github.io",
     "type": "personal-website",

--- a/astro-site/src/components/Search.svelte
+++ b/astro-site/src/components/Search.svelte
@@ -82,6 +82,10 @@
 
   onMount(() => {
     document.addEventListener('keydown', (e) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        e.preventDefault();
+        open();
+      }
       if (
         e.key === '/' &&
         !isOpen &&
@@ -119,6 +123,9 @@
       d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
     />
   </svg>
+  <kbd class="hidden lg:inline-block ml-1.5 text-[10px] px-1.5 py-0.5 rounded border font-sans"
+    style="color: var(--md-sys-color-on-surface-variant); border-color: var(--md-sys-color-outline-variant); opacity: 0.7"
+  >&sol;K</kbd>
 </button>
 
 <!-- Search dialog -->

--- a/astro-site/src/layouts/BaseLayout.astro
+++ b/astro-site/src/layouts/BaseLayout.astro
@@ -132,6 +132,7 @@ const navLinks = [
   <!-- Favicons -->
   <link rel="icon" type="image/svg+xml" href="/assets/images/favicon.svg" />
   <link rel="apple-touch-icon" href="/assets/images/icon-192.svg" />
+  <link rel="manifest" href="/manifest.json" />
   <meta name="theme-color" content="#4338ca" />
 
   <!-- Open Graph -->
@@ -140,6 +141,8 @@ const navLinks = [
   <meta property="og:type" content={type} />
   <meta property="og:url" content={canonicalUrl} />
   <meta property="og:image" content={ogImageUrl} />
+  <meta property="og:image:width" content="1200" />
+  <meta property="og:image:height" content="630" />
   <meta property="og:site_name" content={siteTitle} />
   <meta property="og:locale" content="en_US" />
   {type === 'article' && publishedDate && (

--- a/astro-site/src/layouts/PostLayout.astro
+++ b/astro-site/src/layouts/PostLayout.astro
@@ -39,7 +39,7 @@ const formattedDate = date.toLocaleDateString('en-US', {
         <header class="mb-10">
           {image && (
             <div class="mb-8 -mx-4 sm:mx-0 overflow-hidden rounded-none sm:rounded-2xl">
-              <img src={image} alt="" class="w-full h-48 sm:h-64 object-cover" loading="eager" decoding="async" fetchpriority="high" />
+              <img src={image} alt={`Cover image for ${title}`} class="w-full h-48 sm:h-64 object-cover" loading="eager" decoding="async" fetchpriority="high" />
             </div>
           )}
 

--- a/astro-site/src/pages/index.astro
+++ b/astro-site/src/pages/index.astro
@@ -91,7 +91,7 @@ const recentPosts = allPosts
           <article class="card group relative p-6 flex flex-col">
             {getValidImageUrl(post.data.image) && (
               <div class="mb-4 -mx-6 -mt-6 overflow-hidden rounded-t-[var(--md-sys-shape-corner-large)]">
-                <img src={getValidImageUrl(post.data.image)} alt="" class="w-full h-40 object-cover" loading="lazy" decoding="async" />
+                <img src={getValidImageUrl(post.data.image)} alt={`Cover image for ${post.data.title}`} class="w-full h-40 object-cover" loading="lazy" decoding="async" />
               </div>
             )}
             <div class="flex items-center gap-3 text-sm">

--- a/astro-site/src/pages/posts/index.astro
+++ b/astro-site/src/pages/posts/index.astro
@@ -45,7 +45,7 @@ const sortedTags = [...tagCounts.entries()].sort((a, b) => b[1] - a[1]);
           <article class="card group p-6 flex flex-col sm:flex-row gap-6">
             {getValidImageUrl(post.data.image) && (
               <div class="sm:w-48 sm:flex-shrink-0">
-                <img src={getValidImageUrl(post.data.image)} alt="" class="w-full h-32 sm:h-full object-cover rounded-[var(--md-sys-shape-corner-medium)]" loading="lazy" decoding="async" />
+                <img src={getValidImageUrl(post.data.image)} alt={`Cover image for ${post.data.title}`} class="w-full h-32 sm:h-full object-cover rounded-[var(--md-sys-shape-corner-medium)]" loading="lazy" decoding="async" />
               </div>
             )}
             <div class="flex-grow">


### PR DESCRIPTION
## Summary
- Add **Cmd/Ctrl+K** keyboard shortcut to open search dialog (works from any context, unlike `/` which only works outside inputs)
- Add `/K` hint badge on search button for keyboard shortcut discoverability
- Fix **empty alt=""** on all post cover images — now uses descriptive text: `Cover image for {post title}`
- Add `<link rel="manifest">` to enable **PWA installability** (manifest.json already existed)
- Add `og:image:width` and `og:image:height` meta tags for better **social media preview** rendering

## Test plan
- [ ] Press Cmd+K (Mac) or Ctrl+K (Win/Linux) — search dialog should open
- [ ] Press `/` outside inputs — search dialog should open (existing behavior preserved)
- [ ] Verify `/K` badge appears on search icon on desktop
- [ ] Check post images have descriptive alt text (inspect element on homepage cards)
- [ ] Verify `<link rel="manifest">` in page source
- [ ] Check og:image:width/height in page source
- [ ] Run Lighthouse a11y audit — empty alt violations should be resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)