### PR TITLE
style: bold uppercase header

### DIFF
--- a/astro-site/src/styles/global.css
+++ b/astro-site/src/styles/global.css
@@ -95,13 +95,15 @@ a:hover { text-decoration-style: solid; text-decoration-color: var(--text); }
 /* ===== Header ===== */
 .site-header { margin-block-end: 3rem; }
 .site-title {
-  font-size: clamp(1.75rem, 6vw, 3rem);
-  font-weight: 900; line-height: 1; letter-spacing: -0.03em; margin: 0;
+  font-size: clamp(2.75rem, 9vw, 5.5rem);
+  font-weight: 900; line-height: 0.9; letter-spacing: -0.04em; margin: 0;
+  text-transform: uppercase;
 }
 .site-title a { text-decoration: none; color: var(--text); }
 .site-subtitle {
-  font-size: clamp(1rem, 4vw, 1.5rem);
-  font-weight: 700; color: var(--text-muted); margin-block-start: 0.25rem;
+  font-size: clamp(1rem, 2.5vw, 1.5rem);
+  font-weight: 700; color: var(--text-muted); margin-block-start: 0.5rem;
+  text-transform: uppercase; letter-spacing: 0.15em;
 }
 .site-nav {
   display: flex; flex-wrap: wrap; gap: 0.5rem 1rem;


### PR DESCRIPTION
## Summary
Make the site title and subtitle larger and bolder, inspired by keithcirkel.co.uk's title style.

### Changes
- Title: `clamp(1.75rem, 6vw, 3rem)` → `clamp(2.75rem, 9vw, 5.5rem)` + `uppercase`
- Subtitle: `clamp(1rem, 4vw, 1.5rem)` → `clamp(1rem, 2.5vw, 1.5rem)` + `uppercase` + wider letter-spacing (0.15em)
- "WILLIAM" / "ZUJKOWSKI" stacks on two bold lines at content width
- Subtitle reads "SECURITY ENGINEER & BUILDER" with spaced caps

## Test plan
- [x] Pre-commit build check passed
- [x] Responsive: clamp scales smoothly from mobile to desktop
- [x] Text wraps to 2 lines within 70ch content column

🤖 Generated with [Claude Code](https://claude.com/claude-code)