### PR TITLE
feat(masthead): site header becomes William Zujkowski's Field Notes nameplate

### DIFF
--- a/astro-site/src/layouts/BaseLayout.astro
+++ b/astro-site/src/layouts/BaseLayout.astro
@@ -109,6 +109,9 @@ if (pathSegments.length > 0) {
   });
 }
 
+import { getSiteStats } from '@/lib/siteStats';
+const siteStats = await getSiteStats();
+
 const navLinks = [
   { label: 'Front', href: '/' },
   { label: 'Dispatches', href: '/posts/' },
@@ -206,9 +209,9 @@ function isActiveLink(linkHref: string): boolean {
     <header role="banner" aria-label="Site header" class="site-masthead">
       <div class="site-masthead-inner">
         <p class="site-masthead-eyebrow">
-          <span>Writing</span><span class="dot">·</span>
-          <span>Notes</span><span class="dot">·</span>
-          <span>Homelab Dispatches</span>
+          <span>Vol. {siteStats.volume}</span><span class="dot">·</span>
+          <span>No. {siteStats.postCount}</span><span class="dot">·</span>
+          <span>Writing · Notes · Homelab Dispatches</span>
         </p>
 
         <div class="site-masthead-top">

--- a/astro-site/src/layouts/BaseLayout.astro
+++ b/astro-site/src/layouts/BaseLayout.astro
@@ -110,11 +110,11 @@ if (pathSegments.length > 0) {
 }
 
 const navLinks = [
-  { label: 'Home', href: '/' },
-  { label: 'About', href: '/about/' },
-  { label: 'Blog', href: '/posts/' },
-  { label: 'Projects', href: '/projects/' },
-  { label: 'Uses', href: '/uses/' },
+  { label: 'Front', href: '/' },
+  { label: 'Dispatches', href: '/posts/' },
+  { label: 'Colophon', href: '/about/' },
+  { label: 'Catalog', href: '/uses/' },
+  { label: 'Workbench', href: '/projects/' },
   { label: 'Now', href: '/now/' },
 ];
 
@@ -202,26 +202,40 @@ function isActiveLink(linkHref: string): boolean {
   <body>
     <a href="#main" class="skip-to-main">Skip to main content</a>
 
-    <!-- Header -->
-    <header role="banner" aria-label="Site header" class="site-header">
-      <div class="site-title">
-        <a href="/">William Zujkowski</a>
+    <!-- Masthead -->
+    <header role="banner" aria-label="Site header" class="site-masthead">
+      <div class="site-masthead-inner">
+        <p class="site-masthead-eyebrow">
+          <span>Writing</span><span class="dot">·</span>
+          <span>Notes</span><span class="dot">·</span>
+          <span>Homelab Dispatches</span>
+        </p>
+
+        <div class="site-masthead-top">
+          <div class="site-masthead-tools-left" aria-hidden="true"></div>
+          <a href="/" class="site-nameplate" aria-label="William Zujkowski's Field Notes — home">
+            <span class="site-nameplate-byline">William Zujkowski&rsquo;s</span>
+            <span class="site-nameplate-title"><em>Field</em> Notes</span>
+          </a>
+          <div class="site-masthead-tools-right">
+            <Search client:load />
+            <ThemeToggle />
+          </div>
+        </div>
+
+        <nav class="site-sections" aria-label="Primary navigation">
+          {
+            navLinks.map((link) => (
+              <a
+                href={link.href}
+                aria-current={isActiveLink(link.href) ? 'page' : undefined}
+              >
+                {link.label}
+              </a>
+            ))
+          }
+        </nav>
       </div>
-      <div class="site-subtitle">Security Engineer & Builder</div>
-      <nav class="site-nav" aria-label="Primary navigation">
-        {
-          navLinks.map((link) => (
-            <a
-              href={link.href}
-              aria-current={isActiveLink(link.href) ? 'page' : undefined}
-            >
-              {link.label}
-            </a>
-          ))
-        }
-        <Search client:load />
-        <ThemeToggle />
-      </nav>
     </header>
 
     <!-- Main -->

--- a/astro-site/src/lib/siteStats.ts
+++ b/astro-site/src/lib/siteStats.ts
@@ -1,0 +1,75 @@
+import { getCollection } from 'astro:content';
+import { execSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Canonical site-wide stats derived at build time.
+ * Single source of truth so no page duplicates counting logic.
+ */
+export async function getSiteStats() {
+  const allPosts = await getCollection('posts', ({ data }) => !data.draft);
+  const posts = allPosts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
+  const tagSet = new Set<string>();
+  posts.forEach((p) =>
+    (p.data.tags ?? []).filter((t: string) => t !== 'posts').forEach((t: string) => tagSet.add(t)),
+  );
+  const years = new Set<number>(posts.map((p) => p.data.date.getFullYear()));
+  const latest = posts[0]?.data.date ?? new Date();
+  const currentYear = new Date().getFullYear();
+  return {
+    postCount: posts.length,
+    tagCount: tagSet.size,
+    yearCount: years.size,
+    latest,
+    latestISO: latest.toISOString().split('T')[0],
+    currentYear,
+    volume: toRoman(currentYear),
+  };
+}
+
+/** Roman-numeral formatter for masthead "Vol." markers. */
+export function toRoman(n: number): string {
+  const map: Array<[number, string]> = [
+    [1000, 'M'], [900, 'CM'], [500, 'D'], [400, 'CD'],
+    [100, 'C'], [90, 'XC'], [50, 'L'], [40, 'XL'],
+    [10, 'X'], [9, 'IX'], [5, 'V'], [4, 'IV'], [1, 'I'],
+  ];
+  let out = '';
+  let v = n;
+  for (const [num, letter] of map) {
+    while (v >= num) {
+      out += letter;
+      v -= num;
+    }
+  }
+  return out;
+}
+
+/**
+ * Git mtime for a source file, falls back to current date.
+ * Use for pages like /now/ where "last updated" should be live.
+ */
+export function gitMtime(importMetaUrl: string): Date {
+  try {
+    const path = fileURLToPath(importMetaUrl);
+    if (!existsSync(path)) return new Date();
+    const iso = execSync(`git log -1 --format=%cI -- "${path}"`, {
+      cwd: path.substring(0, path.lastIndexOf('/')),
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    if (!iso) return new Date();
+    return new Date(iso);
+  } catch {
+    return new Date();
+  }
+}
+
+export function formatDate(d: Date): string {
+  return d.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}

--- a/astro-site/src/pages/index.astro
+++ b/astro-site/src/pages/index.astro
@@ -14,19 +14,17 @@ const latestISO = posts[0].data.date.toISOString().split('T')[0];
 ---
 
 <BaseLayout title="William Zujkowski" description="Security engineer, builder, homelab enthusiast. Field notes on security, AI, and building things.">
-  <header class="broadsheet-masthead">
-    <p class="masthead-kicker">
-      <span>Essays</span><span class="dot">·</span>
-      <span>Notes</span><span class="dot">·</span>
-      <span>Homelab Dispatches</span>
-    </p>
-    <p class="masthead-title"><em>Field</em> Notes</p>
-    <p class="masthead-dateline">
+  <header class="broadsheet-masthead landing-issue">
+    <p class="landing-issue-label">
       Vol. MMXXVI
       <span class="rule" aria-hidden="true"></span>
-      {posts.length} entries
+      No. {posts.length}
       <span class="rule" aria-hidden="true"></span>
-      Latest <time datetime={latestISO}>{formatDate(posts[0].data.date)}</time>
+      <time datetime={latestISO}>{formatDate(posts[0].data.date)}</time>
+    </p>
+    <p class="landing-tagline">
+      <em>Field reports</em> from cloud-security engineering,
+      <em>AI experiments</em>, and a homelab that keeps getting bigger.
     </p>
   </header>
 

--- a/astro-site/src/pages/index.astro
+++ b/astro-site/src/pages/index.astro
@@ -35,7 +35,7 @@ const stats = await getSiteStats();
 
   <ol class="entry-list">
     {tail.map((post, i) => (
-      <BroadsheetEntry post={post} variant="entry" number={i + 2} />
+      <BroadsheetEntry post={post} variant="entry" number={stats.postCount - (i + 1)} />
     ))}
   </ol>
 

--- a/astro-site/src/pages/index.astro
+++ b/astro-site/src/pages/index.astro
@@ -1,26 +1,25 @@
 ---
 import BaseLayout from '@layouts/BaseLayout.astro';
-import { getCollection } from 'astro:content';
 import BroadsheetEntry from '@components/BroadsheetEntry.astro';
+import { getSiteStats, formatDate } from '@/lib/siteStats';
+import { getCollection } from 'astro:content';
 
 const allPosts = await getCollection('posts', ({ data }) => !data.draft);
 const posts = allPosts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
 const [lead, ...tail] = posts.slice(0, 6);
 const hasMore = posts.length > 6;
 
-const formatDate = (d: Date) =>
-  d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
-const latestISO = posts[0].data.date.toISOString().split('T')[0];
+const stats = await getSiteStats();
 ---
 
 <BaseLayout title="William Zujkowski" description="Security engineer, builder, homelab enthusiast. Field notes on security, AI, and building things.">
   <header class="broadsheet-masthead landing-issue">
     <p class="landing-issue-label">
-      Vol. MMXXVI
+      Vol. {stats.volume}
       <span class="rule" aria-hidden="true"></span>
-      No. {posts.length}
+      No. {stats.postCount}
       <span class="rule" aria-hidden="true"></span>
-      <time datetime={latestISO}>{formatDate(posts[0].data.date)}</time>
+      <time datetime={stats.latestISO}>{formatDate(stats.latest)}</time>
     </p>
     <p class="landing-tagline">
       <em>Field reports</em> from cloud-security engineering,
@@ -44,7 +43,7 @@ const latestISO = posts[0].data.date.toISOString().split('T')[0];
     <nav class="broadsheet-archive-nav">
       <a href="/posts/" class="archive-link">
         Browse the full archive
-        <span class="archive-count">{posts.length} entries</span>
+        <span class="archive-count">{stats.postCount} entries</span>
       </a>
     </nav>
   )}

--- a/astro-site/src/pages/now.astro
+++ b/astro-site/src/pages/now.astro
@@ -1,5 +1,13 @@
 ---
 import BaseLayout from '@layouts/BaseLayout.astro';
+import { gitMtime } from '@/lib/siteStats';
+
+const lastUpdated = gitMtime(import.meta.url);
+const lastUpdatedISO = lastUpdated.toISOString().split('T')[0];
+const lastUpdatedStr = lastUpdated.toLocaleDateString('en-US', {
+  year: 'numeric',
+  month: 'long',
+});
 ---
 
 <BaseLayout title="Now" description="What I'm currently working on, learning, and thinking about.">
@@ -9,7 +17,7 @@ import BaseLayout from '@layouts/BaseLayout.astro';
     <p>
       This is a <a href="https://nownownow.com/about" target="_blank" rel="noopener noreferrer">now page</a> —
       what I'm actually focused on right now instead of my entire life story.
-      Last updated <time datetime="2026-03-13">March 2026</time>.
+      Last updated <time datetime={lastUpdatedISO}>{lastUpdatedStr}</time>.
     </p>
 
     <h2>Building</h2>

--- a/astro-site/src/pages/posts/index.astro
+++ b/astro-site/src/pages/posts/index.astro
@@ -56,8 +56,8 @@ const years = [...postsByYear.keys()].sort((a, b) => b - a);
         <span class="year-count">{postsByYear.get(year)!.length} entries</span>
       </h2>
       <ol class="entry-list">
-        {postsByYear.get(year)!.map((post, i) => (
-          <BroadsheetEntry post={post} variant="entry" number={i + 1} />
+        {postsByYear.get(year)!.map((post, i, arr) => (
+          <BroadsheetEntry post={post} variant="entry" number={arr.length - i} />
         ))}
       </ol>
     </section>

--- a/astro-site/src/pages/tags/[tag].astro
+++ b/astro-site/src/pages/tags/[tag].astro
@@ -42,8 +42,8 @@ const humanTag = tag.replace(/-/g, ' ').replace(/\b\w/g, (c: string) => c.toUppe
   </header>
 
   <ol class="entry-list">
-    {posts.map((post, i) => (
-      <BroadsheetEntry post={post} variant="entry" number={i + 1} />
+    {posts.map((post, i, arr) => (
+      <BroadsheetEntry post={post} variant="entry" number={arr.length - i} />
     ))}
   </ol>
 </BaseLayout>

--- a/astro-site/src/pages/uses.astro
+++ b/astro-site/src/pages/uses.astro
@@ -1,5 +1,13 @@
 ---
 import BaseLayout from '@layouts/BaseLayout.astro';
+import { gitMtime } from '@/lib/siteStats';
+
+const lastUpdated = gitMtime(import.meta.url);
+const lastUpdatedISO = lastUpdated.toISOString().split('T')[0];
+const lastUpdatedStr = lastUpdated.toLocaleDateString('en-US', {
+  year: 'numeric',
+  month: 'long',
+});
 ---
 
 <BaseLayout title="Uses" description="Hardware, software, and services I use.">
@@ -562,7 +570,7 @@ import BaseLayout from '@layouts/BaseLayout.astro';
     </section>
 
     <p>
-      Last updated <time datetime="2026-03-12">March 2026</time>.
+      Last updated <time datetime={lastUpdatedISO}>{lastUpdatedStr}</time>.
     </p>
   </div>
 </BaseLayout>

--- a/astro-site/src/styles/global.css
+++ b/astro-site/src/styles/global.css
@@ -215,47 +215,162 @@ a {
 a:hover { color: var(--color-accent-hover); }
 
 /* ===== Header — Remarque editorial identity ===== */
-.site-header {
+/* ===== Site masthead nameplate ===== */
+.site-masthead {
+  border-bottom: 1px solid var(--color-border);
   margin-block-end: var(--space-7);
-  max-width: var(--content-reading);
+}
+.site-masthead-inner {
+  max-width: 64rem;
   margin-inline: auto;
+  padding: var(--space-5) var(--space-4) var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
 }
-.site-title {
-  font-family: var(--font-display);
-  font-size: var(--text-display);
-  font-weight: var(--weight-regular);
-  line-height: var(--leading-display);
-  letter-spacing: var(--tracking-display);
+
+.site-masthead-eyebrow {
+  font-family: var(--font-mono);
+  font-size: var(--text-micro);
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--color-muted);
   margin: 0;
+  display: inline-flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.5em;
+  text-align: center;
+  align-self: center;
 }
-.site-title a { text-decoration: none; color: var(--color-fg); }
-.site-subtitle {
+.site-masthead-eyebrow .dot { color: var(--color-border-bold); }
+
+.site-masthead-top {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.site-nameplate {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.1em;
+  text-decoration: none;
+  color: var(--color-fg);
+  text-align: center;
+  transition: color 180ms ease;
+  min-height: 44px;
+  padding: 0 0.5rem;
+}
+.site-nameplate:hover { color: var(--color-accent); }
+.site-nameplate-byline {
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: clamp(0.85rem, 1.4vw, 1rem);
+  font-weight: 300;
+  letter-spacing: 0.02em;
+  color: var(--color-muted);
+  line-height: 1;
+}
+.site-nameplate-title {
+  font-family: var(--font-display);
+  font-size: clamp(2.25rem, 5.5vw, 4.25rem);
+  font-weight: 400;
+  line-height: 0.95;
+  letter-spacing: -0.03em;
+  font-feature-settings: "liga" 1, "dlig" 1, "kern" 1;
+  font-optical-sizing: auto;
+}
+.site-nameplate-title em {
+  font-style: italic;
+  font-weight: 300;
+  color: var(--color-fg-muted);
+}
+
+.site-masthead-tools-left { /* balances grid */ }
+.site-masthead-tools-right {
+  display: inline-flex;
+  justify-self: end;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.site-masthead-byline {
+  font-family: var(--font-display);
+  font-size: 1rem;
+  font-style: normal;
+  color: var(--color-muted);
+  text-align: center;
+  margin: 0;
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75em;
+  align-self: center;
+}
+.site-masthead-byline em {
+  font-style: italic;
+  color: var(--color-fg);
+  font-weight: 400;
+}
+.site-masthead-byline .rule {
+  display: inline-block;
+  width: 2rem;
+  height: 1px;
+  background: var(--color-border-bold);
+  margin-block-end: 3px;
+}
+
+.site-sections {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem 1.5rem;
+  justify-content: center;
+  align-self: center;
+  padding-block-start: var(--space-2);
+  border-top: 1px solid var(--color-border);
+  width: 100%;
   font-family: var(--font-mono);
   font-size: var(--text-meta);
-  font-weight: var(--weight-regular);
-  color: var(--color-muted);
-  margin-block-start: var(--space-2);
+  letter-spacing: 0.08em;
   text-transform: uppercase;
-  letter-spacing: var(--tracking-caps);
 }
-.site-nav {
-  display: flex; flex-wrap: wrap; gap: 0.5rem 1rem;
-  margin-block-start: var(--space-4);
-  font-size: var(--text-meta);
-  letter-spacing: var(--tracking-meta);
-}
-@media (max-width: 480px) { .site-nav { font-size: var(--text-meta); gap: 0.35rem 0.75rem; } }
-.site-nav a {
+.site-sections a {
   text-decoration: none;
-  color: var(--color-fg-muted);
-  transition: color var(--motion-fast) var(--motion-easing);
+  color: var(--color-muted);
+  transition: color 180ms ease;
   min-height: 44px;
-  min-width: 44px; /* WCAG 2.5.5 — 44×44 touch target */
+  min-width: 44px;
+  padding: 0 0.25rem;
   display: inline-flex;
   align-items: center;
   justify-content: center;
 }
-.site-nav a:hover, .site-nav a[aria-current="page"] { color: var(--color-fg); }
+.site-sections a:hover { color: var(--color-fg); }
+.site-sections a[aria-current="page"] {
+  color: var(--color-fg);
+  font-weight: 500;
+}
+.site-sections a[aria-current="page"]::before {
+  content: "§";
+  margin-right: 0.3em;
+  color: var(--color-accent);
+  font-style: italic;
+  font-weight: 400;
+  font-family: var(--font-display);
+  text-transform: none;
+}
+
+/* Mobile masthead: stack tools below nameplate */
+@media (max-width: 640px) {
+  .site-masthead-top { grid-template-columns: 1fr; }
+  .site-masthead-tools-left { display: none; }
+  .site-masthead-tools-right { justify-self: center; }
+  .site-sections { gap: 0.15rem 0.85rem; font-size: var(--text-micro); }
+}
 
 /* ===== Post Article Header ===== */
 .post-breadcrumb {
@@ -470,7 +585,7 @@ a.post-card-title:hover { color: var(--color-accent); }
 }
 
 /* Tabular numerals in metadata, dates, times, code */
-.post-meta, .post-card-date, .uses-meta, .site-subtitle,
+.post-meta, .post-card-date, .uses-meta,
 .year-heading, .section-eyebrow, .related-meta,
 time, pre, code, .chip {
   font-variant-numeric: tabular-nums;
@@ -479,7 +594,7 @@ time, pre, code, .chip {
 /* OpenType features on display typography (Wave 2) */
 /* Newsreader has optical-size axis 6-72; let the font choose the right grade */
 h1, h2, h3, h4, h5, h6,
-.site-title, .post-card-title, .uses-name,
+.post-card-title, .uses-name,
 .prose :where(h1, h2, h3, h4) {
   font-feature-settings: "liga" 1, "calt" 1, "dlig" 1, "kern" 1;
   font-optical-sizing: auto;
@@ -884,6 +999,49 @@ div:has(> .post-card) {
   margin-block-end: 2px;
 }
 
+/* Landing issue marker (replaces large landing masthead since site masthead
+   already carries the 'Field Notes' nameplate) */
+.landing-issue {
+  max-width: var(--content-reading);
+  margin: var(--space-6) auto var(--space-5);
+  text-align: center;
+}
+.landing-issue-label {
+  font-family: var(--font-mono);
+  font-size: var(--text-meta);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+  margin: 0 0 var(--space-4);
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75em;
+  font-variant-numeric: tabular-nums lining-nums;
+}
+.landing-issue-label .rule {
+  display: inline-block;
+  width: 2.5rem;
+  height: 1px;
+  background: var(--color-border-bold);
+  margin-block-end: 2px;
+}
+.landing-tagline {
+  font-family: var(--font-display);
+  font-size: clamp(1.25rem, 2.2vw, 1.625rem);
+  line-height: 1.45;
+  color: var(--color-fg-muted);
+  margin: 0 auto;
+  max-width: 44rem;
+  text-wrap: pretty;
+  hanging-punctuation: first last;
+}
+.landing-tagline em {
+  font-style: italic;
+  color: var(--color-fg);
+}
+
 /* Lead article */
 .lead {
   max-width: var(--content-reading);
@@ -1134,7 +1292,7 @@ time, .post-card-meta, .post-card-readtime, .year-heading span,
 }
 
 /* Hanging punctuation on headings */
-h1, h2, h3, .post-card-title, .site-title {
+h1, h2, h3, .post-card-title {
   hanging-punctuation: first allow-end last;
 }
 


### PR DESCRIPTION
## What
Replaces the generic site header with a broadsheet masthead nameplate.

- Italic possessive byline 'William Zujkowski's' above display title
- 'Field Notes' nameplate with italic F + roman rest
- Eyebrow kicker, hairline rule, mono uppercase sections row
- Active page marked with italic § accent

## Page renames (URLs unchanged)
Home → Front · Blog → Dispatches · About → Colophon · Uses → Catalog · Projects → Workbench · Now

## Landing
No longer duplicates the title. Compact issue marker + italic tagline instead.

All 4 Remarque audits + 16 axe tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)