### PR TITLE
fix: add noindex to 404 page, clean up dead stats fields

### DIFF
--- a/MANIFEST.json
+++ b/MANIFEST.json
@@ -2,7 +2,7 @@
   "version": "5.0.0",
   "schema": "optimized-lazy-loading",
   "generated": "2025-11-01T23:27:04-04:00",
-  "last_validated": "2026-03-11T21:58:30-04:00",
+  "last_validated": "2026-03-11T22:11:16-04:00",
   "repository": {
     "name": "williamzujkowski.github.io",
     "type": "personal-website",

--- a/astro-site/src/components/StatsCharts.svelte
+++ b/astro-site/src/components/StatsCharts.svelte
@@ -20,13 +20,7 @@
     monthlyCounts: Record<string, number>;
     topTags: [string, number][];
     tagCounts: Record<string, number>;
-    dayOfWeekCounts: number[];
-    readingTimeBuckets: Record<string, number>;
-    wordCountBuckets: Record<string, number>;
-    tagByMonth: Record<string, Record<string, number>>;
-    top5Tags: string[];
     heatmapData: Record<string, number>;
-    scatterData: { wordCount: number; readingTime: number; title: string }[];
   }
 
   interface Props {

--- a/astro-site/src/layouts/BaseLayout.astro
+++ b/astro-site/src/layouts/BaseLayout.astro
@@ -15,6 +15,7 @@ interface Props {
   publishedDate?: Date;
   wordCount?: number;
   tags?: string[];
+  noindex?: boolean;
 }
 
 const {
@@ -25,6 +26,7 @@ const {
   publishedDate,
   wordCount,
   tags = [],
+  noindex = false,
 } = Astro.props;
 
 const siteTitle = 'William Zujkowski';
@@ -159,7 +161,7 @@ const navLinks = [
   <meta name="twitter:description" content={description} />
   <meta name="twitter:image" content={ogImageUrl} />
 
-  <meta name="robots" content="index, follow" />
+  <meta name="robots" content={noindex ? 'noindex, nofollow' : 'index, follow'} />
 
   <!-- Structured Data -->
   {jsonLdSchemas.map((schema) => (

--- a/astro-site/src/pages/404.astro
+++ b/astro-site/src/pages/404.astro
@@ -2,20 +2,24 @@
 import BaseLayout from '@layouts/BaseLayout.astro';
 ---
 
-<BaseLayout title="Page Not Found" description="The page you're looking for doesn't exist.">
+<BaseLayout title="Page Not Found" description="The page you're looking for doesn't exist." noindex>
   <section class="py-24 sm:py-32">
     <div class="container mx-auto px-4 text-center">
-      <p class="text-base font-semibold text-[var(--md-sys-color-primary)]">404</p>
+      <p class="text-6xl sm:text-8xl font-bold text-[var(--md-sys-color-primary)]" style="opacity: 0.6">404</p>
       <h1 class="mt-4 text-3xl font-bold tracking-tight sm:text-5xl" style="font-size: var(--md-sys-typescale-display-medium)">
         Page not found
       </h1>
       <p class="mt-6 text-lg text-[var(--md-sys-color-on-surface-variant)]">
         The page you're looking for doesn't exist or has been moved.
       </p>
-      <div class="mt-10 flex items-center justify-center gap-4">
+      <div class="mt-10 flex items-center justify-center gap-4 flex-wrap">
         <a href="/" class="btn-filled">Go home</a>
         <a href="/posts/" class="btn-outlined">Browse posts</a>
+        <a href="/tags/" class="btn-outlined">Explore tags</a>
       </div>
+      <p class="mt-8 text-sm text-[var(--md-sys-color-on-surface-variant)]">
+        Try pressing <kbd class="px-1.5 py-0.5 rounded border text-xs" style="border-color: var(--md-sys-color-outline-variant)">/</kbd> to search the site.
+      </p>
     </div>
   </section>
 </BaseLayout>

--- a/astro-site/src/pages/stats.astro
+++ b/astro-site/src/pages/stats.astro
@@ -47,13 +47,7 @@ const statsData = {
   monthlyCounts,
   topTags,
   tagCounts,
-  dayOfWeekCounts: [] as number[],
-  readingTimeBuckets: {} as Record<string, number>,
-  wordCountBuckets: {} as Record<string, number>,
-  tagByMonth: {} as Record<string, Record<string, number>>,
-  top5Tags: [] as string[],
   heatmapData,
-  scatterData: [] as { wordCount: number; readingTime: number; title: string }[],
 };
 ---
 


### PR DESCRIPTION
## Summary
- Add `noindex` prop to BaseLayout, used by 404 page to prevent search engine indexing of error pages
- Improve 404 page UX: larger visual "404" text, search keyboard hint (`/`), tags link
- Remove 6 unused stub fields from StatsCharts interface (`dayOfWeekCounts`, `readingTimeBuckets`, `wordCountBuckets`, `tagByMonth`, `top5Tags`, `scatterData`) — the component recomputes all data from `filteredPosts` via `$derived` blocks

## Test plan
- [ ] Verify 404 page has `<meta name="robots" content="noindex, nofollow">`
- [ ] Verify all other pages still have `index, follow`
- [ ] Verify stats page renders correctly with cleaned-up data
- [ ] Verify 404 page displays search hint and tags link

🤖 Generated with [Claude Code](https://claude.com/claude-code)