### PR TITLE
fix: dark mode toggle not working with prefers-color-scheme fallback

### DIFF
--- a/MANIFEST.json
+++ b/MANIFEST.json
@@ -2,7 +2,7 @@
   "version": "5.0.0",
   "schema": "optimized-lazy-loading",
   "generated": "2025-11-01T23:27:04-04:00",
-  "last_validated": "2026-03-11T21:19:02-04:00",
+  "last_validated": "2026-03-11T21:46:37-04:00",
   "repository": {
     "name": "williamzujkowski.github.io",
     "type": "personal-website",

--- a/astro-site/src/components/DarkModeToggle.svelte
+++ b/astro-site/src/components/DarkModeToggle.svelte
@@ -10,6 +10,7 @@
   function toggle() {
     isDark = !isDark;
     document.documentElement.classList.toggle('dark', isDark);
+    document.documentElement.classList.toggle('light', !isDark);
     localStorage.theme = isDark ? 'dark' : 'light';
 
     // Update theme-color meta tag

--- a/astro-site/src/layouts/BaseLayout.astro
+++ b/astro-site/src/layouts/BaseLayout.astro
@@ -172,8 +172,20 @@ const navLinks = [
   <script is:inline>
     (function() {
       const isDark = localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches);
-      if (isDark) document.documentElement.classList.add('dark');
+      if (isDark) {
+        document.documentElement.classList.add('dark');
+        document.documentElement.classList.remove('light');
+      } else if ('theme' in localStorage) {
+        document.documentElement.classList.add('light');
+        document.documentElement.classList.remove('dark');
+      }
     })();
+    // Re-apply after View Transitions page swap
+    document.addEventListener('astro:after-swap', function() {
+      var isDark = localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches);
+      document.documentElement.classList.toggle('dark', isDark);
+      document.documentElement.classList.toggle('light', !isDark && 'theme' in localStorage);
+    });
   </script>
 </head>
 


### PR DESCRIPTION
## Summary
- Fix dark/light mode toggle that stopped working after the `prefers-color-scheme` CSS fallback was added
- **Root cause**: The CSS rule `:root:not(.light)` in the `@media (prefers-color-scheme: dark)` block kept applying dark tokens even after the `.dark` class was removed, because no `.light` class was ever added
- Toggle now adds/removes `.light` class alongside `.dark`
- Init script properly sets `.light` when user explicitly chose light mode
- Added `astro:after-swap` handler to persist theme across View Transitions navigation

## Test plan
- [ ] Hard refresh on dark OS — should default to dark mode
- [ ] Click toggle — should switch to light mode visually
- [ ] Click toggle again — should switch back to dark mode
- [ ] Navigate to another page (View Transitions) — theme should persist
- [ ] Reload page after toggling — chosen theme should persist via localStorage

🤖 Generated with [Claude Code](https://claude.com/claude-code)