### PR TITLE
feat: Round 8 — View Transitions, TOC, Related Posts

### DIFF
--- a/MANIFEST.json
+++ b/MANIFEST.json
@@ -2,7 +2,7 @@
   "version": "5.0.0",
   "schema": "optimized-lazy-loading",
   "generated": "2025-11-01T23:27:04-04:00",
-  "last_validated": "2026-03-11T21:09:54-04:00",
+  "last_validated": "2026-03-11T21:19:02-04:00",
   "repository": {
     "name": "williamzujkowski.github.io",
     "type": "personal-website",

--- a/astro-site/src/components/RelatedPosts.astro
+++ b/astro-site/src/components/RelatedPosts.astro
@@ -1,0 +1,66 @@
+---
+import { getCollection } from 'astro:content';
+import { getValidImageUrl, getReadingTime } from '@/lib/utils';
+
+interface Props {
+  currentSlug: string;
+  tags: string[];
+}
+
+const { currentSlug, tags } = Astro.props;
+
+// Get all published posts except current
+const allPosts = await getCollection('posts', ({ data }) => !data.draft);
+const otherPosts = allPosts.filter(p => p.id !== currentSlug);
+
+// Score posts by tag overlap
+const currentTags = new Set(tags.filter(t => t !== 'posts'));
+
+const scored = otherPosts.map(post => {
+  const postTags = new Set((post.data.tags ?? []).filter((t: string) => t !== 'posts'));
+  let overlap = 0;
+  for (const tag of currentTags) {
+    if (postTags.has(tag)) overlap++;
+  }
+  return { post, overlap };
+}).filter(s => s.overlap > 0);
+
+// Sort by overlap descending, then by date descending
+scored.sort((a, b) => {
+  if (b.overlap !== a.overlap) return b.overlap - a.overlap;
+  return b.post.data.date.getTime() - a.post.data.date.getTime();
+});
+
+const related = scored.slice(0, 3);
+---
+
+{related.length > 0 && (
+  <section class="mt-12 pt-8 border-t border-[var(--md-sys-color-outline-variant)]">
+    <h2 class="text-lg font-semibold mb-6">Related posts</h2>
+    <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+      {related.map(({ post }) => (
+        <a href={`/posts/${post.id}/`} class="group card p-4 no-underline hover:no-underline transition-colors">
+          {getValidImageUrl(post.data.image) && (
+            <div class="mb-3 -mx-4 -mt-4 overflow-hidden rounded-t-[var(--md-sys-shape-corner-large)]">
+              <img
+                src={getValidImageUrl(post.data.image)}
+                alt={`Cover image for ${post.data.title}`}
+                class="w-full h-28 object-cover"
+                loading="lazy"
+                decoding="async"
+              />
+            </div>
+          )}
+          <div class="text-xs text-[var(--md-sys-color-on-surface-variant)] mb-1">
+            {post.data.date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+            <span class="mx-1">&middot;</span>
+            {getReadingTime(post.body ?? '')} min read
+          </div>
+          <h3 class="text-sm font-medium leading-snug group-hover:text-[var(--md-sys-color-primary)] transition-colors line-clamp-2" style="color: var(--md-sys-color-on-surface)">
+            {post.data.title}
+          </h3>
+        </a>
+      ))}
+    </div>
+  </section>
+)}

--- a/astro-site/src/components/TableOfContents.astro
+++ b/astro-site/src/components/TableOfContents.astro
@@ -1,0 +1,37 @@
+---
+interface Heading {
+  depth: number;
+  slug: string;
+  text: string;
+}
+
+interface Props {
+  headings: Heading[];
+}
+
+const { headings } = Astro.props;
+
+// Only show TOC if there are 3+ headings (worth navigating)
+const filteredHeadings = headings.filter(h => h.depth <= 3);
+const showToc = filteredHeadings.length >= 3;
+---
+
+{showToc && (
+  <nav aria-label="Table of contents" class="toc mb-10 p-5 rounded-xl border border-[var(--md-sys-color-outline-variant)] bg-[var(--md-sys-color-surface-container-low)]">
+    <h2 class="text-sm font-semibold uppercase tracking-wider mb-3 text-[var(--md-sys-color-on-surface-variant)]">
+      On this page
+    </h2>
+    <ul class="space-y-1.5 text-sm">
+      {filteredHeadings.map((heading) => (
+        <li style={`padding-left: ${(heading.depth - 2) * 1}rem`}>
+          <a
+            href={`#${heading.slug}`}
+            class="text-[var(--md-sys-color-on-surface-variant)] hover:text-[var(--md-sys-color-on-surface)] no-underline hover:underline transition-colors"
+          >
+            {heading.text}
+          </a>
+        </li>
+      ))}
+    </ul>
+  </nav>
+)}

--- a/astro-site/src/layouts/BaseLayout.astro
+++ b/astro-site/src/layouts/BaseLayout.astro
@@ -1,5 +1,6 @@
 ---
 import '@/styles/global.css';
+import { ClientRouter } from 'astro:transitions';
 import DarkModeToggle from '@components/DarkModeToggle.svelte';
 import Search from '@components/Search.svelte';
 import MobileMenu from '@components/MobileMenu.svelte';
@@ -164,6 +165,8 @@ const navLinks = [
   {jsonLdSchemas.map((schema) => (
     <script type="application/ld+json" set:html={JSON.stringify(schema)} />
   ))}
+
+  <ClientRouter />
 
   <!-- Dark mode init (prevents flash) -->
   <script is:inline>

--- a/astro-site/src/layouts/PostLayout.astro
+++ b/astro-site/src/layouts/PostLayout.astro
@@ -1,5 +1,13 @@
 ---
 import BaseLayout from './BaseLayout.astro';
+import TableOfContents from '@components/TableOfContents.astro';
+import RelatedPosts from '@components/RelatedPosts.astro';
+
+interface Heading {
+  depth: number;
+  slug: string;
+  text: string;
+}
 
 interface Props {
   title: string;
@@ -9,9 +17,11 @@ interface Props {
   image?: string;
   readingTime?: number;
   wordCount?: number;
+  headings?: Heading[];
+  slug?: string;
 }
 
-const { title, description, date, tags = [], image, readingTime, wordCount } = Astro.props;
+const { title, description, date, tags = [], image, readingTime, wordCount, headings = [], slug = '' } = Astro.props;
 
 const formattedDate = date.toLocaleDateString('en-US', {
   year: 'numeric',
@@ -74,6 +84,9 @@ const formattedDate = date.toLocaleDateString('en-US', {
           )}
         </header>
 
+        <!-- Table of Contents -->
+        <TableOfContents headings={headings} />
+
         <!-- Content -->
         <div class="prose prose-lg max-w-none">
           <slot />
@@ -109,6 +122,9 @@ const formattedDate = date.toLocaleDateString('en-US', {
             </a>
           </div>
         </footer>
+
+        <!-- Related Posts -->
+        <RelatedPosts currentSlug={slug} tags={tags} />
       </div>
     </div>
   </article>

--- a/astro-site/src/pages/posts/[...slug].astro
+++ b/astro-site/src/pages/posts/[...slug].astro
@@ -12,7 +12,7 @@ export async function getStaticPaths() {
 }
 
 const { post } = Astro.props;
-const { Content } = await render(post);
+const { Content, headings } = await render(post);
 
 const body = post.body ?? '';
 const readingTime = getReadingTime(body);
@@ -28,6 +28,8 @@ const imageUrl = getValidImageUrl(post.data.image);
   image={imageUrl}
   readingTime={readingTime}
   wordCount={wordCount}
+  headings={headings}
+  slug={post.id}
 >
   <Content />
 </PostLayout>


### PR DESCRIPTION
## Summary
- **View Transitions**: Add Astro `ClientRouter` for smooth animated page navigation (no full reloads). Maintains scroll position, animates between pages.
- **Table of Contents**: Auto-generated "On this page" navigation for blog posts with 3+ headings. Supports h2 and h3 levels with proper indentation.
- **Related Posts**: Tag-based related post suggestions at bottom of blog posts. Shows up to 3 related posts scored by tag overlap, with cover images and reading time.

## Test plan
- [ ] Navigate between pages — transitions should be smooth (no white flash)
- [ ] Open a long blog post — TOC should appear below tags with linked headings
- [ ] Click a TOC link — should scroll to that section
- [ ] Scroll to bottom of a blog post — "Related posts" section with 3 tag-matched posts
- [ ] Open a post with < 3 headings — TOC should NOT appear
- [ ] Open a post with no matching tags — Related Posts section should NOT appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)