### PR TITLE
fix(search): trigger uses Remarque tokens (Tailwind classes are dead)

### DIFF
--- a/astro-site/src/components/Search.svelte
+++ b/astro-site/src/components/Search.svelte
@@ -131,17 +131,13 @@
 <button
   type="button"
   onclick={open}
-  class="min-w-[44px] min-h-[44px] flex items-center justify-center rounded-lg text-[var(--color-muted)] hover:bg-[var(--color-surface)] transition-colors"
+  class="search-trigger"
   aria-label="Search site"
 >
-  <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+  <svg class="search-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
     <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
   </svg>
-  <kbd
-    class="hidden lg:inline-block ml-1.5 text-[10px] px-1.5 py-0.5 rounded border font-sans"
-    style="color: var(--color-muted); border-color: var(--color-border); opacity: 0.7"
-    >&sol;K</kbd
-  >
+  <kbd class="search-kbd">&sol;K</kbd>
 </button>
 
 <!-- Search dialog -->
@@ -233,6 +229,44 @@
 {/if}
 
 <style>
+  /* Search trigger — Remarque tokens, no Tailwind (which isn't installed) */
+  .search-trigger {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.375rem;
+    min-width: 44px;
+    min-height: 44px;
+    padding: 0 0.5rem;
+    background: transparent;
+    border: none;
+    border-radius: var(--radius-md, 0.5rem);
+    color: var(--color-muted);
+    cursor: pointer;
+    transition: color var(--motion-fast, 180ms) var(--motion-easing, ease);
+  }
+  .search-trigger:hover {
+    color: var(--color-fg);
+    background: var(--color-surface);
+  }
+  .search-icon {
+    width: 1.25rem;
+    height: 1.25rem;
+  }
+  .search-kbd {
+    display: none;
+    font-family: var(--font-mono);
+    font-size: var(--text-micro);
+    padding: 0.125rem 0.375rem;
+    border: 1px solid var(--color-border);
+    border-radius: 0.25rem;
+    color: var(--color-muted);
+    line-height: 1;
+  }
+  @media (min-width: 1024px) {
+    .search-kbd { display: inline-block; }
+  }
+
   /* Style Pagefind highlight marks */
   :global(mark) {
     background-color: var(--color-surface);

--- a/astro-site/src/layouts/PostLayout.astro
+++ b/astro-site/src/layouts/PostLayout.astro
@@ -90,8 +90,8 @@ const formattedDate = date.toLocaleDateString('en-US', {
 
     <!-- Share -->
     <footer style="margin-top: var(--space-7); padding-top: var(--space-5); border-top: 1px solid var(--color-border);">
-      <div class="flex flex-wrap items-center gap-4">
-        <span class="font-mono" style="font-size: var(--text-meta); color: var(--color-muted);">Share:</span>
+      <div class="share-row">
+        <span class="share-label">Share:</span>
             <a
               href={`https://www.linkedin.com/shareArticle?mini=true&url=${encodeURIComponent(`${siteUrl}${Astro.url.pathname}`)}&title=${encodeURIComponent(title)}`}
               class="chip"

--- a/astro-site/src/styles/global.css
+++ b/astro-site/src/styles/global.css
@@ -824,6 +824,20 @@ div:has(> .post-card) {
   margin-inline: auto;
 }
 
+/* ===== PostLayout share row ===== */
+.share-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-4);
+}
+.share-label {
+  font-family: var(--font-mono);
+  font-size: var(--text-meta);
+  letter-spacing: var(--tracking-meta);
+  color: var(--color-muted);
+}
+
 /* ===== Polish Pass v3: external links, figures, abbr ===== */
 .prose a[href^="http"]:not([href*="williamzujkowski.github.io"])::after {
   content: "↗";


### PR DESCRIPTION
## Live chrome review finding

Search trigger button rendering at **23×44px** (fail WCAG 2.5.5) with **white text in dark mode** because `Search.svelte` uses Tailwind arbitrary-value classes (`min-w-[44px]`, `text-[var(--color-muted)]`, etc.) but **Tailwind is not installed in astro-site**. Those classes never compile.

## Fix
Replace the trigger button + /K kbd hint with scoped CSS in the component's `<style>` block using Remarque tokens.

## Followup
The search dialog itself is full of dead Tailwind classes (`flex`, `max-w-lg`, `p-4`, etc.) but renders acceptably thanks to many inline `style=""` overrides carrying it. Separate PR should migrate those.

All three Remarque audits pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)