### PR TITLE
feat: extract PostCard component and populate projects collection

### DIFF
--- a/MANIFEST.json
+++ b/MANIFEST.json
@@ -2,7 +2,7 @@
   "version": "5.0.0",
   "schema": "optimized-lazy-loading",
   "generated": "2025-11-01T23:27:04-04:00",
-  "last_validated": "2026-03-11T22:19:03-04:00",
+  "last_validated": "2026-03-11T22:25:52-04:00",
   "repository": {
     "name": "williamzujkowski.github.io",
     "type": "personal-website",

--- a/astro-site/src/components/PostCard.astro
+++ b/astro-site/src/components/PostCard.astro
@@ -1,0 +1,106 @@
+---
+import { getValidImageUrl, getReadingTime } from '@/lib/utils';
+
+interface Props {
+  post: {
+    id: string;
+    body?: string | null;
+    data: {
+      title: string;
+      date: Date;
+      description?: string;
+      tags?: string[];
+      image?: string | { url?: string; src?: string };
+    };
+  };
+  variant?: 'horizontal' | 'vertical';
+  maxTags?: number;
+}
+
+const { post, variant = 'horizontal', maxTags = 4 } = Astro.props;
+
+const imageUrl = getValidImageUrl(post.data.image);
+const readingTime = getReadingTime(post.body ?? '');
+const tags = (post.data.tags ?? []).filter((t: string) => t !== 'posts');
+const formattedDate = post.data.date.toLocaleDateString('en-US', {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+});
+
+// Reading time badge color
+const badgeColor = readingTime < 5
+  ? 'var(--md-sys-color-tertiary)'
+  : readingTime < 15
+    ? 'var(--md-sys-color-primary)'
+    : 'var(--md-sys-color-error)';
+---
+
+{variant === 'horizontal' ? (
+  <article class="card group p-6 flex flex-col sm:flex-row gap-6">
+    {imageUrl && (
+      <div class="sm:w-48 sm:flex-shrink-0">
+        <img src={imageUrl} alt={`Cover image for ${post.data.title}`} class="w-full h-32 sm:h-full object-cover rounded-[var(--md-sys-shape-corner-medium)]" loading="lazy" decoding="async" />
+      </div>
+    )}
+    <div class="flex-grow">
+      <div class="flex items-center gap-3 text-sm mb-2">
+        <time datetime={post.data.date.toISOString().split('T')[0]} class="font-medium text-[var(--md-sys-color-primary)]">
+          {formattedDate}
+        </time>
+        <span class="text-[var(--md-sys-color-outline)]">&middot;</span>
+        <span class="text-[var(--md-sys-color-on-surface-variant)]" style={`border-left: 2px solid ${badgeColor}; padding-left: 0.5rem;`}>
+          {readingTime} min read
+        </span>
+      </div>
+      <h2 class="text-xl font-semibold group-hover:text-[var(--md-sys-color-primary)]">
+        <a href={`/posts/${post.id}/`}>
+          {post.data.title}
+        </a>
+      </h2>
+      {post.data.description && (
+        <p class="mt-2 text-[var(--md-sys-color-on-surface-variant)] line-clamp-2">{post.data.description}</p>
+      )}
+      {tags.length > 0 && (
+        <div class="mt-3 flex flex-wrap gap-1.5">
+          {tags.slice(0, maxTags).map((tag: string) => (
+            <span class="chip text-xs">{tag}</span>
+          ))}
+        </div>
+      )}
+    </div>
+  </article>
+) : (
+  <article class="card group relative p-6 flex flex-col">
+    {imageUrl && (
+      <div class="mb-4 -mx-6 -mt-6 overflow-hidden rounded-t-[var(--md-sys-shape-corner-large)]">
+        <img src={imageUrl} alt={`Cover image for ${post.data.title}`} class="w-full h-40 object-cover" loading="lazy" decoding="async" />
+      </div>
+    )}
+    <div class="flex items-center gap-3 text-sm">
+      <time datetime={post.data.date.toISOString().split('T')[0]} class="font-medium text-[var(--md-sys-color-primary)]">
+        {formattedDate}
+      </time>
+      <span class="text-[var(--md-sys-color-outline)]">&middot;</span>
+      <span class="text-[var(--md-sys-color-on-surface-variant)]" style={`border-left: 2px solid ${badgeColor}; padding-left: 0.5rem;`}>
+        {readingTime} min read
+      </span>
+    </div>
+    <h3 class="mt-3 text-lg font-semibold leading-snug group-hover:text-[var(--md-sys-color-primary)]">
+      <a href={`/posts/${post.id}/`}>
+        <span class="absolute inset-0"></span>
+        {post.data.title}
+      </a>
+    </h3>
+    <p class="mt-3 text-sm text-[var(--md-sys-color-on-surface-variant)] line-clamp-3 flex-grow">
+      {post.data.description}
+    </p>
+    {tags.length > 0 && (
+      <div class="mt-4 flex flex-wrap gap-1.5">
+        {tags.slice(0, maxTags).map((tag: string) => (
+          <span class="chip text-xs">{tag}</span>
+        ))}
+      </div>
+    )}
+  </article>
+)}

--- a/astro-site/src/pages/index.astro
+++ b/astro-site/src/pages/index.astro
@@ -1,7 +1,7 @@
 ---
 import BaseLayout from '@layouts/BaseLayout.astro';
 import { getCollection } from 'astro:content';
-import { getValidImageUrl, getReadingTime } from '@/lib/utils';
+import PostCard from '@components/PostCard.astro';
 
 const allPosts = await getCollection('posts', ({ data }) => !data.draft);
 const recentPosts = allPosts
@@ -88,38 +88,7 @@ const recentPosts = allPosts
 
       <div class="mx-auto mt-12 grid max-w-2xl grid-cols-1 gap-8 md:grid-cols-2 lg:mx-0 lg:max-w-none lg:grid-cols-3">
         {recentPosts.map((post) => (
-          <article class="card group relative p-6 flex flex-col">
-            {getValidImageUrl(post.data.image) && (
-              <div class="mb-4 -mx-6 -mt-6 overflow-hidden rounded-t-[var(--md-sys-shape-corner-large)]">
-                <img src={getValidImageUrl(post.data.image)} alt={`Cover image for ${post.data.title}`} class="w-full h-40 object-cover" loading="lazy" decoding="async" />
-              </div>
-            )}
-            <div class="flex items-center gap-3 text-sm">
-              <time datetime={post.data.date.toISOString().split('T')[0]} class="font-medium text-[var(--md-sys-color-primary)]">
-                {post.data.date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
-              </time>
-              <span class="text-[var(--md-sys-color-outline)]">&middot;</span>
-              <span class="text-[var(--md-sys-color-on-surface-variant)]">
-                {getReadingTime(post.body ?? '')} min read
-              </span>
-            </div>
-            <h3 class="mt-3 text-lg font-semibold leading-snug group-hover:text-[var(--md-sys-color-primary)]">
-              <a href={`/posts/${post.id}/`}>
-                <span class="absolute inset-0"></span>
-                {post.data.title}
-              </a>
-            </h3>
-            <p class="mt-3 text-sm text-[var(--md-sys-color-on-surface-variant)] line-clamp-3 flex-grow">
-              {post.data.description}
-            </p>
-            {post.data.tags && post.data.tags.length > 0 && (
-              <div class="mt-4 flex flex-wrap gap-1.5">
-                {post.data.tags.filter((t: string) => t !== 'posts').slice(0, 3).map((tag: string) => (
-                  <span class="chip text-xs">{tag}</span>
-                ))}
-              </div>
-            )}
-          </article>
+          <PostCard post={post} variant="vertical" maxTags={3} />
         ))}
       </div>
 

--- a/astro-site/src/pages/posts/index.astro
+++ b/astro-site/src/pages/posts/index.astro
@@ -1,7 +1,7 @@
 ---
 import BaseLayout from '@layouts/BaseLayout.astro';
 import { getCollection } from 'astro:content';
-import { getValidImageUrl, getReadingTime } from '@/lib/utils';
+import PostCard from '@components/PostCard.astro';
 
 const allPosts = await getCollection('posts', ({ data }) => !data.draft);
 const posts = allPosts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
@@ -42,39 +42,7 @@ const sortedTags = [...tagCounts.entries()].sort((a, b) => b[1] - a[1]);
       <!-- Posts list -->
       <div class="space-y-6">
         {posts.map((post) => (
-          <article class="card group p-6 flex flex-col sm:flex-row gap-6">
-            {getValidImageUrl(post.data.image) && (
-              <div class="sm:w-48 sm:flex-shrink-0">
-                <img src={getValidImageUrl(post.data.image)} alt={`Cover image for ${post.data.title}`} class="w-full h-32 sm:h-full object-cover rounded-[var(--md-sys-shape-corner-medium)]" loading="lazy" decoding="async" />
-              </div>
-            )}
-            <div class="flex-grow">
-              <div class="flex items-center gap-3 text-sm mb-2">
-                <time datetime={post.data.date.toISOString().split('T')[0]} class="font-medium text-[var(--md-sys-color-primary)]">
-                  {post.data.date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
-                </time>
-                <span class="text-[var(--md-sys-color-outline)]">&middot;</span>
-                <span class="text-[var(--md-sys-color-on-surface-variant)]">
-                  {getReadingTime(post.body ?? '')} min read
-                </span>
-              </div>
-              <h2 class="text-xl font-semibold group-hover:text-[var(--md-sys-color-primary)]">
-                <a href={`/posts/${post.id}/`}>
-                  {post.data.title}
-                </a>
-              </h2>
-              {post.data.description && (
-                <p class="mt-2 text-[var(--md-sys-color-on-surface-variant)] line-clamp-2">{post.data.description}</p>
-              )}
-              {post.data.tags && post.data.tags.length > 0 && (
-                <div class="mt-3 flex flex-wrap gap-1.5">
-                  {post.data.tags.filter((t: string) => t !== 'posts').slice(0, 4).map((tag: string) => (
-                    <span class="chip text-xs">{tag}</span>
-                  ))}
-                </div>
-              )}
-            </div>
-          </article>
+          <PostCard post={post} variant="horizontal" />
         ))}
       </div>
     </div>

--- a/astro-site/src/projects/api-contract-tester.md
+++ b/astro-site/src/projects/api-contract-tester.md
@@ -1,0 +1,10 @@
+---
+title: API Contract Tester
+description: "Generate and run contract tests from OpenAPI 3.0 specs. Automates API validation against published specifications."
+url: https://github.com/williamzujkowski/api-contract-tester
+category: tools
+tags: [typescript, openapi, testing, api, automation]
+featured: false
+status: active
+order: 8
+---

--- a/astro-site/src/projects/federal-agentic-ai-guidance.md
+++ b/astro-site/src/projects/federal-agentic-ai-guidance.md
@@ -1,0 +1,10 @@
+---
+title: Federal Agentic AI Guidance
+description: "Comprehensive guidance for US federal employees building with AI agents. Aligned with NIST AI RMF, SP 800-53, CISA Secure by Design, and OWASP Top 10 for LLM/Agentic Apps."
+url: https://github.com/williamzujkowski/federal-agentic-ai-guidance
+category: security
+tags: [nist, federal, ai-safety, compliance, governance]
+featured: true
+status: active
+order: 2
+---

--- a/astro-site/src/projects/homelab-homepage.md
+++ b/astro-site/src/projects/homelab-homepage.md
@@ -1,0 +1,10 @@
+---
+title: Homelab Dashboard
+description: "Homelab dashboard powered by gethomepage/homepage, deployed to Cloud Foundry via Concourse CI/CD."
+url: https://github.com/williamzujkowski/homelab-homepage
+category: infrastructure
+tags: [dashboard, cloud-foundry, concourse, homelab, monitoring]
+featured: false
+status: active
+order: 7
+---

--- a/astro-site/src/projects/homelab-iac.md
+++ b/astro-site/src/projects/homelab-iac.md
@@ -1,0 +1,10 @@
+---
+title: Homelab IaC
+description: "Infrastructure as code for a bare-metal homelab — Terraform, BOSH, and Cloud Foundry managing enterprise-grade infrastructure at home."
+url: https://github.com/williamzujkowski/homelab-iac
+category: infrastructure
+tags: [terraform, bosh, cloud-foundry, bare-metal, homelab]
+featured: true
+status: active
+order: 4
+---

--- a/astro-site/src/projects/machine-rites.md
+++ b/astro-site/src/projects/machine-rites.md
@@ -1,0 +1,10 @@
+---
+title: Machine Rites
+description: "Dotfiles management with intelligent SSH agent handling, atomic operations, and comprehensive rollback support."
+url: https://github.com/williamzujkowski/machine-rites
+category: tools
+tags: [shell, dotfiles, automation, ssh, unix]
+featured: false
+status: active
+order: 6
+---

--- a/astro-site/src/projects/mcp-standards-server.md
+++ b/astro-site/src/projects/mcp-standards-server.md
@@ -1,0 +1,10 @@
+---
+title: MCP Standards Server
+description: "Model Context Protocol server for NIST 800-53r5 compliance checking, automated code analysis, and standards enforcement in development workflows."
+url: https://github.com/williamzujkowski/mcp-standards-server
+category: security
+tags: [mcp, nist, compliance, python, security-automation]
+featured: true
+status: active
+order: 3
+---

--- a/astro-site/src/projects/nexus-agents.md
+++ b/astro-site/src/projects/nexus-agents.md
@@ -1,0 +1,10 @@
+---
+title: Nexus Agents
+description: "Multi-model AI orchestration system that coordinates Claude, Gemini, Codex, and OpenCode. Routes tasks to specialized experts with consensus voting, adaptive routing, and graph workflows."
+url: https://github.com/williamzujkowski/nexus-agents
+category: ai
+tags: [typescript, mcp, ai-orchestration, multi-agent, llm]
+featured: true
+status: active
+order: 1
+---

--- a/astro-site/src/projects/security-disclosures.md
+++ b/astro-site/src/projects/security-disclosures.md
@@ -1,0 +1,10 @@
+---
+title: Security Disclosures
+description: "Tracking coordinated vulnerability disclosures and responsible security reporting across various platforms."
+url: https://github.com/williamzujkowski/security-disclosures
+category: security
+tags: [security, vulnerability-disclosure, responsible-disclosure]
+featured: false
+status: active
+order: 9
+---

--- a/astro-site/src/projects/svg-terminal.md
+++ b/astro-site/src/projects/svg-terminal.md
@@ -1,0 +1,10 @@
+---
+title: SVG Terminal
+description: "Generate beautiful animated SVG terminals for GitHub READMEs. Declarative config, built-in themes, and plugin blocks."
+url: https://github.com/williamzujkowski/svg-terminal
+category: tools
+tags: [typescript, svg, animation, cli, developer-tools]
+featured: false
+status: active
+order: 5
+---


### PR DESCRIPTION
## Summary
- **PostCard.astro** — reusable component replacing duplicated card HTML in `index.astro` and `posts/index.astro`. Supports horizontal and vertical variants with color-coded reading time badges
- **9 project content files** — populates the existing (empty) Astro content collection so the Projects page renders real data from GitHub repos
- Featured projects: Nexus Agents, Federal Agentic AI Guidance, MCP Standards Server, Homelab IaC
- Reading time badge colors: green (<5min), blue (5-15min), red (15min+)

## Test plan
- [ ] Blog page: verify PostCard renders identically to previous inline cards
- [ ] Home page: verify vertical PostCard variant renders in 3-column grid
- [ ] Reading time badges show correct color thresholds
- [ ] Projects page: verify 4 featured + 5 more projects render with correct categories and status
- [ ] All project links open correct GitHub repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)