### PR TITLE
fix(a11y,typography): H1 display clamp, nav 44×44 touch targets

### DIFF
--- a/astro-site/src/pages/about.astro
+++ b/astro-site/src/pages/about.astro
@@ -36,14 +36,27 @@ import { SITE_CONFIG } from '@/lib/siteConfig';
     <h2>Career</h2>
 
     <dl class="uses-list">
-      <dt>Cloud.gov <span class="uses-detail">2023 – present</span></dt>
-      <dd>Cloud security architecture and federal compliance for a FedRAMP Moderate platform. NIST 800-53 Rev 4 → Rev 5 transition.</dd>
-
-      <dt>NIH <span class="uses-detail">2014 – 2023</span></dt>
-      <dd>HPC site reliability → enterprise vulnerability management across 100,000+ assets and 27 Institutes → security engineering for research infrastructure. Led the Log4j response. Got to burn in 8-way H100 nodes.</dd>
-
-      <dt>Independent consultant <span class="uses-detail">2005 – 2014</span></dt>
-      <dd>House calls to infrastructure management. A decade of learning how things break in the real world.</dd>
+      <div class="uses-row">
+        <dt>
+          <span class="uses-name">Cloud.gov</span>
+          <span class="uses-meta">2023 – present</span>
+        </dt>
+        <dd>Cloud security architecture and federal compliance for a FedRAMP Moderate platform. NIST 800-53 Rev 4 → Rev 5 transition.</dd>
+      </div>
+      <div class="uses-row">
+        <dt>
+          <span class="uses-name">NIH</span>
+          <span class="uses-meta">2014 – 2023</span>
+        </dt>
+        <dd>HPC site reliability → enterprise vulnerability management across 100,000+ assets and 27 Institutes → security engineering for research infrastructure. Led the Log4j response. Got to burn in 8-way H100 nodes.</dd>
+      </div>
+      <div class="uses-row">
+        <dt>
+          <span class="uses-name">Independent consultant</span>
+          <span class="uses-meta">2005 – 2014</span>
+        </dt>
+        <dd>House calls to infrastructure management. A decade of learning how things break in the real world.</dd>
+      </div>
     </dl>
 
     <h2>How I think about security</h2>
@@ -103,12 +116,5 @@ import { SITE_CONFIG } from '@/lib/siteConfig';
     letter-spacing: var(--tracking-meta);
     color: var(--color-muted);
     margin-block-end: var(--space-7);
-  }
-  .uses-detail {
-    font-family: var(--font-mono);
-    font-size: 0.85em;
-    color: var(--color-muted);
-    font-weight: 400;
-    margin-left: 0.5em;
   }
 </style>

--- a/astro-site/src/styles/global.css
+++ b/astro-site/src/styles/global.css
@@ -21,7 +21,7 @@
   --font-mono: 'JetBrains Mono Variable', 'JetBrains Mono', 'Fira Code', monospace;
 
   /* Type scale */
-  --text-display: clamp(2.75rem, 5.5vw, 5rem);
+  --text-display: clamp(2.25rem, 3.5vw, 3.5rem); /* 36-56px — editorial restraint */
   --text-title: clamp(1.875rem, 3.5vw, 3rem);
   --text-section: clamp(1.375rem, 2.25vw, 2rem);
   --text-body-lg: 1.1875rem;
@@ -250,8 +250,10 @@ a:hover { color: var(--color-accent-hover); }
   color: var(--color-fg-muted);
   transition: color var(--motion-fast) var(--motion-easing);
   min-height: 44px;
+  min-width: 44px; /* WCAG 2.5.5 — 44×44 touch target */
   display: inline-flex;
   align-items: center;
+  justify-content: center;
 }
 .site-nav a:hover, .site-nav a[aria-current="page"] { color: var(--color-fg); }
 


### PR DESCRIPTION
## Live chrome review findings

**H1 was 80px** — too loud. Tightened `--text-display` clamp from `2.75rem → 5rem` to `2.25rem → 3.5rem` (36–56px).

**Nav links failed WCAG 2.5.5** (44×44). Width was 31–41px (Home/About/Blog/Uses/Now). Added `min-width: 44px` + `justify-content: center`.

All three Remarque audits (contrast / typography / colors) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)