### PR TITLE
refactor: use Astro.site instead of hardcoded siteUrl

### DIFF
--- a/MANIFEST.json
+++ b/MANIFEST.json
@@ -2,7 +2,7 @@
   "version": "5.0.0",
   "schema": "optimized-lazy-loading",
   "generated": "2025-11-01T23:27:04-04:00",
-  "last_validated": "2026-03-11T21:57:04-04:00",
+  "last_validated": "2026-03-11T21:58:30-04:00",
   "repository": {
     "name": "williamzujkowski.github.io",
     "type": "personal-website",

--- a/astro-site/src/layouts/BaseLayout.astro
+++ b/astro-site/src/layouts/BaseLayout.astro
@@ -28,7 +28,7 @@ const {
 } = Astro.props;
 
 const siteTitle = 'William Zujkowski';
-const siteUrl = 'https://williamzujkowski.github.io';
+const siteUrl = Astro.site?.toString().replace(/\/$/, '') ?? 'https://williamzujkowski.github.io';
 const pageTitle = title === 'Home' ? siteTitle : `${title} - ${siteTitle}`;
 const canonicalUrl = new URL(Astro.url.pathname, siteUrl).href;
 const ogImageUrl = new URL(image, siteUrl).href;

--- a/astro-site/src/layouts/PostLayout.astro
+++ b/astro-site/src/layouts/PostLayout.astro
@@ -22,6 +22,7 @@ interface Props {
 }
 
 const { title, description, date, tags = [], image, readingTime, wordCount, headings = [], slug = '' } = Astro.props;
+const siteUrl = Astro.site?.toString().replace(/\/$/, '') ?? 'https://williamzujkowski.github.io';
 
 const formattedDate = date.toLocaleDateString('en-US', {
   year: 'numeric',
@@ -97,7 +98,7 @@ const formattedDate = date.toLocaleDateString('en-US', {
           <div class="flex flex-wrap items-center gap-4">
             <span class="text-sm font-medium">Share:</span>
             <a
-              href={`https://www.linkedin.com/shareArticle?mini=true&url=${encodeURIComponent(`https://williamzujkowski.github.io${Astro.url.pathname}`)}&title=${encodeURIComponent(title)}`}
+              href={`https://www.linkedin.com/shareArticle?mini=true&url=${encodeURIComponent(`${siteUrl}${Astro.url.pathname}`)}&title=${encodeURIComponent(title)}`}
               class="chip"
               target="_blank"
               rel="noopener noreferrer"
@@ -105,7 +106,7 @@ const formattedDate = date.toLocaleDateString('en-US', {
               LinkedIn
             </a>
             <a
-              href={`https://news.ycombinator.com/submitlink?u=${encodeURIComponent(`https://williamzujkowski.github.io${Astro.url.pathname}`)}&t=${encodeURIComponent(title)}`}
+              href={`https://news.ycombinator.com/submitlink?u=${encodeURIComponent(`${siteUrl}${Astro.url.pathname}`)}&t=${encodeURIComponent(title)}`}
               class="chip"
               target="_blank"
               rel="noopener noreferrer"
@@ -113,7 +114,7 @@ const formattedDate = date.toLocaleDateString('en-US', {
               Hacker News
             </a>
             <a
-              href={`https://www.reddit.com/submit?url=${encodeURIComponent(`https://williamzujkowski.github.io${Astro.url.pathname}`)}&title=${encodeURIComponent(title)}`}
+              href={`https://www.reddit.com/submit?url=${encodeURIComponent(`${siteUrl}${Astro.url.pathname}`)}&title=${encodeURIComponent(title)}`}
               class="chip"
               target="_blank"
               rel="noopener noreferrer"


### PR DESCRIPTION
Replace hardcoded URL with Astro.site in BaseLayout and PostLayout share links. Single source of truth.