### PR TITLE
chore(ci): remarque audits always run

### DIFF
--- a/.github/workflows/audits.yml
+++ b/.github/workflows/audits.yml
@@ -3,15 +3,8 @@ name: Remarque Audits
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'astro-site/src/**'
-      - 'astro-site/scripts/contrast-audit.mjs'
-      - 'astro-site/scripts/typography-audit.mjs'
-      - 'astro-site/package.json'
   push:
     branches: [main]
-    paths:
-      - 'astro-site/src/styles/**'
 
 jobs:
   remarque:


### PR DESCRIPTION
Path filter meant workflow-only PRs (like #208) couldn't satisfy the required check. Audits run in <1s with no deps — no reason to filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)