### PR TITLE
feat(typography): chip sup, archive eyebrow

### DIFF
--- a/astro-site/src/pages/posts/index.astro
+++ b/astro-site/src/pages/posts/index.astro
@@ -38,16 +38,17 @@ const years = [...postsByYear.keys()].sort((a, b) => b - a);
 
   <div class="chip-row" style="margin-block-end: var(--space-6);">
     {topTags.map(([tag, count]) => (
-      <a href={`/tags/${tag}/`} class="chip">{tag} ({count})</a>
+      <a href={`/tags/${tag}/`} class="chip">{tag}<sup>{count}</sup></a>
     ))}
     <a href="/tags/" class="chip">all tags</a>
   </div>
 
-  {years.map((year) => (
+  {years.map((year, idx) => (
     <section>
+      {idx === 0 && <p class="section-eyebrow">Archive</p>}
       <h2 class="year-heading">
         {year}
-        <span>({postsByYear.get(year)!.length})</span>
+        <span>{postsByYear.get(year)!.length}</span>
       </h2>
       {postsByYear.get(year)!.map((post) => (
         <PostCard post={post} showTags={true} />

--- a/astro-site/src/pages/tags/index.astro
+++ b/astro-site/src/pages/tags/index.astro
@@ -28,7 +28,7 @@ const sortedTags = [...tagCounts.entries()].sort((a, b) => b[1] - a[1]);
     {
       sortedTags.map(([tag, count]) => (
         <a href={`/tags/${tag}/`} class="chip">
-          {tag} ({count})
+          {tag}<sup>{count}</sup>
         </a>
       ))
     }

--- a/astro-site/src/styles/global.css
+++ b/astro-site/src/styles/global.css
@@ -876,6 +876,15 @@ h1, h2, h3, .post-card-title, .site-title {
 
 /* Chip small-caps treatment */
 .chip { font-variant-caps: all-small-caps; letter-spacing: 0.06em; }
+.chip sup {
+  font-family: var(--font-mono);
+  font-size: 0.7em;
+  margin-left: 0.3em;
+  color: var(--color-muted);
+  font-variant-numeric: tabular-nums lining-nums;
+  top: -0.25em;
+  position: relative;
+}
 
 /* Smart-quote character set for <q> elements */
 .prose { quotes: "\201C" "\201D" "\2018" "\2019"; }


### PR DESCRIPTION
Chips render tag superscript-count; /posts/ gets Archive eyebrow. CSS + markup only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)