### PR TITLE
fix: center all content to reading-width column per Remarque spec

### DIFF
--- a/astro-site/package-lock.json
+++ b/astro-site/package-lock.json
@@ -14,6 +14,7 @@
         "@astrojs/svelte": "^8.0.0",
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
+        "@fontsource-variable/newsreader": "^5.2.10",
         "@shikijs/transformers": "^4.0.2",
         "astro": "^6.0.3",
         "markdown-it": "^14.1.1",
@@ -965,6 +966,15 @@
       "version": "5.2.8",
       "resolved": "https://registry.npmjs.org/@fontsource-variable/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
       "integrity": "sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/newsreader": {
+      "version": "5.2.10",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/newsreader/-/newsreader-5.2.10.tgz",
+      "integrity": "sha512-MdI2iRwrqWpMOU/2aV2BgfZ4dJNlj/XlYaY8Zb7t87mWqHskYW0XiUANkt1cyOCiEfW2VQ0bQ5vZgGPp6B2B4w==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"

--- a/astro-site/package.json
+++ b/astro-site/package.json
@@ -24,6 +24,7 @@
     "@astrojs/svelte": "^8.0.0",
     "@fontsource-variable/inter": "^5.2.8",
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
+    "@fontsource-variable/newsreader": "^5.2.10",
     "@shikijs/transformers": "^4.0.2",
     "astro": "^6.0.3",
     "markdown-it": "^14.1.1",

--- a/astro-site/src/layouts/PostLayout.astro
+++ b/astro-site/src/layouts/PostLayout.astro
@@ -58,9 +58,7 @@ const formattedDate = date.toLocaleDateString('en-US', {
         {readingTime && <> &middot; {readingTime} min read</>}
       </div>
 
-      <h1 class="post-card-title" style="font-size: clamp(1.75rem, 5vw, 2.5rem);">
-        {title}
-      </h1>
+      <h1>{title}</h1>
 
       {description && <p class="post-description">{description}</p>}
 
@@ -91,7 +89,7 @@ const formattedDate = date.toLocaleDateString('en-US', {
         </div>
 
         <!-- Share -->
-        <footer class="mt-12 pt-8 border-t border-[var(--border)]">
+        <footer class="mt-12 pt-8" style="border-top: 1px solid var(--color-border);">
           <div class="flex flex-wrap items-center gap-4">
             <span class="text-sm font-medium">Share:</span>
             <a

--- a/astro-site/src/pages/now.astro
+++ b/astro-site/src/pages/now.astro
@@ -3,9 +3,7 @@ import BaseLayout from '@layouts/BaseLayout.astro';
 ---
 
 <BaseLayout title="Now" description="What I'm currently working on, learning, and thinking about.">
-  
-    <div>
-      <div class="max-w-3xl mx-auto prose prose-lg">
+  <div class="prose">
         <h1>What I'm Doing Now</h1>
 
         <p class="lead text-xl italic">
@@ -92,7 +90,5 @@ import BaseLayout from '@layouts/BaseLayout.astro';
           If you're curious about my full setup, check the <a href="/uses/">uses page</a>.
           For my background, see the <a href="/about/">about page</a>.
         </p>
-      </div>
-    </div>
-  
+  </div>
 </BaseLayout>

--- a/astro-site/src/pages/projects.astro
+++ b/astro-site/src/pages/projects.astro
@@ -26,11 +26,12 @@ const statusColors: Record<string, string> = {
   title="Projects"
   description="Open source projects and tools — AI orchestration, security engineering, and homelab infrastructure."
 >
-  
+  <div class="prose">
     <h1>Projects</h1>
     <p>
       Open source tools and experiments in AI orchestration, security engineering, and infrastructure.
     </p>
+  </div>
 
       <!-- Featured Projects -->
       {

--- a/astro-site/src/pages/resources.astro
+++ b/astro-site/src/pages/resources.astro
@@ -6,12 +6,12 @@ import BaseLayout from '@layouts/BaseLayout.astro';
  title="Resources"
  description="Books that shaped how I think, learning platforms worth your time, tools that didn't survive, and homelab projects that teach you more than any course."
 >
+ <div class="prose">
  <h1>Resources</h1>
- <div class="prose prose-lg">
  <p><em>
  The books that made me better at what I do, the learning platforms worth your time, and the tools that didn't
  survive contact with reality. No affiliate links, no vendor pitches.
- </p>
+ </em></p>
 
  <!-- Jump to -->
  <nav>

--- a/astro-site/src/pages/uses.astro
+++ b/astro-site/src/pages/uses.astro
@@ -3,9 +3,7 @@ import BaseLayout from '@layouts/BaseLayout.astro';
 ---
 
 <BaseLayout title="Uses" description="Hardware, software, and services I use.">
-  
-    <div>
-      <div class="max-w-3xl mx-auto prose prose-lg">
+  <div class="prose">
         <h1>Uses</h1>
 
         <p>
@@ -1076,7 +1074,5 @@ ollama run llama3.1:8b  # Or codellama:34b for larger models</code></pre>
         <p class="text-sm">
           <em>Last updated: 2026-03-12</em>
         </p>
-      </div>
-    </div>
-  
+  </div>
 </BaseLayout>

--- a/astro-site/src/styles/global.css
+++ b/astro-site/src/styles/global.css
@@ -1,48 +1,158 @@
+/*
+ * williamzujkowski.github.io — Global Styles
+ * ────────────────────────────────────────────
+ * Built on the Remarque design system.
+ * See: https://github.com/williamzujkowski/remarque
+ *
+ * Previous theme saved as global.css.pre-remarque
+ */
+
 @import '@fontsource-variable/inter';
 @import '@fontsource-variable/jetbrains-mono';
+@import '@fontsource-variable/newsreader';
+@import '@fontsource-variable/newsreader/wght-italic.css';
 
-/* ===== Design Tokens (oklch) ===== */
-/* Perceptually uniform color space — hue 50-80 = warm stone palette */
+/* ===== Remarque Design Tokens (oklch) ===== */
+
 :root {
-  --bg: oklch(98.5% 0.002 80);
-  --text: oklch(18% 0.005 60);
-  --text-muted: oklch(55% 0.01 60);
-  --accent: oklch(44% 0.2 280);
-  --surface: oklch(96.5% 0.002 80);
-  --border: oklch(92% 0.004 80);
-  --inverse-bg: oklch(22% 0.005 50);
-  --inverse-text: oklch(96.5% 0.002 80);
-  --font-sans: 'Inter Variable', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  /* Font stacks — Remarque three-font system */
+  --font-display: 'Newsreader', Georgia, 'Times New Roman', serif;
+  --font-body: 'Inter Variable', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   --font-mono: 'JetBrains Mono Variable', 'JetBrains Mono', 'Fira Code', monospace;
-  --line-height: 1.7;
-  --content-width: 70ch;
+
+  /* Type scale */
+  --text-display: clamp(2.75rem, 5.5vw, 5rem);
+  --text-title: clamp(1.875rem, 3.5vw, 3rem);
+  --text-section: clamp(1.375rem, 2.25vw, 2rem);
+  --text-body-lg: 1.1875rem;
+  --text-body: 1.0625rem;
+  --text-meta: 0.8125rem;
+  --text-micro: 0.75rem;
+
+  /* Line heights */
+  --leading-display: 1.05;
+  --leading-title: 1.15;
+  --leading-section: 1.2;
+  --leading-body: 1.75;
+  --leading-meta: 1.4;
+
+  /* Letter spacing */
+  --tracking-display: -0.02em;
+  --tracking-title: -0.015em;
+  --tracking-meta: 0.02em;
+  --tracking-caps: 0.06em;
+
+  /* Font weights */
+  --weight-regular: 400;
+  --weight-medium: 500;
+  --weight-semibold: 600;
+
+  /* Spacing */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.5rem;
+  --space-6: 2rem;
+  --space-7: 3rem;
+  --space-8: 4rem;
+  --space-9: 6rem;
+
+  /* Content widths */
+  --content-reading: 46rem;
+  --content-standard: 72rem;
+
+  /* Border radius — restrained */
+  --radius-sm: 0.25rem;
+  --radius-md: 0.5rem;
+
+  /* Motion — minimal */
+  --motion-fast: 120ms;
+  --motion-normal: 180ms;
+  --motion-easing: ease-out;
+
+  /* Colors — Light theme (warm off-white, not pure white) */
+  --color-bg: oklch(0.975 0.005 80);
+  --color-bg-subtle: oklch(0.955 0.005 80);
+  --color-fg: oklch(0.18 0.01 80);
+  --color-fg-muted: oklch(0.45 0.015 80);
+  --color-muted: oklch(0.55 0.01 80);
+  --color-border: oklch(0.88 0.005 80);
+  --color-border-bold: oklch(0.78 0.01 80);
+  --color-surface: oklch(0.965 0.005 80);
+  --color-accent: oklch(0.50 0.14 250);
+  --color-accent-hover: oklch(0.42 0.14 250);
+  --color-code-bg: oklch(0.945 0.005 80);
+  --color-code-fg: oklch(0.18 0.01 80);
+  --color-selection-bg: oklch(0.92 0.04 250);
+
+  /* Legacy compat aliases (used by existing components) */
+  --bg: var(--color-bg);
+  --text: var(--color-fg);
+  --text-muted-color: var(--color-fg-muted);
+  --accent: var(--color-accent);
+  --surface: var(--color-surface);
+  --border: var(--color-border);
+  --inverse-bg: var(--color-fg);
+  --inverse-text: var(--color-bg);
+  --font-sans: var(--font-body);
+
   color-scheme: light;
 }
 
-/* Dark tokens — manual .dark class override */
+/* Dark theme */
 :root.dark {
-  --bg: oklch(10% 0.005 50);
-  --text: oklch(86% 0.005 70);
-  --text-muted: oklch(72% 0.008 70);
-  --accent: oklch(78% 0.12 270);
-  --surface: oklch(18% 0.005 60);
-  --border: oklch(22% 0.005 50);
-  --inverse-bg: oklch(92% 0.004 80);
-  --inverse-text: oklch(18% 0.005 60);
+  --color-bg: oklch(0.16 0.01 80);
+  --color-bg-subtle: oklch(0.19 0.01 80);
+  --color-fg: oklch(0.90 0.005 80);
+  --color-fg-muted: oklch(0.65 0.01 80);
+  --color-muted: oklch(0.50 0.01 80);
+  --color-border: oklch(0.25 0.005 80);
+  --color-border-bold: oklch(0.35 0.01 80);
+  --color-surface: oklch(0.19 0.01 80);
+  --color-accent: oklch(0.68 0.12 250);
+  --color-accent-hover: oklch(0.75 0.12 250);
+  --color-code-bg: oklch(0.20 0.005 80);
+  --color-code-fg: oklch(0.88 0.005 80);
+  --color-selection-bg: oklch(0.30 0.06 250);
+
+  --bg: var(--color-bg);
+  --text: var(--color-fg);
+  --text-muted-color: var(--color-fg-muted);
+  --accent: var(--color-accent);
+  --surface: var(--color-surface);
+  --border: var(--color-border);
+  --inverse-bg: var(--color-fg);
+  --inverse-text: var(--color-bg);
+
   color-scheme: dark;
 }
 
-/* Dark tokens — system preference (same values, DRY not possible in plain CSS) */
 @media (prefers-color-scheme: dark) {
   :root:not(.light) {
-    --bg: oklch(10% 0.005 50);
-    --text: oklch(86% 0.005 70);
-    --text-muted: oklch(72% 0.008 70);
-    --accent: oklch(78% 0.12 270);
-    --surface: oklch(18% 0.005 60);
-    --border: oklch(22% 0.005 50);
-    --inverse-bg: oklch(92% 0.004 80);
-    --inverse-text: oklch(18% 0.005 60);
+    --color-bg: oklch(0.16 0.01 80);
+    --color-bg-subtle: oklch(0.19 0.01 80);
+    --color-fg: oklch(0.90 0.005 80);
+    --color-fg-muted: oklch(0.65 0.01 80);
+    --color-muted: oklch(0.50 0.01 80);
+    --color-border: oklch(0.25 0.005 80);
+    --color-border-bold: oklch(0.35 0.01 80);
+    --color-surface: oklch(0.19 0.01 80);
+    --color-accent: oklch(0.68 0.12 250);
+    --color-accent-hover: oklch(0.75 0.12 250);
+    --color-code-bg: oklch(0.20 0.005 80);
+    --color-code-fg: oklch(0.88 0.005 80);
+    --color-selection-bg: oklch(0.30 0.06 250);
+
+    --bg: var(--color-bg);
+    --text: var(--color-fg);
+    --text-muted-color: var(--color-fg-muted);
+    --accent: var(--color-accent);
+    --surface: var(--color-surface);
+    --border: var(--color-border);
+    --inverse-bg: var(--color-fg);
+    --inverse-text: var(--color-bg);
+
     color-scheme: dark;
   }
 }
@@ -53,165 +163,237 @@
 img, svg { max-width: 100%; height: auto; display: block; }
 
 /* ===== Base ===== */
-html { scroll-behavior: smooth; }
-
-body {
-  font-family: var(--font-sans);
-  background-color: var(--bg);
-  color: var(--text);
-  line-height: var(--line-height);
-  max-width: var(--content-width);
-  margin: 0 auto;
-  padding: 2rem 1.5rem;
+html {
+  scroll-behavior: smooth;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
 }
 
-/* ===== Typography ===== */
-h1, h2, h3, h4, h5, h6 {
-  font-weight: 900;
-  line-height: 1.1;
-  letter-spacing: -0.02em;
-  text-wrap: balance;
+body {
+  font-family: var(--font-body);
+  background-color: var(--color-bg);
+  color: var(--color-fg);
+  font-size: var(--text-body);
+  line-height: var(--leading-body);
+  max-width: var(--content-standard);
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
 }
-h1 { font-size: clamp(2rem, 6vw, 3.5rem); margin-block: 1.5rem 1rem; }
-h2 { font-size: clamp(1.5rem, 4vw, 2.25rem); margin-block: 2rem 0.75rem; }
-h3 { font-size: clamp(1.25rem, 3vw, 1.75rem); margin-block: 1.5rem 0.5rem; }
-h4 { font-size: 1.25rem; margin-block: 1.25rem 0.5rem; }
-p { margin-block: 0.75rem; text-wrap: pretty; }
-hr { border: none; border-top: 1px solid var(--border); margin-block: 2rem; }
+
+::selection {
+  background-color: var(--color-selection-bg);
+  color: var(--color-fg);
+}
+
+/* ===== Remarque Typography ===== */
+/* Display headings use Newsreader serif — the editorial signature */
+h1 {
+  font-family: var(--font-display);
+  font-size: var(--text-display);
+  font-weight: var(--weight-regular);
+  line-height: var(--leading-display);
+  letter-spacing: var(--tracking-display);
+  margin-block: var(--space-5) var(--space-4);
+}
+
+h2 {
+  font-family: var(--font-display);
+  font-size: var(--text-section);
+  font-weight: var(--weight-medium);
+  line-height: var(--leading-section);
+  letter-spacing: var(--tracking-title);
+  margin-block: var(--space-7) var(--space-3);
+}
+
+h3 {
+  font-family: var(--font-body);
+  font-size: var(--text-body-lg);
+  font-weight: var(--weight-semibold);
+  line-height: var(--leading-title);
+  margin-block: var(--space-6) var(--space-2);
+}
+
+h4 {
+  font-family: var(--font-body);
+  font-size: var(--text-body);
+  font-weight: var(--weight-semibold);
+  margin-block: var(--space-5) var(--space-2);
+}
+
+p { margin-block: var(--space-3); text-wrap: pretty; }
+hr { border: none; border-top: 1px solid var(--color-border); margin-block: var(--space-7); }
 
 /* ===== Links ===== */
 a {
-  color: var(--text);
+  color: var(--color-accent);
   text-decoration: underline;
-  text-decoration-style: dotted;
-  text-underline-offset: 3px;
-  text-decoration-color: var(--text-muted);
-  transition: text-decoration-color 150ms ease;
+  text-underline-offset: 0.2em;
+  text-decoration-thickness: 1px;
+  transition: color var(--motion-fast) var(--motion-easing);
 }
-a:hover { text-decoration-style: solid; text-decoration-color: var(--text); }
+a:hover { color: var(--color-accent-hover); }
 
-/* ===== Header ===== */
-.site-header { margin-block-end: 3rem; }
+/* ===== Header — Remarque editorial identity ===== */
+.site-header { margin-block-end: var(--space-7); }
 .site-title {
-  font-size: clamp(2.75rem, 9vw, 5.5rem);
-  font-weight: 900; line-height: 0.9; letter-spacing: -0.04em; margin: 0;
-  text-transform: uppercase;
+  font-family: var(--font-display);
+  font-size: var(--text-display);
+  font-weight: var(--weight-regular);
+  line-height: var(--leading-display);
+  letter-spacing: var(--tracking-display);
+  margin: 0;
 }
-.site-title a { text-decoration: none; color: var(--text); }
+.site-title a { text-decoration: none; color: var(--color-fg); }
 .site-subtitle {
-  font-size: clamp(1rem, 2.5vw, 1.5rem);
-  font-weight: 700; color: var(--text-muted); margin-block-start: 0.5rem;
-  text-transform: uppercase; letter-spacing: 0.15em;
+  font-family: var(--font-mono);
+  font-size: var(--text-meta);
+  font-weight: var(--weight-regular);
+  color: var(--color-muted);
+  margin-block-start: var(--space-2);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-caps);
 }
 .site-nav {
   display: flex; flex-wrap: wrap; gap: 0.5rem 1rem;
-  margin-block-start: 1rem; font-weight: 700; font-size: 0.9rem;
+  margin-block-start: var(--space-4);
+  font-size: var(--text-meta);
+  letter-spacing: var(--tracking-meta);
 }
-@media (max-width: 480px) { .site-nav { font-size: 0.85rem; gap: 0.35rem 0.75rem; } }
-.site-nav a { text-decoration: none; color: var(--text-muted); transition: color 150ms ease; }
-.site-nav a:hover, .site-nav a[aria-current="page"] { color: var(--text); }
+@media (max-width: 480px) { .site-nav { font-size: var(--text-meta); gap: 0.35rem 0.75rem; } }
+.site-nav a {
+  text-decoration: none;
+  color: var(--color-fg-muted);
+  transition: color var(--motion-fast) var(--motion-easing);
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+}
+.site-nav a:hover, .site-nav a[aria-current="page"] { color: var(--color-fg); }
 
 /* ===== Post Article Header ===== */
 .post-breadcrumb {
-  font-size: 0.85rem;
-  color: var(--text-muted);
-  margin-block-end: 2rem;
+  font-family: var(--font-mono);
+  font-size: var(--text-meta);
+  color: var(--color-muted);
+  letter-spacing: var(--tracking-meta);
+  margin-block-end: var(--space-6);
 }
-.post-breadcrumb a { color: var(--text-muted); }
-.post-breadcrumb a:hover { color: var(--text); }
+.post-breadcrumb a { color: var(--color-muted); text-decoration: none; }
+.post-breadcrumb a:hover { color: var(--color-fg); }
 
-.post-header { margin-block-end: 2.5rem; }
+.post-header { margin-block-end: var(--space-7); }
 
 .post-meta {
-  font-size: 0.85rem;
-  color: var(--text-muted);
-  margin-block-end: 0.75rem;
+  font-family: var(--font-mono);
+  font-size: var(--text-meta);
+  color: var(--color-muted);
+  letter-spacing: var(--tracking-meta);
+  margin-block-end: var(--space-3);
 }
 
 .post-description {
-  font-size: 1.1rem;
-  color: var(--text-muted);
-  line-height: 1.6;
-  margin-block-start: 1rem;
+  font-size: var(--text-body-lg);
+  color: var(--color-fg-muted);
+  line-height: var(--leading-body);
+  margin-block-start: var(--space-4);
 }
 
 /* ===== Post Cards ===== */
-.post-card { padding-block-end: 2.5rem; margin-block-end: 2.5rem; border-bottom: 1px solid var(--border); }
+.post-card {
+  padding-block-end: var(--space-7);
+  margin-block-end: var(--space-7);
+  border-bottom: 1px solid var(--color-border);
+}
 .post-card:last-child { border-bottom: none; }
 .post-card-title,
 a.post-card-title,
 a.post-card-title:visited {
   display: block;
-  font-size: clamp(1.25rem, 3vw, 1.6rem);
-  font-weight: 900; line-height: 1.3;
-  color: var(--inverse-text);
-  background-color: var(--inverse-bg);
-  padding: 0.6rem 0.8rem;
+  font-family: var(--font-display);
+  font-size: var(--text-title);
+  font-weight: var(--weight-regular);
+  line-height: var(--leading-title);
+  letter-spacing: var(--tracking-title);
+  color: var(--color-fg);
   text-decoration: none;
-  letter-spacing: -0.01em;
 }
 a.post-card-title:hover {
-  opacity: 0.85;
-  text-decoration: none;
-  color: var(--inverse-text);
+  color: var(--color-accent);
 }
-.post-card-excerpt { margin-block-start: 0.5rem; color: var(--text-muted); font-size: 1rem; line-height: 1.6; }
-.post-card-date { font-size: 0.8rem; color: var(--text-muted); margin-block-start: 0.5rem; }
+.post-card-excerpt {
+  margin-block-start: var(--space-2);
+  color: var(--color-fg-muted);
+  font-size: var(--text-body);
+  line-height: var(--leading-body);
+}
+.post-card-date {
+  font-family: var(--font-mono);
+  font-size: var(--text-meta);
+  color: var(--color-muted);
+  letter-spacing: var(--tracking-meta);
+  margin-block-start: var(--space-2);
+}
 
 /* ===== Chips ===== */
 .chip {
   display: inline-flex; align-items: center;
-  padding: 0.2rem 0.6rem; font-size: 0.8rem; font-weight: 600;
-  color: var(--text-muted); border: 1px solid var(--border);
-  border-radius: 0.25rem; text-decoration: none; transition: all 150ms ease;
+  padding: 0.2rem 0.6rem;
+  font-family: var(--font-mono);
+  font-size: var(--text-meta);
+  color: var(--color-muted);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  text-decoration: none;
+  transition: all var(--motion-fast) var(--motion-easing);
 }
-.chip:hover { color: var(--text); border-color: var(--text); text-decoration: none; }
+.chip:hover { color: var(--color-fg); border-color: var(--color-border-bold); }
 
 /* ===== Cards ===== */
 .card {
-  border: 1px solid var(--border); border-radius: 0.5rem;
-  padding: 1.5rem; transition: border-color 150ms ease;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-5);
+  transition: border-color var(--motion-fast) var(--motion-easing);
 }
-.card:hover { border-color: var(--text-muted); }
+.card:hover { border-color: var(--color-border-bold); }
 
 /* ===== Layout Utilities ===== */
-.card-grid { display: grid; grid-template-columns: 1fr; gap: 1.5rem; }
+.card-grid { display: grid; grid-template-columns: 1fr; gap: var(--space-5); }
 @media (min-width: 640px) { .card-grid { grid-template-columns: repeat(2, 1fr); } }
-.card-grid-3 { display: grid; grid-template-columns: 1fr; gap: 1.5rem; }
+.card-grid-3 { display: grid; grid-template-columns: 1fr; gap: var(--space-5); }
 @media (min-width: 640px) { .card-grid-3 { grid-template-columns: repeat(2, 1fr); } }
 @media (min-width: 1024px) { .card-grid-3 { grid-template-columns: repeat(3, 1fr); } }
-.chip-row { display: flex; flex-wrap: wrap; gap: 0.5rem; }
+.chip-row { display: flex; flex-wrap: wrap; gap: var(--space-2); }
 .flex { display: flex; }
 .flex-col { flex-direction: column; }
 .flex-wrap { flex-wrap: wrap; }
 .items-center { align-items: center; }
 .justify-center { justify-content: center; }
 .justify-between { justify-content: space-between; }
-.gap-1 { gap: 0.25rem; }
-.gap-2 { gap: 0.5rem; }
-.gap-3 { gap: 0.75rem; }
-.gap-4 { gap: 1rem; }
-.gap-6 { gap: 1.5rem; }
-.gap-8 { gap: 2rem; }
+.gap-1 { gap: var(--space-1); }
+.gap-2 { gap: var(--space-2); }
+.gap-3 { gap: var(--space-3); }
+.gap-4 { gap: var(--space-4); }
+.gap-6 { gap: var(--space-6); }
+.gap-8 { gap: var(--space-8); }
 .text-center { text-align: center; }
-.text-sm { font-size: 0.875rem; }
-.text-xs { font-size: 0.75rem; }
-.text-lg { font-size: 1.125rem; }
+.text-sm { font-size: var(--text-meta); }
+.text-xs { font-size: var(--text-micro); }
+.text-lg { font-size: var(--text-body-lg); }
 .text-xl { font-size: 1.25rem; }
 .text-2xl { font-size: 1.5rem; }
 .text-3xl { font-size: 1.875rem; }
 .font-bold { font-weight: 700; }
-.font-semibold { font-weight: 600; }
-.font-medium { font-weight: 500; }
+.font-semibold { font-weight: var(--weight-semibold); }
+.font-medium { font-weight: var(--weight-medium); }
 .italic { font-style: italic; }
 .uppercase { text-transform: uppercase; }
-.tracking-wider { letter-spacing: 0.05em; }
+.tracking-wider { letter-spacing: var(--tracking-caps); }
 .line-clamp-2 { display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
 .line-clamp-3 { display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
-.rounded { border-radius: 0.25rem; }
-.rounded-lg { border-radius: 0.5rem; }
+.rounded { border-radius: var(--radius-sm); }
+.rounded-lg { border-radius: var(--radius-md); }
 .rounded-full { border-radius: 9999px; }
 .hidden { display: none; }
 .sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }
@@ -232,118 +414,141 @@ a.post-card-title:hover {
 .space-y-6 > * + * { margin-block-start: 1.5rem; }
 
 /* Spacing */
-.mt-1 { margin-top: 0.25rem; } .mt-2 { margin-top: 0.5rem; } .mt-3 { margin-top: 0.75rem; }
-.mt-4 { margin-top: 1rem; } .mt-6 { margin-top: 1.5rem; } .mt-8 { margin-top: 2rem; }
-.mt-12 { margin-top: 3rem; }
-.mb-1 { margin-bottom: 0.25rem; } .mb-2 { margin-bottom: 0.5rem; } .mb-3 { margin-bottom: 0.75rem; }
-.mb-4 { margin-bottom: 1rem; } .mb-6 { margin-bottom: 1.5rem; } .mb-8 { margin-bottom: 2rem; }
-.mb-10 { margin-bottom: 2.5rem; } .mb-12 { margin-bottom: 3rem; }
-.p-4 { padding: 1rem; } .p-5 { padding: 1.25rem; } .p-6 { padding: 1.5rem; }
-.px-2 { padding-inline: 0.5rem; } .px-3 { padding-inline: 0.75rem; }
-.py-0\.5 { padding-block: 0.125rem; } .py-2 { padding-block: 0.5rem; }
-.py-8 { padding-block: 2rem; } .py-12 { padding-block: 3rem; }
-.my-8 { margin-block: 2rem; }
+.mt-1 { margin-top: var(--space-1); } .mt-2 { margin-top: var(--space-2); } .mt-3 { margin-top: var(--space-3); }
+.mt-4 { margin-top: var(--space-4); } .mt-6 { margin-top: var(--space-6); } .mt-8 { margin-top: var(--space-8); }
+.mt-12 { margin-top: var(--space-7); }
+.mb-1 { margin-bottom: var(--space-1); } .mb-2 { margin-bottom: var(--space-2); } .mb-3 { margin-bottom: var(--space-3); }
+.mb-4 { margin-bottom: var(--space-4); } .mb-6 { margin-bottom: var(--space-6); } .mb-8 { margin-bottom: var(--space-8); }
+.mb-10 { margin-bottom: 2.5rem; } .mb-12 { margin-bottom: var(--space-7); }
+.p-4 { padding: var(--space-4); } .p-5 { padding: var(--space-5); } .p-6 { padding: var(--space-6); }
+.px-2 { padding-inline: var(--space-2); } .px-3 { padding-inline: var(--space-3); }
+.py-0\.5 { padding-block: 0.125rem; } .py-2 { padding-block: var(--space-2); }
+.py-8 { padding-block: var(--space-8); } .py-12 { padding-block: var(--space-7); }
+.my-8 { margin-block: var(--space-8); }
 
-/* ===== Prose / Article Content ===== */
+/* ===== Prose / Article Content (Remarque prose styling) ===== */
 .prose {
-  color: var(--text); max-width: 700px;
-  font-size: 1.1rem; line-height: 1.8;
+  color: var(--color-fg);
+  max-width: var(--content-reading);
+  font-size: var(--text-body);
+  line-height: var(--leading-body);
 }
 .prose :where(p) { margin-block: 1.25em; }
-.prose :where(li) { font-size: 1.1rem; line-height: 1.7; margin-block-end: 0.5em; }
-.prose :where(ul, ol) { padding-inline-start: 1.5em; margin-block: 1em; }
-.prose :where(h1) { font-size: clamp(2rem, 6vw, 3.5rem); margin-block: 1.5rem 1rem; }
-.prose :where(h2) { margin-block: 2.5rem 1rem; }
-.prose :where(h3) { margin-block: 2rem 0.75rem; }
-.prose :where(h4) { margin-block: 1.5rem 0.5rem; }
-.prose :where(a) {
-  color: var(--text); text-decoration-style: dotted; text-underline-offset: 3px;
+.prose :where(li) { font-size: var(--text-body); line-height: var(--leading-body); margin-block-end: 0.5em; }
+.prose :where(ul, ol) { padding-inline-start: var(--space-5); margin-block: 1em; }
+.prose :where(h1) {
+  font-family: var(--font-display);
+  font-size: var(--text-display);
+  font-weight: var(--weight-regular);
+  line-height: var(--leading-display);
+  letter-spacing: var(--tracking-display);
+  margin-block: var(--space-5) var(--space-4);
 }
-.prose :where(a):hover { text-decoration-style: solid; }
-.prose :where(strong) { font-weight: 700; color: var(--text); }
+.prose :where(h2) {
+  font-family: var(--font-display);
+  font-size: var(--text-section);
+  font-weight: var(--weight-medium);
+  line-height: var(--leading-section);
+  letter-spacing: var(--tracking-title);
+  margin-block: var(--space-7) var(--space-3);
+}
+.prose :where(h3) {
+  font-family: var(--font-body);
+  font-size: var(--text-body-lg);
+  font-weight: var(--weight-semibold);
+  line-height: var(--leading-title);
+  margin-block: var(--space-6) var(--space-2);
+}
+.prose :where(h4) { margin-block: var(--space-5) var(--space-2); }
+.prose :where(a) {
+  color: var(--color-accent);
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+  text-decoration-thickness: 1px;
+}
+.prose :where(a):hover { color: var(--color-accent-hover); }
+.prose :where(strong) { font-weight: var(--weight-semibold); color: var(--color-fg); }
 .prose :where(em) { font-style: italic; }
 .prose :where(blockquote) {
-  border-left: 3px solid var(--border);
-  padding: 0.5rem 1rem; margin-block: 1.5rem;
-  color: var(--text-muted); font-style: italic;
+  border-left: 2px solid var(--color-border-bold);
+  padding: var(--space-2) var(--space-5);
+  margin-block: var(--space-5);
+  color: var(--color-fg-muted);
+  font-style: italic;
 }
-.prose :where(img) { border-radius: 0.375rem; margin-block: 1.5rem; }
-.prose :where(figure) { margin-block: 1.5rem; }
-.prose :where(figcaption) { font-size: 0.9rem; color: var(--text-muted); margin-top: 0.5rem; text-align: center; }
-/* Scrollable wrapper for wide tables and mermaid diagrams */
-.prose :where(.scroll-wrap) {
-  overflow-x: auto; -webkit-overflow-scrolling: touch;
-  margin-block: 1.5rem;
-}
-.prose :where(table) { width: 100%; border-collapse: collapse; font-size: 0.95rem; }
-.prose :where(th) { text-align: left; font-weight: 700; padding: 0.5rem; border-bottom: 2px solid var(--border); }
-.prose :where(td) { padding: 0.5rem; border-bottom: 1px solid var(--border); }
-.prose :where(code):not(:where(pre *)) {
-  background-color: var(--surface); padding: 0.125rem 0.375rem;
-  border-radius: 0.25rem; font-size: 0.9em; font-weight: 500;
+.prose :where(img) { border: 1px solid var(--color-border); border-radius: var(--radius-sm); margin-block: var(--space-5); }
+.prose :where(figure) { margin-block: var(--space-5); }
+.prose :where(figcaption) {
   font-family: var(--font-mono);
+  font-size: var(--text-meta);
+  letter-spacing: var(--tracking-meta);
+  color: var(--color-muted);
+  margin-top: var(--space-2);
+}
+.prose :where(.scroll-wrap) { overflow-x: auto; -webkit-overflow-scrolling: touch; margin-block: var(--space-5); }
+.prose :where(table) { width: 100%; border-collapse: collapse; font-size: 0.95rem; }
+.prose :where(th) { text-align: left; font-weight: var(--weight-semibold); padding: var(--space-2); border-bottom: 2px solid var(--color-border); }
+.prose :where(td) { padding: var(--space-2); border-bottom: 1px solid var(--color-border); }
+.prose :where(code):not(:where(pre *)) {
+  background-color: var(--color-code-bg);
+  padding: 0.15em 0.35em;
+  border-radius: var(--radius-sm);
+  font-size: 0.9em;
+  font-family: var(--font-mono);
+  color: var(--color-code-fg);
 }
 .prose :where(code)::before, .prose :where(code)::after { content: ''; }
 .prose :where(pre) {
-  background-color: var(--surface); border: 1px solid var(--border);
-  border-radius: 0.375rem; padding: 1rem; max-width: 100%;
+  background-color: var(--color-code-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-5); max-width: 100%;
   overflow-x: auto; -webkit-overflow-scrolling: touch;
-  font-family: var(--font-mono); font-size: 0.9rem; line-height: 1.6;
+  font-family: var(--font-mono);
+  font-size: var(--text-meta);
+  line-height: 1.6;
 }
-/* Code block filename tab — rendered via data-title attribute */
 .prose :where(pre[data-title]) { padding-top: 2.25rem; position: relative; }
 .prose :where(pre[data-title])::before {
   content: attr(data-title);
   position: absolute; top: 0; left: 0;
   padding: 0.25rem 0.75rem;
-  font-size: 0.75rem; font-family: var(--font-mono);
-  color: var(--text-muted); background-color: var(--border);
-  border-radius: 0.375rem 0 0.375rem 0;
-  border-bottom: 1px solid var(--border);
-  border-right: 1px solid var(--border);
+  font-size: var(--text-micro); font-family: var(--font-mono);
+  color: var(--color-muted); background-color: var(--color-border);
+  border-radius: var(--radius-md) 0 var(--radius-md) 0;
+  border-bottom: 1px solid var(--color-border);
+  border-right: 1px solid var(--color-border);
 }
 .prose :where(pre code) { background: none; padding: 0; border-radius: 0; font-size: inherit; }
-.prose-lg { font-size: 1.15rem; }
+.prose-lg { font-size: var(--text-body-lg); }
 
 /* Shiki dual-theme dark mode swap */
-/* Astro renders --shiki-dark and --shiki-dark-bg as inline CSS custom properties.
-   These rules swap to dark colors when dark mode is active. */
 @media (prefers-color-scheme: dark) {
-  .astro-code,
-  .astro-code span {
+  .astro-code, .astro-code span {
     color: var(--shiki-dark) !important;
     background-color: var(--shiki-dark-bg) !important;
   }
 }
-:root.dark .astro-code,
-:root.dark .astro-code span {
+:root.dark .astro-code, :root.dark .astro-code span {
   color: var(--shiki-dark) !important;
   background-color: var(--shiki-dark-bg) !important;
 }
 
-/* Mermaid Diagrams — dual-theme (light + dark images rendered at build time) */
-.prose :where(.mermaid-themed) { margin-block: 1.5rem; }
+/* Mermaid Diagrams */
+.prose :where(.mermaid-themed) { margin-block: var(--space-5); }
 .prose :where(.mermaid-themed) img {
   display: block; max-width: 100%; height: auto;
-  margin: 0 auto; border-radius: 0.375rem;
-  border: 1px solid var(--border);
+  margin: 0 auto; border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
 }
-
-/* Default: show light, hide dark */
 .mermaid-dark { display: none !important; }
 .mermaid-light { display: block; }
-
-/* OS dark preference (no manual override): swap */
 @media (prefers-color-scheme: dark) {
   :root:not(.light) .mermaid-light { display: none !important; }
   :root:not(.light) .mermaid-dark { display: block !important; }
 }
-
-/* Manual .dark class toggle: swap */
 :root.dark .mermaid-light { display: none !important; }
 :root.dark .mermaid-dark { display: block !important; }
-
-/* Manual .light class toggle: ensure light shows (overrides OS dark) */
 :root.light .mermaid-light { display: block !important; }
 :root.light .mermaid-dark { display: none !important; }
 
@@ -352,34 +557,65 @@ a.post-card-title:hover {
 
 /* ===== Callout boxes ===== */
 .callout {
-  background-color: var(--surface); border-left: 4px solid var(--text-muted);
-  padding: 1.25rem 1.5rem; margin-block: 1.5rem; border-radius: 0 0.375rem 0.375rem 0;
+  background-color: var(--color-surface);
+  border-left: 2px solid var(--color-border-bold);
+  padding: var(--space-4) var(--space-5);
+  margin-block: var(--space-5);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
 }
-.callout-accent { border-left-color: var(--accent); }
+.callout-accent { border-left-color: var(--color-accent); }
 
 /* ===== Footer ===== */
 .site-footer {
-  margin-block-start: 4rem; padding-block-start: 2rem;
-  border-top: 1px solid var(--border); font-size: 0.85rem;
-  color: var(--text-muted); text-align: center;
+  margin-block-start: var(--space-8);
+  padding-block-start: var(--space-6);
+  border-top: 1px solid var(--color-border);
+  font-family: var(--font-mono);
+  font-size: var(--text-meta);
+  letter-spacing: var(--tracking-meta);
+  color: var(--color-muted);
+  text-align: center;
 }
+.site-footer a { color: var(--color-muted); transition: color var(--motion-fast) var(--motion-easing); }
+.site-footer a:hover { color: var(--color-fg); }
 
 /* ===== Focus (WCAG) ===== */
 *:focus { outline: none; }
-*:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 2px; }
+*:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 2px; border-radius: 2px; }
 
 /* ===== Skip Link ===== */
 .skip-to-main {
   position: absolute; left: -9999px; z-index: 999;
-  padding: 0.75rem 1rem; background-color: var(--bg); color: var(--text); text-decoration: none;
+  padding: var(--space-3) var(--space-4);
+  background-color: var(--color-bg); color: var(--color-fg); text-decoration: none;
 }
 .skip-to-main:focus { left: 50%; top: 1rem; transform: translateX(-50%); }
 
-/* ===== Selection ===== */
-::selection { background-color: color-mix(in srgb, var(--accent) 30%, transparent); color: var(--text); }
+/* ===== Buttons ===== */
+.btn-filled {
+  display: inline-flex; align-items: center; gap: var(--space-2);
+  padding: var(--space-2) var(--space-5);
+  font-size: var(--text-meta); font-weight: var(--weight-medium);
+  color: var(--color-bg); background-color: var(--color-fg);
+  border-radius: var(--radius-sm); border: none; cursor: pointer;
+  text-decoration: none; transition: opacity var(--motion-fast) var(--motion-easing);
+}
+.btn-filled:hover { opacity: 0.85; text-decoration: none; color: var(--color-bg); }
+.btn-outlined {
+  display: inline-flex; align-items: center; gap: var(--space-2);
+  padding: var(--space-2) var(--space-5);
+  font-size: var(--text-meta); font-weight: var(--weight-medium);
+  color: var(--color-fg); background-color: transparent;
+  border: 1px solid var(--color-border); border-radius: var(--radius-sm);
+  cursor: pointer; text-decoration: none; transition: all var(--motion-fast) var(--motion-easing);
+}
+.btn-outlined:hover { border-color: var(--color-border-bold); }
 
 /* ===== Responsive ===== */
-@media (max-width: 640px) { body { padding: 1.5rem 1rem; } .prose { font-size: 1rem; } }
+@media (max-width: 640px) {
+  body { padding: var(--space-5) var(--space-4); }
+  .prose { font-size: var(--text-body); }
+}
 
 /* ===== Reduced Motion ===== */
 @media (prefers-reduced-motion: reduce) {
@@ -388,21 +624,3 @@ a.post-card-title:hover {
     transition-duration: 0.01ms !important; scroll-behavior: auto !important;
   }
 }
-
-/* ===== Buttons ===== */
-.btn-filled {
-  display: inline-flex; align-items: center; gap: 0.5rem;
-  padding: 0.5rem 1.25rem; font-size: 0.9rem; font-weight: 700;
-  color: var(--inverse-text); background-color: var(--inverse-bg);
-  border-radius: 0.25rem; border: none; cursor: pointer;
-  text-decoration: none; transition: opacity 150ms ease;
-}
-.btn-filled:hover { opacity: 0.85; text-decoration: none; color: var(--inverse-text); }
-.btn-outlined {
-  display: inline-flex; align-items: center; gap: 0.5rem;
-  padding: 0.5rem 1.25rem; font-size: 0.9rem; font-weight: 700;
-  color: var(--text); background-color: transparent;
-  border: 1px solid var(--border); border-radius: 0.25rem;
-  cursor: pointer; text-decoration: none; transition: all 150ms ease;
-}
-.btn-outlined:hover { border-color: var(--text); text-decoration: none; }

--- a/astro-site/src/styles/global.css
+++ b/astro-site/src/styles/global.css
@@ -235,7 +235,11 @@ a {
 a:hover { color: var(--color-accent-hover); }
 
 /* ===== Header — Remarque editorial identity ===== */
-.site-header { margin-block-end: var(--space-7); }
+.site-header {
+  margin-block-end: var(--space-7);
+  max-width: var(--content-reading);
+  margin-inline: auto;
+}
 .site-title {
   font-family: var(--font-display);
   font-size: var(--text-display);
@@ -278,11 +282,17 @@ a:hover { color: var(--color-accent-hover); }
   color: var(--color-muted);
   letter-spacing: var(--tracking-meta);
   margin-block-end: var(--space-6);
+  max-width: var(--content-reading);
+  margin-inline: auto;
 }
 .post-breadcrumb a { color: var(--color-muted); text-decoration: none; }
 .post-breadcrumb a:hover { color: var(--color-fg); }
 
-.post-header { margin-block-end: var(--space-7); }
+.post-header {
+  margin-block-end: var(--space-7);
+  max-width: var(--content-reading);
+  margin-inline: auto;
+}
 
 .post-meta {
   font-family: var(--font-mono);
@@ -304,6 +314,8 @@ a:hover { color: var(--color-accent-hover); }
   padding-block-end: var(--space-7);
   margin-block-end: var(--space-7);
   border-bottom: 1px solid var(--color-border);
+  max-width: var(--content-reading);
+  margin-inline: auto;
 }
 .post-card:last-child { border-bottom: none; }
 .post-card-title,
@@ -430,6 +442,7 @@ a.post-card-title:hover {
 .prose {
   color: var(--color-fg);
   max-width: var(--content-reading);
+  margin-inline: auto;
   font-size: var(--text-body);
   line-height: var(--leading-body);
 }
@@ -575,6 +588,8 @@ a.post-card-title:hover {
   letter-spacing: var(--tracking-meta);
   color: var(--color-muted);
   text-align: center;
+  max-width: var(--content-reading);
+  margin-inline: auto;
 }
 .site-footer a { color: var(--color-muted); transition: color var(--motion-fast) var(--motion-easing); }
 .site-footer a:hover { color: var(--color-fg); }

--- a/astro-site/src/styles/global.css.pre-remarque
+++ b/astro-site/src/styles/global.css.pre-remarque
@@ -1,0 +1,408 @@
+@import '@fontsource-variable/inter';
+@import '@fontsource-variable/jetbrains-mono';
+
+/* ===== Design Tokens (oklch) ===== */
+/* Perceptually uniform color space — hue 50-80 = warm stone palette */
+:root {
+  --bg: oklch(98.5% 0.002 80);
+  --text: oklch(18% 0.005 60);
+  --text-muted: oklch(55% 0.01 60);
+  --accent: oklch(44% 0.2 280);
+  --surface: oklch(96.5% 0.002 80);
+  --border: oklch(92% 0.004 80);
+  --inverse-bg: oklch(22% 0.005 50);
+  --inverse-text: oklch(96.5% 0.002 80);
+  --font-sans: 'Inter Variable', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-mono: 'JetBrains Mono Variable', 'JetBrains Mono', 'Fira Code', monospace;
+  --line-height: 1.7;
+  --content-width: 70ch;
+  color-scheme: light;
+}
+
+/* Dark tokens — manual .dark class override */
+:root.dark {
+  --bg: oklch(10% 0.005 50);
+  --text: oklch(86% 0.005 70);
+  --text-muted: oklch(72% 0.008 70);
+  --accent: oklch(78% 0.12 270);
+  --surface: oklch(18% 0.005 60);
+  --border: oklch(22% 0.005 50);
+  --inverse-bg: oklch(92% 0.004 80);
+  --inverse-text: oklch(18% 0.005 60);
+  color-scheme: dark;
+}
+
+/* Dark tokens — system preference (same values, DRY not possible in plain CSS) */
+@media (prefers-color-scheme: dark) {
+  :root:not(.light) {
+    --bg: oklch(10% 0.005 50);
+    --text: oklch(86% 0.005 70);
+    --text-muted: oklch(72% 0.008 70);
+    --accent: oklch(78% 0.12 270);
+    --surface: oklch(18% 0.005 60);
+    --border: oklch(22% 0.005 50);
+    --inverse-bg: oklch(92% 0.004 80);
+    --inverse-text: oklch(18% 0.005 60);
+    color-scheme: dark;
+  }
+}
+:root.light { color-scheme: light; }
+
+/* ===== Reset ===== */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+img, svg { max-width: 100%; height: auto; display: block; }
+
+/* ===== Base ===== */
+html { scroll-behavior: smooth; }
+
+body {
+  font-family: var(--font-sans);
+  background-color: var(--bg);
+  color: var(--text);
+  line-height: var(--line-height);
+  max-width: var(--content-width);
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* ===== Typography ===== */
+h1, h2, h3, h4, h5, h6 {
+  font-weight: 900;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  text-wrap: balance;
+}
+h1 { font-size: clamp(2rem, 6vw, 3.5rem); margin-block: 1.5rem 1rem; }
+h2 { font-size: clamp(1.5rem, 4vw, 2.25rem); margin-block: 2rem 0.75rem; }
+h3 { font-size: clamp(1.25rem, 3vw, 1.75rem); margin-block: 1.5rem 0.5rem; }
+h4 { font-size: 1.25rem; margin-block: 1.25rem 0.5rem; }
+p { margin-block: 0.75rem; text-wrap: pretty; }
+hr { border: none; border-top: 1px solid var(--border); margin-block: 2rem; }
+
+/* ===== Links ===== */
+a {
+  color: var(--text);
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-underline-offset: 3px;
+  text-decoration-color: var(--text-muted);
+  transition: text-decoration-color 150ms ease;
+}
+a:hover { text-decoration-style: solid; text-decoration-color: var(--text); }
+
+/* ===== Header ===== */
+.site-header { margin-block-end: 3rem; }
+.site-title {
+  font-size: clamp(2.75rem, 9vw, 5.5rem);
+  font-weight: 900; line-height: 0.9; letter-spacing: -0.04em; margin: 0;
+  text-transform: uppercase;
+}
+.site-title a { text-decoration: none; color: var(--text); }
+.site-subtitle {
+  font-size: clamp(1rem, 2.5vw, 1.5rem);
+  font-weight: 700; color: var(--text-muted); margin-block-start: 0.5rem;
+  text-transform: uppercase; letter-spacing: 0.15em;
+}
+.site-nav {
+  display: flex; flex-wrap: wrap; gap: 0.5rem 1rem;
+  margin-block-start: 1rem; font-weight: 700; font-size: 0.9rem;
+}
+@media (max-width: 480px) { .site-nav { font-size: 0.85rem; gap: 0.35rem 0.75rem; } }
+.site-nav a { text-decoration: none; color: var(--text-muted); transition: color 150ms ease; }
+.site-nav a:hover, .site-nav a[aria-current="page"] { color: var(--text); }
+
+/* ===== Post Article Header ===== */
+.post-breadcrumb {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  margin-block-end: 2rem;
+}
+.post-breadcrumb a { color: var(--text-muted); }
+.post-breadcrumb a:hover { color: var(--text); }
+
+.post-header { margin-block-end: 2.5rem; }
+
+.post-meta {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  margin-block-end: 0.75rem;
+}
+
+.post-description {
+  font-size: 1.1rem;
+  color: var(--text-muted);
+  line-height: 1.6;
+  margin-block-start: 1rem;
+}
+
+/* ===== Post Cards ===== */
+.post-card { padding-block-end: 2.5rem; margin-block-end: 2.5rem; border-bottom: 1px solid var(--border); }
+.post-card:last-child { border-bottom: none; }
+.post-card-title,
+a.post-card-title,
+a.post-card-title:visited {
+  display: block;
+  font-size: clamp(1.25rem, 3vw, 1.6rem);
+  font-weight: 900; line-height: 1.3;
+  color: var(--inverse-text);
+  background-color: var(--inverse-bg);
+  padding: 0.6rem 0.8rem;
+  text-decoration: none;
+  letter-spacing: -0.01em;
+}
+a.post-card-title:hover {
+  opacity: 0.85;
+  text-decoration: none;
+  color: var(--inverse-text);
+}
+.post-card-excerpt { margin-block-start: 0.5rem; color: var(--text-muted); font-size: 1rem; line-height: 1.6; }
+.post-card-date { font-size: 0.8rem; color: var(--text-muted); margin-block-start: 0.5rem; }
+
+/* ===== Chips ===== */
+.chip {
+  display: inline-flex; align-items: center;
+  padding: 0.2rem 0.6rem; font-size: 0.8rem; font-weight: 600;
+  color: var(--text-muted); border: 1px solid var(--border);
+  border-radius: 0.25rem; text-decoration: none; transition: all 150ms ease;
+}
+.chip:hover { color: var(--text); border-color: var(--text); text-decoration: none; }
+
+/* ===== Cards ===== */
+.card {
+  border: 1px solid var(--border); border-radius: 0.5rem;
+  padding: 1.5rem; transition: border-color 150ms ease;
+}
+.card:hover { border-color: var(--text-muted); }
+
+/* ===== Layout Utilities ===== */
+.card-grid { display: grid; grid-template-columns: 1fr; gap: 1.5rem; }
+@media (min-width: 640px) { .card-grid { grid-template-columns: repeat(2, 1fr); } }
+.card-grid-3 { display: grid; grid-template-columns: 1fr; gap: 1.5rem; }
+@media (min-width: 640px) { .card-grid-3 { grid-template-columns: repeat(2, 1fr); } }
+@media (min-width: 1024px) { .card-grid-3 { grid-template-columns: repeat(3, 1fr); } }
+.chip-row { display: flex; flex-wrap: wrap; gap: 0.5rem; }
+.flex { display: flex; }
+.flex-col { flex-direction: column; }
+.flex-wrap { flex-wrap: wrap; }
+.items-center { align-items: center; }
+.justify-center { justify-content: center; }
+.justify-between { justify-content: space-between; }
+.gap-1 { gap: 0.25rem; }
+.gap-2 { gap: 0.5rem; }
+.gap-3 { gap: 0.75rem; }
+.gap-4 { gap: 1rem; }
+.gap-6 { gap: 1.5rem; }
+.gap-8 { gap: 2rem; }
+.text-center { text-align: center; }
+.text-sm { font-size: 0.875rem; }
+.text-xs { font-size: 0.75rem; }
+.text-lg { font-size: 1.125rem; }
+.text-xl { font-size: 1.25rem; }
+.text-2xl { font-size: 1.5rem; }
+.text-3xl { font-size: 1.875rem; }
+.font-bold { font-weight: 700; }
+.font-semibold { font-weight: 600; }
+.font-medium { font-weight: 500; }
+.italic { font-style: italic; }
+.uppercase { text-transform: uppercase; }
+.tracking-wider { letter-spacing: 0.05em; }
+.line-clamp-2 { display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+.line-clamp-3 { display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
+.rounded { border-radius: 0.25rem; }
+.rounded-lg { border-radius: 0.5rem; }
+.rounded-full { border-radius: 9999px; }
+.hidden { display: none; }
+.sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }
+.relative { position: relative; }
+.absolute { position: absolute; }
+.inset-0 { top: 0; right: 0; bottom: 0; left: 0; }
+.z-10 { z-index: 10; }
+.w-full { width: 100%; }
+.w-4 { width: 1rem; } .h-4 { height: 1rem; }
+.w-5 { width: 1.25rem; } .h-5 { height: 1.25rem; }
+.w-6 { width: 1.5rem; } .h-6 { height: 1.5rem; }
+.w-16 { width: 4rem; } .h-16 { height: 4rem; }
+.h-1 { height: 0.25rem; }
+.h-28 { height: 7rem; } .h-48 { height: 12rem; } .h-64 { height: 16rem; }
+.h-80 { height: 20rem; }
+.space-y-2 > * + * { margin-block-start: 0.5rem; }
+.space-y-4 > * + * { margin-block-start: 1rem; }
+.space-y-6 > * + * { margin-block-start: 1.5rem; }
+
+/* Spacing */
+.mt-1 { margin-top: 0.25rem; } .mt-2 { margin-top: 0.5rem; } .mt-3 { margin-top: 0.75rem; }
+.mt-4 { margin-top: 1rem; } .mt-6 { margin-top: 1.5rem; } .mt-8 { margin-top: 2rem; }
+.mt-12 { margin-top: 3rem; }
+.mb-1 { margin-bottom: 0.25rem; } .mb-2 { margin-bottom: 0.5rem; } .mb-3 { margin-bottom: 0.75rem; }
+.mb-4 { margin-bottom: 1rem; } .mb-6 { margin-bottom: 1.5rem; } .mb-8 { margin-bottom: 2rem; }
+.mb-10 { margin-bottom: 2.5rem; } .mb-12 { margin-bottom: 3rem; }
+.p-4 { padding: 1rem; } .p-5 { padding: 1.25rem; } .p-6 { padding: 1.5rem; }
+.px-2 { padding-inline: 0.5rem; } .px-3 { padding-inline: 0.75rem; }
+.py-0\.5 { padding-block: 0.125rem; } .py-2 { padding-block: 0.5rem; }
+.py-8 { padding-block: 2rem; } .py-12 { padding-block: 3rem; }
+.my-8 { margin-block: 2rem; }
+
+/* ===== Prose / Article Content ===== */
+.prose {
+  color: var(--text); max-width: 700px;
+  font-size: 1.1rem; line-height: 1.8;
+}
+.prose :where(p) { margin-block: 1.25em; }
+.prose :where(li) { font-size: 1.1rem; line-height: 1.7; margin-block-end: 0.5em; }
+.prose :where(ul, ol) { padding-inline-start: 1.5em; margin-block: 1em; }
+.prose :where(h1) { font-size: clamp(2rem, 6vw, 3.5rem); margin-block: 1.5rem 1rem; }
+.prose :where(h2) { margin-block: 2.5rem 1rem; }
+.prose :where(h3) { margin-block: 2rem 0.75rem; }
+.prose :where(h4) { margin-block: 1.5rem 0.5rem; }
+.prose :where(a) {
+  color: var(--text); text-decoration-style: dotted; text-underline-offset: 3px;
+}
+.prose :where(a):hover { text-decoration-style: solid; }
+.prose :where(strong) { font-weight: 700; color: var(--text); }
+.prose :where(em) { font-style: italic; }
+.prose :where(blockquote) {
+  border-left: 3px solid var(--border);
+  padding: 0.5rem 1rem; margin-block: 1.5rem;
+  color: var(--text-muted); font-style: italic;
+}
+.prose :where(img) { border-radius: 0.375rem; margin-block: 1.5rem; }
+.prose :where(figure) { margin-block: 1.5rem; }
+.prose :where(figcaption) { font-size: 0.9rem; color: var(--text-muted); margin-top: 0.5rem; text-align: center; }
+/* Scrollable wrapper for wide tables and mermaid diagrams */
+.prose :where(.scroll-wrap) {
+  overflow-x: auto; -webkit-overflow-scrolling: touch;
+  margin-block: 1.5rem;
+}
+.prose :where(table) { width: 100%; border-collapse: collapse; font-size: 0.95rem; }
+.prose :where(th) { text-align: left; font-weight: 700; padding: 0.5rem; border-bottom: 2px solid var(--border); }
+.prose :where(td) { padding: 0.5rem; border-bottom: 1px solid var(--border); }
+.prose :where(code):not(:where(pre *)) {
+  background-color: var(--surface); padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem; font-size: 0.9em; font-weight: 500;
+  font-family: var(--font-mono);
+}
+.prose :where(code)::before, .prose :where(code)::after { content: ''; }
+.prose :where(pre) {
+  background-color: var(--surface); border: 1px solid var(--border);
+  border-radius: 0.375rem; padding: 1rem; max-width: 100%;
+  overflow-x: auto; -webkit-overflow-scrolling: touch;
+  font-family: var(--font-mono); font-size: 0.9rem; line-height: 1.6;
+}
+/* Code block filename tab — rendered via data-title attribute */
+.prose :where(pre[data-title]) { padding-top: 2.25rem; position: relative; }
+.prose :where(pre[data-title])::before {
+  content: attr(data-title);
+  position: absolute; top: 0; left: 0;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.75rem; font-family: var(--font-mono);
+  color: var(--text-muted); background-color: var(--border);
+  border-radius: 0.375rem 0 0.375rem 0;
+  border-bottom: 1px solid var(--border);
+  border-right: 1px solid var(--border);
+}
+.prose :where(pre code) { background: none; padding: 0; border-radius: 0; font-size: inherit; }
+.prose-lg { font-size: 1.15rem; }
+
+/* Shiki dual-theme dark mode swap */
+/* Astro renders --shiki-dark and --shiki-dark-bg as inline CSS custom properties.
+   These rules swap to dark colors when dark mode is active. */
+@media (prefers-color-scheme: dark) {
+  .astro-code,
+  .astro-code span {
+    color: var(--shiki-dark) !important;
+    background-color: var(--shiki-dark-bg) !important;
+  }
+}
+:root.dark .astro-code,
+:root.dark .astro-code span {
+  color: var(--shiki-dark) !important;
+  background-color: var(--shiki-dark-bg) !important;
+}
+
+/* Mermaid Diagrams — dual-theme (light + dark images rendered at build time) */
+.prose :where(.mermaid-themed) { margin-block: 1.5rem; }
+.prose :where(.mermaid-themed) img {
+  display: block; max-width: 100%; height: auto;
+  margin: 0 auto; border-radius: 0.375rem;
+  border: 1px solid var(--border);
+}
+
+/* Default: show light, hide dark */
+.mermaid-dark { display: none !important; }
+.mermaid-light { display: block; }
+
+/* OS dark preference (no manual override): swap */
+@media (prefers-color-scheme: dark) {
+  :root:not(.light) .mermaid-light { display: none !important; }
+  :root:not(.light) .mermaid-dark { display: block !important; }
+}
+
+/* Manual .dark class toggle: swap */
+:root.dark .mermaid-light { display: none !important; }
+:root.dark .mermaid-dark { display: block !important; }
+
+/* Manual .light class toggle: ensure light shows (overrides OS dark) */
+:root.light .mermaid-light { display: block !important; }
+:root.light .mermaid-dark { display: none !important; }
+
+/* "not-prose" escape hatch */
+.not-prose, .not-prose * { font-size: revert; line-height: revert; color: revert; }
+
+/* ===== Callout boxes ===== */
+.callout {
+  background-color: var(--surface); border-left: 4px solid var(--text-muted);
+  padding: 1.25rem 1.5rem; margin-block: 1.5rem; border-radius: 0 0.375rem 0.375rem 0;
+}
+.callout-accent { border-left-color: var(--accent); }
+
+/* ===== Footer ===== */
+.site-footer {
+  margin-block-start: 4rem; padding-block-start: 2rem;
+  border-top: 1px solid var(--border); font-size: 0.85rem;
+  color: var(--text-muted); text-align: center;
+}
+
+/* ===== Focus (WCAG) ===== */
+*:focus { outline: none; }
+*:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 2px; }
+
+/* ===== Skip Link ===== */
+.skip-to-main {
+  position: absolute; left: -9999px; z-index: 999;
+  padding: 0.75rem 1rem; background-color: var(--bg); color: var(--text); text-decoration: none;
+}
+.skip-to-main:focus { left: 50%; top: 1rem; transform: translateX(-50%); }
+
+/* ===== Selection ===== */
+::selection { background-color: color-mix(in srgb, var(--accent) 30%, transparent); color: var(--text); }
+
+/* ===== Responsive ===== */
+@media (max-width: 640px) { body { padding: 1.5rem 1rem; } .prose { font-size: 1rem; } }
+
+/* ===== Reduced Motion ===== */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important; animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important; scroll-behavior: auto !important;
+  }
+}
+
+/* ===== Buttons ===== */
+.btn-filled {
+  display: inline-flex; align-items: center; gap: 0.5rem;
+  padding: 0.5rem 1.25rem; font-size: 0.9rem; font-weight: 700;
+  color: var(--inverse-text); background-color: var(--inverse-bg);
+  border-radius: 0.25rem; border: none; cursor: pointer;
+  text-decoration: none; transition: opacity 150ms ease;
+}
+.btn-filled:hover { opacity: 0.85; text-decoration: none; color: var(--inverse-text); }
+.btn-outlined {
+  display: inline-flex; align-items: center; gap: 0.5rem;
+  padding: 0.5rem 1.25rem; font-size: 0.9rem; font-weight: 700;
+  color: var(--text); background-color: transparent;
+  border: 1px solid var(--border); border-radius: 0.25rem;
+  cursor: pointer; text-decoration: none; transition: all 150ms ease;
+}
+.btn-outlined:hover { border-color: var(--text); text-decoration: none; }


### PR DESCRIPTION
## Summary
- Center all major content elements (prose, header, footer, post cards, post header, breadcrumb) to reading-width column using margin-inline: auto
- Remove pre-Remarque max-w-3xl mx-auto wrappers from Now, Uses pages
- Fix unclosed <em> tag in Resources page
- Remove inline style override on PostLayout h1
- Fix --border to --color-border in PostLayout share section

## Test plan
- [ ] All pages center content within the body column
- [ ] Header and footer align with prose content
- [ ] Post cards center on home page
- [ ] Blog posts center breadcrumb, header, and prose

🤖 Generated with [Claude Code](https://claude.com/claude-code)