### PR TITLE
fix(a11y): WCAG 1.4.11 contrast for interactive borders + AAA fg-muted + audit script

### DIFF
--- a/astro-site/package.json
+++ b/astro-site/package.json
@@ -16,7 +16,8 @@
     "format": "prettier --write 'src/**/*.{astro,svelte,ts,js,css}'",
     "format:check": "prettier --check 'src/**/*.{astro,svelte,ts,js,css}'",
     "test:e2e": "npx playwright test",
-    "test:e2e:headed": "npx playwright test --headed"
+    "test:e2e:headed": "npx playwright test --headed",
+    "audit:contrast": "node scripts/contrast-audit.mjs"
   },
   "dependencies": {
     "@astrojs/rss": "^4.0.17",

--- a/astro-site/scripts/contrast-audit.mjs
+++ b/astro-site/scripts/contrast-audit.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+/**
+ * WCAG contrast audit for Remarque tokens.
+ * Parses global.css, extracts OKLCH values, reports AA/AAA pass/fail.
+ * Exit 1 if any required pair fails.
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const css = readFileSync(resolve(here, '../src/styles/global.css'), 'utf8');
+
+function oklchToRgb(L, C, h) {
+  const r = (h * Math.PI) / 180;
+  const a = C * Math.cos(r);
+  const b = C * Math.sin(r);
+  const l_ = L + 0.3963377774 * a + 0.2158037573 * b;
+  const m_ = L - 0.1055613458 * a - 0.0638541728 * b;
+  const s_ = L - 0.0894841775 * a - 1.291485548 * b;
+  const l = l_ ** 3, m = m_ ** 3, s = s_ ** 3;
+  return [
+    4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s,
+    -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s,
+    -0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s,
+  ];
+}
+const lum = (rgb) => {
+  const c = (v) => Math.max(0, Math.min(1, v));
+  const [r, g, b] = rgb.map(c);
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+};
+const contrast = (a, b) => {
+  const [hi, lo] = [a, b].sort((x, y) => y - x);
+  return (hi + 0.05) / (lo + 0.05);
+};
+
+// Parse OKLCH values from CSS (first occurrence per selector block)
+function parseTheme(blockRegex) {
+  const match = css.match(blockRegex);
+  if (!match) throw new Error(`Theme block not found: ${blockRegex}`);
+  const block = match[0];
+  const out = {};
+  for (const m of block.matchAll(/--color-([\w-]+):\s*oklch\(([\d.]+)\s+([\d.]+)\s+([\d.]+)\)/g)) {
+    out[m[1]] = [parseFloat(m[2]), parseFloat(m[3]), parseFloat(m[4])];
+  }
+  return out;
+}
+
+const light = parseTheme(/:root\s*\{[^}]+\}/);
+const dark = parseTheme(/:root\.dark\s*\{[^}]+\}/);
+
+// Required pairs — [theme, fg, bg, minContrast, label]
+const required = [
+  ['light', 'fg', 'bg', 4.5, 'body text'],
+  ['light', 'fg-muted', 'bg', 7.0, 'fg-muted (AAA body-adjacent)'],
+  ['light', 'muted', 'bg', 4.5, 'muted text'],
+  ['light', 'border-bold', 'bg', 3.0, 'interactive border (WCAG 1.4.11)'],
+  ['light', 'accent', 'bg', 4.5, 'accent text'],
+  ['dark', 'fg', 'bg', 4.5, 'body text'],
+  ['dark', 'fg-muted', 'bg', 7.0, 'fg-muted (AAA body-adjacent)'],
+  ['dark', 'muted', 'bg', 4.5, 'muted text'],
+  ['dark', 'border-bold', 'bg', 3.0, 'interactive border (WCAG 1.4.11)'],
+  ['dark', 'accent', 'bg', 4.5, 'accent text'],
+];
+
+let failed = 0;
+console.log('Remarque Contrast Audit\n');
+for (const [theme, fg, bg, min, label] of required) {
+  const src = theme === 'light' ? light : dark;
+  const c = contrast(lum(oklchToRgb(...src[bg])), lum(oklchToRgb(...src[fg])));
+  const pass = c >= min;
+  const status = pass ? 'PASS' : 'FAIL';
+  if (!pass) failed++;
+  console.log(
+    `  [${status}] ${theme.padEnd(5)} ${fg.padEnd(12)} vs ${bg.padEnd(4)} ${c.toFixed(2)}:1 (min ${min}:1) — ${label}`,
+  );
+}
+
+if (failed > 0) {
+  console.error(`\n${failed} contrast check(s) failed.`);
+  process.exit(1);
+}
+console.log('\nAll contrast requirements met.');

--- a/astro-site/src/styles/global.css
+++ b/astro-site/src/styles/global.css
@@ -75,10 +75,10 @@
   --color-bg: oklch(0.975 0.005 80);
   --color-bg-subtle: oklch(0.955 0.005 80);
   --color-fg: oklch(0.18 0.01 80);
-  --color-fg-muted: oklch(0.45 0.015 80);
-  --color-muted: oklch(0.55 0.01 80);
-  --color-border: oklch(0.88 0.005 80);
-  --color-border-bold: oklch(0.78 0.01 80);
+  --color-fg-muted: oklch(0.43 0.015 80);  /* 7.55:1 AAA on --color-bg */
+  --color-muted: oklch(0.55 0.01 80);       /* 4.52:1 AA on --color-bg */
+  --color-border: oklch(0.88 0.005 80);     /* Decorative only — use --color-border-bold for interactive states */
+  --color-border-bold: oklch(0.62 0.01 80); /* 3.39:1 WCAG 1.4.11 non-text */
   --color-surface: oklch(0.965 0.005 80);
   --color-accent: oklch(0.50 0.14 250);
   --color-accent-hover: oklch(0.42 0.14 250);
@@ -96,8 +96,8 @@
   --color-fg: oklch(0.90 0.005 80);
   --color-fg-muted: oklch(0.70 0.01 80);
   --color-muted: oklch(0.58 0.01 80);
-  --color-border: oklch(0.25 0.005 80);
-  --color-border-bold: oklch(0.35 0.01 80);
+  --color-border: oklch(0.25 0.005 80);     /* Decorative only */
+  --color-border-bold: oklch(0.50 0.01 80); /* 3.23:1 WCAG 1.4.11 non-text */
   --color-surface: oklch(0.19 0.01 80);
   --color-accent: oklch(0.68 0.12 250);
   --color-accent-hover: oklch(0.75 0.12 250);
@@ -115,8 +115,8 @@
     --color-fg: oklch(0.90 0.005 80);
     --color-fg-muted: oklch(0.70 0.01 80);
     --color-muted: oklch(0.58 0.01 80);
-    --color-border: oklch(0.25 0.005 80);
-    --color-border-bold: oklch(0.35 0.01 80);
+    --color-border: oklch(0.25 0.005 80);     /* Decorative only */
+    --color-border-bold: oklch(0.50 0.01 80); /* 3.23:1 WCAG 1.4.11 non-text */
     --color-surface: oklch(0.19 0.01 80);
     --color-accent: oklch(0.68 0.12 250);
     --color-accent-hover: oklch(0.75 0.12 250);


### PR DESCRIPTION
## Summary
Found by building a contrast audit script for the Remarque tokens — then running it.

**Failures caught:**
- \`--color-border-bold\` light: 1.34:1 → **FAIL** WCAG 1.4.11 (3:1 for non-text UI)
- \`--color-border-bold\` dark: 1.21:1 → **FAIL**
- \`--color-fg-muted\` light: 6.93:1 → 0.07 shy of AAA 7:1 (my new Remarque checklist says ≥7:1)

**Fixes:**
- \`--color-border-bold\` light: L 0.78 → 0.62 (3.39:1 PASS)
- \`--color-border-bold\` dark: L 0.35 → 0.50 (3.23:1 PASS)
- \`--color-fg-muted\` light: L 0.45 → 0.43 (7.55:1 AAA)
- \`--color-border\` (the quiet 1px decorative divider) left unchanged + commented as decorative-only

**Tooling:**
- \`scripts/contrast-audit.mjs\` parses OKLCH tokens from global.css and validates against WCAG
- \`pnpm audit:contrast\` → exit 1 on any fail — wire into CI later

## Test plan
- [ ] \`pnpm audit:contrast\` → All 10 checks PASS
- [ ] Chips, ThemeToggle hover borders are still visible but quiet
- [ ] Links/meta text visibly unchanged (only ~0.02 OKLCH delta on fg-muted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)