### PR TITLE
feat(broadsheet): extend to /posts/, /tags/, PostLayout

### DIFF
--- a/astro-site/src/components/BroadsheetEntry.astro
+++ b/astro-site/src/components/BroadsheetEntry.astro
@@ -1,0 +1,66 @@
+---
+import { getReadingTime } from '@/lib/utils';
+
+interface Props {
+  post: {
+    id: string;
+    body?: string | null;
+    data: {
+      title: string;
+      date: Date;
+      description?: string;
+      tags?: string[];
+    };
+  };
+  number?: number | string;
+  variant?: 'lead' | 'entry';
+}
+
+const { post, number, variant = 'entry' } = Astro.props;
+
+const humanTag = (t: string) =>
+  t.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+
+const tag = (post.data.tags ?? []).find((t) => t !== 'posts') ?? 'Essay';
+const section = humanTag(tag);
+const rt = getReadingTime(post.body ?? '');
+const iso = post.data.date.toISOString().split('T')[0];
+const dateStr = post.data.date.toLocaleDateString('en-US', {
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric',
+});
+---
+
+{variant === 'lead' ? (
+  <article class="lead">
+    <p class="lead-kicker">
+      <span class="lead-section">{section}</span>
+      <span class="dot">·</span>
+      <span>{rt} min read</span>
+      <span class="dot">·</span>
+      <time datetime={iso}>{dateStr}</time>
+    </p>
+    <h2 class="lead-title">
+      <a href={`/posts/${post.id}/`}>{post.data.title}</a>
+    </h2>
+    {post.data.description && <p class="lead-lede">{post.data.description}</p>}
+  </article>
+) : (
+  <li class="entry" data-entry-number={number}>
+    <div class="entry-meta">
+      <p class="entry-kicker">
+        <span class="entry-section">{section}</span>
+        <span class="dot">·</span>
+        <span>{rt} min</span>
+      </p>
+      <time class="entry-date" datetime={iso}>{dateStr}</time>
+    </div>
+    <div class="entry-body">
+      <h3 class="entry-title">
+        <a href={`/posts/${post.id}/`}>{post.data.title}</a>
+      </h3>
+      {post.data.description && <p class="entry-excerpt">{post.data.description}</p>}
+    </div>
+  </li>
+)}

--- a/astro-site/src/layouts/PostLayout.astro
+++ b/astro-site/src/layouts/PostLayout.astro
@@ -34,6 +34,11 @@ const formattedDate = date.toLocaleDateString('en-US', {
   month: 'long',
   day: 'numeric',
 });
+
+const humanTag = (t: string) =>
+  t.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+const primaryTag = tags.find((t) => t !== 'posts');
+const section = primaryTag ? humanTag(primaryTag) : 'Essay';
 ---
 
 <BaseLayout
@@ -53,10 +58,17 @@ const formattedDate = date.toLocaleDateString('en-US', {
 
     <!-- Header -->
     <header class="post-header">
-      <div class="post-meta">
+      <p class="post-kicker">
+        <span class="post-section">{section}</span>
+        {readingTime && (
+          <>
+            <span class="dot">·</span>
+            <span>{readingTime} min read</span>
+          </>
+        )}
+        <span class="dot">·</span>
         <time datetime={date.toISOString().split('T')[0]}>{formattedDate}</time>
-        {readingTime && <> &middot; {readingTime} min read</>}
-      </div>
+      </p>
 
       <h1>{title}</h1>
 

--- a/astro-site/src/pages/index.astro
+++ b/astro-site/src/pages/index.astro
@@ -1,41 +1,26 @@
 ---
 import BaseLayout from '@layouts/BaseLayout.astro';
 import { getCollection } from 'astro:content';
-import { getReadingTime } from '@/lib/utils';
+import BroadsheetEntry from '@components/BroadsheetEntry.astro';
 
 const allPosts = await getCollection('posts', ({ data }) => !data.draft);
 const posts = allPosts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
 const [lead, ...tail] = posts.slice(0, 6);
 const hasMore = posts.length > 6;
 
-const humanTag = (t: string) =>
-  t.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
-
 const formatDate = (d: Date) =>
   d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
-
-const kicker = (post: (typeof posts)[number]) => {
-  const tag = (post.data.tags ?? []).find((t) => t !== 'posts') ?? 'Essay';
-  const rt = getReadingTime(post.body ?? '');
-  return { section: humanTag(tag), rt, date: formatDate(post.data.date) };
-};
-
-const leadK = kicker(lead);
 const latestISO = posts[0].data.date.toISOString().split('T')[0];
 ---
 
 <BaseLayout title="William Zujkowski" description="Security engineer, builder, homelab enthusiast. Field notes on security, AI, and building things.">
   <header class="broadsheet-masthead">
     <p class="masthead-kicker">
-      <span>Essays</span>
-      <span class="dot">·</span>
-      <span>Notes</span>
-      <span class="dot">·</span>
+      <span>Essays</span><span class="dot">·</span>
+      <span>Notes</span><span class="dot">·</span>
       <span>Homelab Dispatches</span>
     </p>
-    <p class="masthead-title">
-      <em>Field</em> Notes
-    </p>
+    <p class="masthead-title"><em>Field</em> Notes</p>
     <p class="masthead-dateline">
       Vol. MMXXVI
       <span class="rule" aria-hidden="true"></span>
@@ -47,50 +32,14 @@ const latestISO = posts[0].data.date.toISOString().split('T')[0];
 
   <h1 class="sr-only">Latest writing from William Zujkowski</h1>
 
-  <article class="lead">
-    <p class="lead-kicker">
-      <span class="lead-section">{leadK.section}</span>
-      <span class="dot">·</span>
-      <span>{leadK.rt} min read</span>
-      <span class="dot">·</span>
-      <time datetime={lead.data.date.toISOString().split('T')[0]}>{leadK.date}</time>
-    </p>
-    <h2 class="lead-title">
-      <a href={`/posts/${lead.id}/`}>{lead.data.title}</a>
-    </h2>
-    {lead.data.description && (
-      <p class="lead-lede">{lead.data.description}</p>
-    )}
-  </article>
+  <BroadsheetEntry post={lead} variant="lead" />
 
   <hr class="broadsheet-rule" aria-hidden="true" />
 
-  <ol class="entry-list" start="2">
-    {tail.map((post) => {
-      const k = kicker(post);
-      return (
-        <li class="entry">
-          <div class="entry-meta">
-            <p class="entry-kicker">
-              <span class="entry-section">{k.section}</span>
-              <span class="dot">·</span>
-              <span>{k.rt} min</span>
-            </p>
-            <time class="entry-date" datetime={post.data.date.toISOString().split('T')[0]}>
-              {k.date}
-            </time>
-          </div>
-          <div class="entry-body">
-            <h3 class="entry-title">
-              <a href={`/posts/${post.id}/`}>{post.data.title}</a>
-            </h3>
-            {post.data.description && (
-              <p class="entry-excerpt">{post.data.description}</p>
-            )}
-          </div>
-        </li>
-      );
-    })}
+  <ol class="entry-list">
+    {tail.map((post, i) => (
+      <BroadsheetEntry post={post} variant="entry" number={i + 2} />
+    ))}
   </ol>
 
   {hasMore && (
@@ -102,270 +51,3 @@ const latestISO = posts[0].data.date.toISOString().split('T')[0];
     </nav>
   )}
 </BaseLayout>
-
-<style>
-  /* ===== Masthead ===== */
-  .broadsheet-masthead {
-    max-width: var(--content-reading);
-    margin: var(--space-8) auto var(--space-6);
-    text-align: center;
-  }
-
-  .masthead-kicker {
-    font-family: var(--font-mono);
-    font-size: var(--text-micro);
-    letter-spacing: 0.15em;
-    text-transform: uppercase;
-    color: var(--color-muted);
-    margin-block-end: var(--space-3);
-    display: inline-flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 0.5em;
-  }
-  .masthead-kicker .dot { color: var(--color-border-bold); }
-
-  .masthead-title {
-    font-family: var(--font-display);
-    font-size: clamp(3.5rem, 9vw, 7.5rem);
-    line-height: 0.92;
-    letter-spacing: -0.035em;
-    font-weight: 400;
-    color: var(--color-fg);
-    margin: 0;
-    font-feature-settings: "liga" 1, "dlig" 1, "kern" 1;
-    font-optical-sizing: auto;
-    text-wrap: balance;
-  }
-  .masthead-title em {
-    font-style: italic;
-    font-weight: 300;
-    color: var(--color-fg-muted);
-  }
-
-  .masthead-dateline {
-    font-family: var(--font-mono);
-    font-size: var(--text-meta);
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: var(--color-muted);
-    margin-block-start: var(--space-4);
-    display: inline-flex;
-    flex-wrap: wrap;
-    align-items: center;
-    justify-content: center;
-    gap: 0.75em;
-    font-variant-numeric: tabular-nums lining-nums;
-  }
-  .masthead-dateline .rule {
-    display: inline-block;
-    width: 2.5rem;
-    height: 1px;
-    background: var(--color-border-bold);
-    margin-block-end: 2px;
-  }
-
-  /* ===== Lead article ===== */
-  .lead {
-    max-width: var(--content-reading);
-    margin: var(--space-7) auto var(--space-6);
-  }
-
-  .lead-kicker,
-  .entry-kicker {
-    font-family: var(--font-mono);
-    font-size: var(--text-micro);
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-    color: var(--color-muted);
-    margin: 0 0 var(--space-3);
-    display: inline-flex;
-    flex-wrap: wrap;
-    gap: 0.4em;
-    font-variant-numeric: tabular-nums lining-nums;
-  }
-  .lead-section,
-  .entry-section {
-    color: var(--color-accent);
-    font-weight: 500;
-  }
-  .lead-kicker .dot,
-  .entry-kicker .dot { color: var(--color-border-bold); }
-
-  .lead-title {
-    font-family: var(--font-display);
-    font-size: clamp(2.25rem, 4.5vw, 3.75rem);
-    line-height: 1.05;
-    letter-spacing: -0.02em;
-    font-weight: 400;
-    margin: 0 0 var(--space-4);
-    text-wrap: balance;
-  }
-  .lead-title a {
-    color: var(--color-fg);
-    text-decoration: none;
-    background-image: linear-gradient(var(--color-fg), var(--color-fg));
-    background-size: 0 1px;
-    background-repeat: no-repeat;
-    background-position: 0 95%;
-    transition: background-size 220ms ease;
-  }
-  .lead-title a:hover { background-size: 100% 1px; }
-
-  .lead-lede {
-    font-family: var(--font-display);
-    font-size: 1.375rem;
-    line-height: 1.55;
-    font-style: italic;
-    font-weight: 300;
-    color: var(--color-fg-muted);
-    margin: 0;
-    text-wrap: pretty;
-    hanging-punctuation: first last;
-  }
-  .lead-lede::first-letter {
-    font-family: var(--font-display);
-    font-style: italic;
-    font-weight: 400;
-    font-size: 3.25em;
-    line-height: 0.85;
-    float: left;
-    padding: 0.08em 0.12em 0 0;
-    color: var(--color-fg);
-  }
-
-  /* ===== Hairline between lead and list ===== */
-  .broadsheet-rule {
-    max-width: var(--content-reading);
-    margin: var(--space-6) auto;
-    border: 0;
-    border-top: 1px solid var(--color-border);
-  }
-
-  /* ===== Entry list ===== */
-  .entry-list {
-    max-width: var(--content-reading);
-    margin: 0 auto;
-    padding: 0;
-    list-style: none;
-    counter-reset: entry 1;
-  }
-
-  .entry {
-    counter-increment: entry;
-    display: grid;
-    grid-template-columns: minmax(9rem, 11rem) 1fr;
-    gap: var(--space-5);
-    padding: var(--space-5) 0;
-    border-bottom: 1px solid var(--color-border);
-    position: relative;
-  }
-  .entry:last-child { border-bottom: 0; }
-
-  .entry::before {
-    content: counter(entry);
-    position: absolute;
-    left: calc(-1 * var(--space-6));
-    top: var(--space-5);
-    font-family: var(--font-display);
-    font-style: italic;
-    font-weight: 300;
-    font-size: 2.5rem;
-    line-height: 1;
-    color: var(--color-border-bold);
-    font-feature-settings: "onum" 1, "pnum" 1;
-  }
-
-  .entry-meta {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-1);
-  }
-  .entry-date {
-    font-family: var(--font-mono);
-    font-size: var(--text-meta);
-    letter-spacing: 0.02em;
-    color: var(--color-muted);
-    font-variant-numeric: tabular-nums lining-nums;
-  }
-
-  .entry-title {
-    font-family: var(--font-display);
-    font-size: clamp(1.5rem, 2.5vw, 1.875rem);
-    line-height: 1.15;
-    letter-spacing: -0.01em;
-    font-weight: 400;
-    margin: 0 0 var(--space-2);
-    text-wrap: balance;
-  }
-  .entry-title a {
-    color: var(--color-fg);
-    text-decoration: none;
-    background-image: linear-gradient(var(--color-fg), var(--color-fg));
-    background-size: 0 1px;
-    background-repeat: no-repeat;
-    background-position: 0 95%;
-    transition: background-size 220ms ease;
-  }
-  .entry-title a:hover { background-size: 100% 1px; }
-
-  .entry-excerpt {
-    font-family: var(--font-body);
-    font-size: var(--text-body);
-    line-height: var(--leading-body);
-    color: var(--color-fg-muted);
-    margin: 0;
-    text-wrap: pretty;
-  }
-
-  /* ===== Archive link ===== */
-  .broadsheet-archive-nav {
-    max-width: var(--content-reading);
-    margin: var(--space-7) auto var(--space-8);
-    text-align: center;
-  }
-  .archive-link {
-    display: inline-flex;
-    flex-direction: column;
-    align-items: center;
-    gap: var(--space-1);
-    text-decoration: none;
-    color: var(--color-fg);
-    padding: var(--space-3) var(--space-5);
-    min-height: 44px;
-    min-width: 44px;
-  }
-  .archive-link {
-    font-family: var(--font-display);
-    font-style: italic;
-    font-size: 1.25rem;
-    font-weight: 400;
-    letter-spacing: -0.005em;
-    transition: color 180ms ease;
-  }
-  .archive-link:hover { color: var(--color-accent); }
-  .archive-count {
-    font-family: var(--font-mono);
-    font-size: var(--text-micro);
-    letter-spacing: 0.15em;
-    text-transform: uppercase;
-    color: var(--color-muted);
-    font-style: normal;
-    font-variant-numeric: tabular-nums lining-nums;
-  }
-
-  /* ===== Mobile ===== */
-  @media (max-width: 640px) {
-    .entry {
-      grid-template-columns: 1fr;
-      gap: var(--space-2);
-    }
-    .entry::before {
-      position: static;
-      font-size: 1.75rem;
-      display: block;
-      margin-block-end: var(--space-1);
-    }
-    .entry-meta { flex-direction: row; gap: 0.75em; align-items: baseline; }
-  }
-</style>

--- a/astro-site/src/pages/posts/index.astro
+++ b/astro-site/src/pages/posts/index.astro
@@ -1,23 +1,19 @@
 ---
 import BaseLayout from '@layouts/BaseLayout.astro';
 import { getCollection } from 'astro:content';
-import PostCard from '@components/PostCard.astro';
+import BroadsheetEntry from '@components/BroadsheetEntry.astro';
 
 const allPosts = await getCollection('posts', ({ data }) => !data.draft);
 const posts = allPosts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
 
-// Collect top tags
 const tagCounts = new Map<string, number>();
 posts.forEach((post) => {
   (post.data.tags ?? [])
     .filter((t: string) => t !== 'posts')
-    .forEach((tag: string) => {
-      tagCounts.set(tag, (tagCounts.get(tag) ?? 0) + 1);
-    });
+    .forEach((tag: string) => tagCounts.set(tag, (tagCounts.get(tag) ?? 0) + 1));
 });
 const topTags = [...tagCounts.entries()].sort((a, b) => b[1] - a[1]).slice(0, 8);
 
-// Group posts by year
 const postsByYear = new Map<number, typeof posts>();
 posts.forEach((post) => {
   const year = post.data.date.getFullYear();
@@ -31,48 +27,80 @@ const years = [...postsByYear.keys()].sort((a, b) => b - a);
   title="Blog"
   description="Security insights, AI experiments, homelab adventures, and lessons from the field."
 >
-  <div class="prose">
-    <h1>Blog</h1>
-    <p>{posts.length} posts on security, AI, and building things.</p>
-  </div>
+  <header class="broadsheet-masthead" style="margin-block-start: var(--space-6);">
+    <p class="masthead-kicker">The archive</p>
+    <p class="masthead-title" style="font-size: clamp(2.75rem, 6vw, 5rem);">
+      <em>Writing</em>
+    </p>
+    <p class="masthead-dateline">
+      {posts.length} entries
+      <span class="rule" aria-hidden="true"></span>
+      {years.length} years
+      <span class="rule" aria-hidden="true"></span>
+      {tagCounts.size} tags
+    </p>
+  </header>
 
-  <div class="chip-row" style="margin-block-end: var(--space-6);">
+  <div class="chip-row" style="max-width: var(--content-reading); margin: 0 auto var(--space-6); justify-content: center;">
     {topTags.map(([tag, count]) => (
       <a href={`/tags/${tag}/`} class="chip">{tag}<sup>{count}</sup></a>
     ))}
     <a href="/tags/" class="chip">all tags</a>
   </div>
 
-  {years.map((year, idx) => (
-    <section>
-      {idx === 0 && <p class="section-eyebrow">Archive</p>}
-      <h2 class="year-heading">
-        {year}
-        <span>{postsByYear.get(year)!.length}</span>
+  {years.map((year) => (
+    <section class="year-section">
+      <h2 class="year-divider">
+        <span class="year-number">{year}</span>
+        <span class="year-rule" aria-hidden="true"></span>
+        <span class="year-count">{postsByYear.get(year)!.length} entries</span>
       </h2>
-      {postsByYear.get(year)!.map((post) => (
-        <PostCard post={post} showTags={true} />
-      ))}
+      <ol class="entry-list">
+        {postsByYear.get(year)!.map((post, i) => (
+          <BroadsheetEntry post={post} variant="entry" number={i + 1} />
+        ))}
+      </ol>
     </section>
   ))}
 </BaseLayout>
 
 <style>
-  .year-heading {
-    font-family: var(--font-mono);
-    font-size: var(--text-meta);
-    color: var(--color-muted);
-    font-weight: 400;
+  .year-section {
     max-width: var(--content-reading);
-    margin-inline: auto;
-    margin-block: var(--space-7) var(--space-4);
-    padding-block-end: var(--space-2);
-    border-bottom: 1px solid var(--color-border);
-    /* small-caps + letter-spacing applied via global .year-heading rule (Wave 2) */
+    margin: 0 auto;
+    padding-block: var(--space-6);
   }
-
-  .year-heading span {
+  .year-divider {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: baseline;
+    gap: var(--space-4);
+    margin: 0 0 var(--space-4);
     font-weight: 400;
+    border: 0;
+  }
+  .year-number {
+    font-family: var(--font-display);
+    font-size: clamp(2.25rem, 4.5vw, 3.25rem);
+    font-style: italic;
+    font-weight: 300;
+    line-height: 1;
+    color: var(--color-fg);
+    letter-spacing: -0.02em;
+    font-variant-numeric: oldstyle-nums proportional-nums;
+    font-feature-settings: "onum" 1, "pnum" 1;
+  }
+  .year-rule {
+    height: 1px;
+    background: var(--color-border);
+    align-self: center;
+  }
+  .year-count {
+    font-family: var(--font-mono);
+    font-size: var(--text-micro);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
     color: var(--color-muted);
+    font-variant-numeric: tabular-nums lining-nums;
   }
 </style>

--- a/astro-site/src/pages/tags/[tag].astro
+++ b/astro-site/src/pages/tags/[tag].astro
@@ -1,13 +1,15 @@
 ---
 import BaseLayout from '@layouts/BaseLayout.astro';
 import { getCollection } from 'astro:content';
-import PostCard from '@components/PostCard.astro';
+import BroadsheetEntry from '@components/BroadsheetEntry.astro';
 
 export async function getStaticPaths() {
   const posts = await getCollection('posts', ({ data }) => !data.draft);
   const tags = new Set<string>();
   posts.forEach((post) => {
-    (post.data.tags ?? []).filter((t: string) => t !== 'posts').forEach((tag: string) => tags.add(tag));
+    (post.data.tags ?? [])
+      .filter((t: string) => t !== 'posts')
+      .forEach((tag: string) => tags.add(tag));
   });
   return [...tags].map((tag) => ({
     params: { tag },
@@ -21,6 +23,7 @@ export async function getStaticPaths() {
 }
 
 const { tag, posts } = Astro.props;
+const humanTag = tag.replace(/-/g, ' ').replace(/\b\w/g, (c: string) => c.toUpperCase());
 ---
 
 <BaseLayout title={`Posts tagged "${tag}"`} description={`All blog posts tagged with "${tag}".`}>
@@ -28,10 +31,19 @@ const { tag, posts } = Astro.props;
     <a href="/">Home</a> / <a href="/posts/">Blog</a> / <a href="/tags/">Tags</a> / {tag}
   </nav>
 
-  <div class="prose">
-    <h1>{tag}</h1>
-    <p>{posts.length} post{posts.length === 1 ? '' : 's'} tagged with {tag}.</p>
-  </div>
+  <header class="broadsheet-masthead" style="margin-block-start: var(--space-5);">
+    <p class="masthead-kicker">The archive · By tag</p>
+    <p class="masthead-title" style="font-size: clamp(2.5rem, 6vw, 4.5rem);">
+      <em>{humanTag}</em>
+    </p>
+    <p class="masthead-dateline">
+      {posts.length} {posts.length === 1 ? 'entry' : 'entries'}
+    </p>
+  </header>
 
-  {posts.map((post) => <PostCard post={post} showTags={true} />)}
+  <ol class="entry-list">
+    {posts.map((post, i) => (
+      <BroadsheetEntry post={post} variant="entry" number={i + 1} />
+    ))}
+  </ol>
 </BaseLayout>

--- a/astro-site/src/styles/global.css
+++ b/astro-site/src/styles/global.css
@@ -824,6 +824,265 @@ div:has(> .post-card) {
   margin-inline: auto;
 }
 
+/* ===== Broadsheet layout (landing, /posts/, tag pages) ===== */
+
+/* Masthead used on landing */
+.broadsheet-masthead {
+  max-width: var(--content-reading);
+  margin: var(--space-8) auto var(--space-6);
+  text-align: center;
+}
+.masthead-kicker {
+  font-family: var(--font-mono);
+  font-size: var(--text-micro);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+  margin-block-end: var(--space-3);
+  display: inline-flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.5em;
+}
+.masthead-kicker .dot { color: var(--color-border-bold); }
+.masthead-title {
+  font-family: var(--font-display);
+  font-size: clamp(3.5rem, 9vw, 7.5rem);
+  line-height: 0.92;
+  letter-spacing: -0.035em;
+  font-weight: 400;
+  color: var(--color-fg);
+  margin: 0;
+  font-feature-settings: "liga" 1, "dlig" 1, "kern" 1;
+  font-optical-sizing: auto;
+  text-wrap: balance;
+}
+.masthead-title em {
+  font-style: italic;
+  font-weight: 300;
+  color: var(--color-fg-muted);
+}
+.masthead-dateline {
+  font-family: var(--font-mono);
+  font-size: var(--text-meta);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+  margin-block-start: var(--space-4);
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75em;
+  font-variant-numeric: tabular-nums lining-nums;
+}
+.masthead-dateline .rule {
+  display: inline-block;
+  width: 2.5rem;
+  height: 1px;
+  background: var(--color-border-bold);
+  margin-block-end: 2px;
+}
+
+/* Lead article */
+.lead {
+  max-width: var(--content-reading);
+  margin: var(--space-7) auto var(--space-6);
+}
+.lead-kicker,
+.entry-kicker {
+  font-family: var(--font-mono);
+  font-size: var(--text-micro);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+  margin: 0 0 var(--space-3);
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.4em;
+  font-variant-numeric: tabular-nums lining-nums;
+}
+.lead-section,
+.entry-section {
+  color: var(--color-accent);
+  font-weight: 500;
+}
+.lead-kicker .dot,
+.entry-kicker .dot { color: var(--color-border-bold); }
+.lead-title {
+  font-family: var(--font-display);
+  font-size: clamp(2.25rem, 4.5vw, 3.75rem);
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+  font-weight: 400;
+  margin: 0 0 var(--space-4);
+  text-wrap: balance;
+}
+.lead-title a,
+.entry-title a {
+  color: var(--color-fg);
+  text-decoration: none;
+  background-image: linear-gradient(var(--color-fg), var(--color-fg));
+  background-size: 0 1px;
+  background-repeat: no-repeat;
+  background-position: 0 95%;
+  transition: background-size 220ms ease;
+}
+.lead-title a:hover,
+.entry-title a:hover { background-size: 100% 1px; }
+.lead-lede {
+  font-family: var(--font-display);
+  font-size: 1.375rem;
+  line-height: 1.55;
+  font-style: italic;
+  font-weight: 300;
+  color: var(--color-fg-muted);
+  margin: 0;
+  text-wrap: pretty;
+  hanging-punctuation: first last;
+}
+.lead-lede::first-letter {
+  font-family: var(--font-display);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 3.25em;
+  line-height: 0.85;
+  float: left;
+  padding: 0.08em 0.12em 0 0;
+  color: var(--color-fg);
+}
+
+/* Hairline divider */
+.broadsheet-rule {
+  max-width: var(--content-reading);
+  margin: var(--space-6) auto;
+  border: 0;
+  border-top: 1px solid var(--color-border);
+}
+
+/* Numbered entry list */
+.entry-list {
+  max-width: var(--content-reading);
+  margin: 0 auto;
+  padding: 0;
+  list-style: none;
+}
+.entry {
+  display: grid;
+  grid-template-columns: minmax(9rem, 11rem) 1fr;
+  gap: var(--space-5);
+  padding: var(--space-5) 0;
+  border-bottom: 1px solid var(--color-border);
+  position: relative;
+}
+.entry:last-child { border-bottom: 0; }
+.entry[data-entry-number]::before {
+  content: attr(data-entry-number);
+  position: absolute;
+  left: calc(-1 * var(--space-6));
+  top: var(--space-5);
+  font-family: var(--font-display);
+  font-style: italic;
+  font-weight: 300;
+  font-size: 2.5rem;
+  line-height: 1;
+  color: var(--color-border-bold);
+  font-feature-settings: "onum" 1, "pnum" 1;
+}
+.entry-meta {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+.entry-date {
+  font-family: var(--font-mono);
+  font-size: var(--text-meta);
+  letter-spacing: 0.02em;
+  color: var(--color-muted);
+  font-variant-numeric: tabular-nums lining-nums;
+}
+.entry-title {
+  font-family: var(--font-display);
+  font-size: clamp(1.5rem, 2.5vw, 1.875rem);
+  line-height: 1.15;
+  letter-spacing: -0.01em;
+  font-weight: 400;
+  margin: 0 0 var(--space-2);
+  text-wrap: balance;
+}
+.entry-excerpt {
+  font-family: var(--font-body);
+  font-size: var(--text-body);
+  line-height: var(--leading-body);
+  color: var(--color-fg-muted);
+  margin: 0;
+  text-wrap: pretty;
+}
+
+/* Archive link */
+.broadsheet-archive-nav {
+  max-width: var(--content-reading);
+  margin: var(--space-7) auto var(--space-8);
+  text-align: center;
+}
+.archive-link {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-1);
+  text-decoration: none;
+  color: var(--color-fg);
+  padding: var(--space-3) var(--space-5);
+  min-height: 44px;
+  min-width: 44px;
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 1.25rem;
+  font-weight: 400;
+  letter-spacing: -0.005em;
+  transition: color 180ms ease;
+}
+.archive-link:hover { color: var(--color-accent); }
+.archive-count {
+  font-family: var(--font-mono);
+  font-size: var(--text-micro);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+  font-style: normal;
+  font-variant-numeric: tabular-nums lining-nums;
+}
+
+/* Post-header kicker (individual posts) */
+.post-kicker {
+  font-family: var(--font-mono);
+  font-size: var(--text-micro);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+  margin: 0 0 var(--space-3);
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.4em;
+  font-variant-numeric: tabular-nums lining-nums;
+}
+.post-kicker .post-section { color: var(--color-accent); font-weight: 500; }
+.post-kicker .dot { color: var(--color-border-bold); }
+
+@media (max-width: 640px) {
+  .entry {
+    grid-template-columns: 1fr;
+    gap: var(--space-2);
+  }
+  .entry[data-entry-number]::before {
+    position: static;
+    font-size: 1.75rem;
+    display: block;
+    margin-block-end: var(--space-1);
+  }
+  .entry-meta { flex-direction: row; gap: 0.75em; align-items: baseline; }
+}
+
 /* ===== PostLayout share row ===== */
 .share-row {
   display: flex;


### PR DESCRIPTION
Stacks on top of #213. Extracts the broadsheet typography into shared CSS + a BroadsheetEntry component, applies to:

- **/posts/**: masthead 'Writing', per-year italic oldstyle-figure dividers, numbered entries
- **/tags/[tag]**: masthead 'Archive · By tag', numbered entries
- **PostLayout**: mono kicker ('Civic Tech · 5 min read · Apr 2, 2026') above each post title

All 4 Remarque audits + 16 axe tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)