### PR TITLE
feat(a11y): APCA (WCAG 3 draft) audit + dark-mode tuning

### DIFF
--- a/.github/workflows/audits.yml
+++ b/.github/workflows/audits.yml
@@ -20,3 +20,6 @@ jobs:
         run: node astro-site/scripts/typography-audit.mjs
       - name: Color-token audit (no hardcoded hex/rgb/oklch outside tokens)
         run: node astro-site/scripts/color-token-audit.mjs
+      - name: APCA advisory (WCAG 3 draft — informational only)
+        run: node astro-site/scripts/apca-audit.mjs
+        continue-on-error: true

--- a/astro-site/package.json
+++ b/astro-site/package.json
@@ -20,7 +20,8 @@
     "audit:contrast": "node scripts/contrast-audit.mjs",
     "audit:typography": "node scripts/typography-audit.mjs",
     "audit:colors": "node scripts/color-token-audit.mjs",
-    "audit": "pnpm audit:contrast && pnpm audit:typography && pnpm audit:colors",
+    "audit:apca": "node scripts/apca-audit.mjs",
+    "audit": "pnpm audit:contrast && pnpm audit:typography && pnpm audit:colors && pnpm audit:apca",
     "test:a11y": "playwright test tests/e2e/a11y.spec.ts"
   },
   "dependencies": {
@@ -44,6 +45,8 @@
     "@types/markdown-it": "^14.1.2",
     "@types/sanitize-html": "^2.16.1",
     "@typescript-eslint/parser": "^8.57.0",
+    "apca-w3": "^0.1.9",
+    "colorparsley": "^0.1.8",
     "eslint": "^10.0.3",
     "eslint-plugin-astro": "^1.6.0",
     "pagefind": "^1.4.0",

--- a/astro-site/pnpm-lock.yaml
+++ b/astro-site/pnpm-lock.yaml
@@ -63,6 +63,12 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^8.57.0
         version: 8.58.1(eslint@10.2.0)(typescript@5.9.3)
+      apca-w3:
+        specifier: ^0.1.9
+        version: 0.1.9
+      colorparsley:
+        specifier: ^0.1.8
+        version: 0.1.8
       eslint:
         specifier: ^10.0.3
         version: 10.2.0
@@ -1120,6 +1126,9 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  apca-w3@0.1.9:
+    resolution: {integrity: sha512-Zrf6AeBeQjNe/fxK7U1jCo5zfdjDl6T4/kdw5Xlky3G7u+EJTZkyItjMYQGtwf9pkftsINxcYyOpuLkzKf1ITQ==}
+
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
@@ -1225,6 +1234,9 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  colorparsley@0.1.8:
+    resolution: {integrity: sha512-rObESTTTE6G5qO5WFwFxWPggpw4KfpxnLC6Ssl8bITBnNVRhDsyCeTRAUxWQNVTx2pRknKlO2nddYTxjkdNFaw==}
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
@@ -3881,6 +3893,10 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.2
 
+  apca-w3@0.1.9:
+    dependencies:
+      colorparsley: 0.1.8
+
   arg@5.0.2: {}
 
   argparse@2.0.1: {}
@@ -4068,6 +4084,8 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  colorparsley@0.1.8: {}
 
   comma-separated-tokens@2.0.3: {}
 

--- a/astro-site/scripts/apca-audit.mjs
+++ b/astro-site/scripts/apca-audit.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+/**
+ * APCA (WCAG 3 draft) contrast audit — ADVISORY ONLY.
+ *
+ * APCA is perceptually more accurate than WCAG 2's relative-luminance math,
+ * but WCAG 3 is still a W3C Working Draft. Thresholds may shift. This
+ * script is informational — it exits 0 regardless of pass/fail so a
+ * draft-stage regression never blocks a release.
+ *
+ * When WCAG 3 becomes Recommendation, flip the exit code at the bottom.
+ *
+ * APCA Lc (Lightness contrast) thresholds for the Bronze/Silver conformance
+ * targets in the current WCAG 3 draft (approximate):
+ *   Lc 90+  Exemplary — any text
+ *   Lc 75+  Body copy and small fluent text (equivalent guidance to WCAG 2 AA body)
+ *   Lc 60+  Large text, non-critical content
+ *   Lc 45+  Large bold / hero / headlines / interactive controls
+ *   Lc 30+  Non-text contrast (UI controls, borders, icons)
+ *   Lc <15  Invisible — fails by any standard
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { APCAcontrast, sRGBtoY } from 'apca-w3';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const css = readFileSync(resolve(here, '../src/styles/global.css'), 'utf8');
+
+// OKLCH → linear sRGB → sRGB 0-255 (same conversion as contrast-audit.mjs)
+function oklchToSrgb255(L, C, h) {
+  const r = (h * Math.PI) / 180;
+  const a = C * Math.cos(r);
+  const b = C * Math.sin(r);
+  const l_ = L + 0.3963377774 * a + 0.2158037573 * b;
+  const m_ = L - 0.1055613458 * a - 0.0638541728 * b;
+  const s_ = L - 0.0894841775 * a - 1.291485548 * b;
+  const lCube = l_ ** 3;
+  const mCube = m_ ** 3;
+  const sCube = s_ ** 3;
+  const lin = [
+    4.0767416621 * lCube - 3.3077115913 * mCube + 0.2309699292 * sCube,
+    -1.2684380046 * lCube + 2.6097574011 * mCube - 0.3413193965 * sCube,
+    -0.0041960863 * lCube - 0.7034186147 * mCube + 1.707614701 * sCube,
+  ];
+  // Linear → sRGB (gamma encode), clip, scale to 0-255
+  return lin.map((v) => {
+    const clipped = Math.max(0, Math.min(1, v));
+    const gamma = clipped <= 0.0031308 ? 12.92 * clipped : 1.055 * clipped ** (1 / 2.4) - 0.055;
+    return Math.round(Math.max(0, Math.min(1, gamma)) * 255);
+  });
+}
+
+function parseTheme(blockRegex) {
+  const m = css.match(blockRegex);
+  if (!m) throw new Error(`Theme block not found: ${blockRegex}`);
+  const out = {};
+  for (const entry of m[0].matchAll(
+    /--color-([\w-]+):\s*oklch\(([\d.]+)\s+([\d.]+)\s+([\d.]+)\)/g,
+  )) {
+    out[entry[1]] = [parseFloat(entry[2]), parseFloat(entry[3]), parseFloat(entry[4])];
+  }
+  return out;
+}
+
+const light = parseTheme(/:root\s*\{[^}]+\}/);
+const dark = parseTheme(/:root\.dark\s*\{[^}]+\}/);
+
+// text on bg (polarity matters for APCA — text is first, bg is second)
+const pairs = [
+  ['light', 'fg', 'bg', 75, 'body copy'],
+  ['light', 'fg-muted', 'bg', 75, 'body-adjacent (fg-muted)'],
+  ['light', 'muted', 'bg', 60, 'metadata text'],
+  ['light', 'border-bold', 'bg', 30, 'interactive border (non-text)'],
+  ['light', 'accent', 'bg', 60, 'accent links'],
+  ['dark', 'fg', 'bg', 75, 'body copy'],
+  ['dark', 'fg-muted', 'bg', 75, 'body-adjacent (fg-muted)'],
+  ['dark', 'muted', 'bg', 60, 'metadata text'],
+  ['dark', 'border-bold', 'bg', 30, 'interactive border (non-text)'],
+  ['dark', 'accent', 'bg', 60, 'accent links'],
+];
+
+function apcaLc(theme, textKey, bgKey) {
+  const src = theme === 'light' ? light : dark;
+  const textRgb = oklchToSrgb255(...src[textKey]);
+  const bgRgb = oklchToSrgb255(...src[bgKey]);
+  const textY = sRGBtoY(textRgb);
+  const bgY = sRGBtoY(bgRgb);
+  return APCAcontrast(textY, bgY);
+}
+
+console.log('APCA (WCAG 3 draft) — ADVISORY contrast report\n');
+let warnings = 0;
+for (const [theme, text, bg, target, label] of pairs) {
+  const Lc = apcaLc(theme, text, bg);
+  const abs = Math.abs(Lc);
+  const status = abs >= target ? 'OK    ' : 'REVIEW';
+  if (abs < target) warnings++;
+  const lcStr = Lc.toFixed(1).padStart(6);
+  console.log(
+    `  [${status}] ${theme.padEnd(5)} ${text.padEnd(12)} vs ${bg.padEnd(4)} Lc ${lcStr} (target ≥${target}) — ${label}`,
+  );
+}
+
+if (warnings > 0) {
+  console.log(`\n${warnings} pair(s) below APCA target. Advisory only — not blocking.`);
+} else {
+  console.log('\nAll pairs meet APCA draft targets.');
+}
+// Always exit 0 — advisory until WCAG 3 becomes Recommendation.
+process.exit(0);

--- a/astro-site/src/styles/global.css
+++ b/astro-site/src/styles/global.css
@@ -94,13 +94,13 @@
   --color-bg: oklch(0.16 0.01 80);
   --color-bg-subtle: oklch(0.19 0.01 80);
   --color-fg: oklch(0.90 0.005 80);
-  --color-fg-muted: oklch(0.70 0.01 80);
-  --color-muted: oklch(0.58 0.01 80);
+  --color-fg-muted: oklch(0.85 0.01 80);    /* APCA Lc 76 (draft-AA body), WCAG 12.28:1 AAA */
+  --color-muted: oklch(0.78 0.01 80);       /* APCA Lc 63 (draft-AA large), WCAG 9.70:1 AAA */
   --color-border: oklch(0.25 0.005 80);     /* Decorative only */
-  --color-border-bold: oklch(0.50 0.01 80); /* 3.23:1 WCAG 1.4.11 non-text */
+  --color-border-bold: oklch(0.60 0.01 80); /* APCA Lc 35 (draft non-text), WCAG 4.92:1 */
   --color-surface: oklch(0.19 0.01 80);
-  --color-accent: oklch(0.68 0.12 250);
-  --color-accent-hover: oklch(0.75 0.12 250);
+  --color-accent: oklch(0.78 0.12 250);     /* APCA Lc 64 (draft-AA), WCAG 9.73:1 AAA */
+  --color-accent-hover: oklch(0.85 0.12 250);
   --color-code-bg: oklch(0.20 0.005 80);
   --color-code-fg: oklch(0.88 0.005 80);
   --color-selection-bg: oklch(0.30 0.06 250);
@@ -113,13 +113,13 @@
     --color-bg: oklch(0.16 0.01 80);
     --color-bg-subtle: oklch(0.19 0.01 80);
     --color-fg: oklch(0.90 0.005 80);
-    --color-fg-muted: oklch(0.70 0.01 80);
-    --color-muted: oklch(0.58 0.01 80);
+    --color-fg-muted: oklch(0.85 0.01 80);    /* APCA Lc 76, WCAG 12.28:1 AAA */
+    --color-muted: oklch(0.78 0.01 80);       /* APCA Lc 63, WCAG 9.70:1 AAA */
     --color-border: oklch(0.25 0.005 80);     /* Decorative only */
-    --color-border-bold: oklch(0.50 0.01 80); /* 3.23:1 WCAG 1.4.11 non-text */
+    --color-border-bold: oklch(0.60 0.01 80); /* APCA Lc 35, WCAG 4.92:1 */
     --color-surface: oklch(0.19 0.01 80);
-    --color-accent: oklch(0.68 0.12 250);
-    --color-accent-hover: oklch(0.75 0.12 250);
+    --color-accent: oklch(0.78 0.12 250);     /* APCA Lc 64, WCAG 9.73:1 AAA */
+    --color-accent-hover: oklch(0.85 0.12 250);
     --color-code-bg: oklch(0.20 0.005 80);
     --color-code-fg: oklch(0.88 0.005 80);
     --color-selection-bg: oklch(0.30 0.06 250);


### PR DESCRIPTION
## What
- New `scripts/apca-audit.mjs` — advisory (non-blocking) APCA contrast check against token pairs
- Wired into CI as fourth audit step with `continue-on-error: true` (WCAG 3 is still a draft — don't gate on it)
- Tuned 5 dark-mode tokens to meet both WCAG 2 AA and APCA draft targets

## Why tune now
APCA is perceptually more accurate than WCAG 2's luminance math. WCAG 2 overestimates contrast for light text on dark backgrounds. Initial APCA run showed 4 dark-mode pairs under-target despite passing WCAG 2 AA at 4.5–7:1.

## New dark-mode values
| Token | Old → New (L) | APCA | WCAG 2 |
|---|---|---|---|
| `fg-muted` | 0.70 → 0.85 | Lc 76 ✅ | 12.28:1 AAA |
| `muted` | 0.58 → 0.78 | Lc 63 ✅ | 9.70:1 AAA |
| `border-bold` | 0.50 → 0.60 | Lc 35 ✅ | 4.92:1 ✅ |
| `accent` | 0.68 → 0.78 | Lc 64 ✅ | 9.73:1 AAA |
| `accent-hover` | 0.75 → 0.85 | (pair) | — |

## Trade-off
Dark mode becomes brighter. For a "warm charcoal" aesthetic this is a slightly bolder look — still muted relative to pure white, but no longer dim.

## Followup
If this validates well on the live site, mirror into remarque#26 so semantic-color tokens also get APCA coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)