### PR TITLE
feat(typography): polish pass v3 + v4

### DIFF
--- a/astro-site/src/styles/global.css
+++ b/astro-site/src/styles/global.css
@@ -822,6 +822,66 @@ div:has(> .post-card) {
   margin-inline: auto;
 }
 
+/* ===== Polish Pass v3: external links, figures, abbr ===== */
+.prose a[href^="http"]:not([href*="williamzujkowski.github.io"])::after {
+  content: "↗";
+  font-family: var(--font-mono);
+  font-size: 0.7em;
+  color: var(--color-muted);
+  margin-left: 0.15em;
+  vertical-align: super;
+  text-decoration: none;
+}
+
+.prose figure { margin-block: var(--space-6); }
+.prose figcaption {
+  font-family: var(--font-mono);
+  font-size: var(--text-meta);
+  letter-spacing: var(--tracking-meta);
+  color: var(--color-muted);
+  text-align: center;
+  margin-top: var(--space-2);
+}
+
+.prose abbr[title] {
+  text-decoration: underline dotted;
+  text-underline-offset: 0.2em;
+  cursor: help;
+}
+
+/* ===== Typography Pass v4: rhythm, numerals, optical alignment ===== */
+
+/* Tabular lining numerals on metadata — kills year-row jitter */
+time, .post-card-meta, .post-card-readtime, .year-heading span,
+.chip, .uses-list dt, .post-breadcrumb {
+  font-variant-numeric: tabular-nums lining-nums;
+  font-feature-settings: "tnum" 1, "lnum" 1;
+}
+
+/* Hanging punctuation on headings */
+h1, h2, h3, .post-card-title, .site-title {
+  hanging-punctuation: first allow-end last;
+}
+
+/* Newsreader at display sizes prefers slight negative tracking */
+.prose h2 { letter-spacing: -0.01em; }
+.prose h2 + p { margin-top: var(--space-2); }
+
+/* Post-card meta as small-caps eyebrow */
+.post-card-meta {
+  font-variant-caps: all-small-caps;
+  letter-spacing: 0.1em;
+  color: var(--color-muted);
+}
+
+/* Chip small-caps treatment */
+.chip { font-variant-caps: all-small-caps; letter-spacing: 0.06em; }
+
+/* Smart-quote character set for <q> elements */
+.prose { quotes: "\201C" "\201D" "\2018" "\2019"; }
+.prose q::before { content: open-quote; }
+.prose q::after { content: close-quote; }
+
 /* ===== Reduced Motion ===== */
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {


### PR DESCRIPTION
## Summary
- Polish Pass v3 (approved via consensus vote 2-0 @ 0.82/0.95 confidence): external link ↗ indicators, figure/figcaption, abbr[title] styling
- Typography Pass v4: tabular lining numerals on metadata, hanging punctuation on headings, negative tracking on Newsreader H2s, small-caps eyebrow on post-card meta + chips, smart-quote <q> set

All CSS-only, no markup changes required. Build passes. Continues the Remarque alignment work from epic #189 / #197.

## Test plan
- [ ] Visual: /posts/ year rows align (tabular nums)
- [ ] Visual: external links in blog prose show ↗
- [ ] Visual: chips + post-card meta render as small-caps eyebrows
- [ ] No regressions on /about/, /uses/, /now/, /projects/

🤖 Generated with [Claude Code](https://claude.com/claude-code)