### PR TITLE
feat(copy): drop 'archive', broaden site eyebrow to 'Ephemera'

### DIFF
--- a/astro-site/src/layouts/BaseLayout.astro
+++ b/astro-site/src/layouts/BaseLayout.astro
@@ -211,7 +211,7 @@ function isActiveLink(linkHref: string): boolean {
         <p class="site-masthead-eyebrow">
           <span>Vol. {siteStats.volume}</span><span class="dot">·</span>
           <span>No. {siteStats.postCount}</span><span class="dot">·</span>
-          <span>Writing · Experiments · Ephemera</span>
+          <span>Est. {siteStats.established}</span>
         </p>
 
         <div class="site-masthead-top">

--- a/astro-site/src/layouts/BaseLayout.astro
+++ b/astro-site/src/layouts/BaseLayout.astro
@@ -211,7 +211,7 @@ function isActiveLink(linkHref: string): boolean {
         <p class="site-masthead-eyebrow">
           <span>Vol. {siteStats.volume}</span><span class="dot">·</span>
           <span>No. {siteStats.postCount}</span><span class="dot">·</span>
-          <span>Writing · Notes · Homelab Dispatches</span>
+          <span>Writing · Experiments · Ephemera</span>
         </p>
 
         <div class="site-masthead-top">

--- a/astro-site/src/lib/siteStats.ts
+++ b/astro-site/src/lib/siteStats.ts
@@ -16,15 +16,20 @@ export async function getSiteStats() {
   );
   const years = new Set<number>(posts.map((p) => p.data.date.getFullYear()));
   const latest = posts[0]?.data.date ?? new Date();
+  const earliest = posts[posts.length - 1]?.data.date ?? new Date();
   const currentYear = new Date().getFullYear();
+  const earliestYear = earliest.getFullYear();
   return {
     postCount: posts.length,
     tagCount: tagSet.size,
     yearCount: years.size,
     latest,
     latestISO: latest.toISOString().split('T')[0],
+    earliest,
+    earliestYear,
     currentYear,
     volume: toRoman(currentYear),
+    established: toRoman(earliestYear),
   };
 }
 

--- a/astro-site/src/pages/index.astro
+++ b/astro-site/src/pages/index.astro
@@ -42,7 +42,7 @@ const stats = await getSiteStats();
   {hasMore && (
     <nav class="broadsheet-archive-nav">
       <a href="/posts/" class="archive-link">
-        Browse the full archive
+        Read every dispatch
         <span class="archive-count">{stats.postCount} entries</span>
       </a>
     </nav>

--- a/astro-site/src/pages/posts/index.astro
+++ b/astro-site/src/pages/posts/index.astro
@@ -28,7 +28,7 @@ const years = [...postsByYear.keys()].sort((a, b) => b - a);
   description="Security insights, AI experiments, homelab adventures, and lessons from the field."
 >
   <header class="broadsheet-masthead" style="margin-block-start: var(--space-6);">
-    <p class="masthead-kicker">The archive</p>
+    <p class="masthead-kicker">Every piece, in order</p>
     <h1 class="masthead-title" style="font-size: clamp(2.75rem, 6vw, 5rem);">
       <em>Writing</em>
     </h1>

--- a/astro-site/src/pages/tags/[tag].astro
+++ b/astro-site/src/pages/tags/[tag].astro
@@ -32,7 +32,7 @@ const humanTag = tag.replace(/-/g, ' ').replace(/\b\w/g, (c: string) => c.toUppe
   </nav>
 
   <header class="broadsheet-masthead" style="margin-block-start: var(--space-5);">
-    <p class="masthead-kicker">The archive · By tag</p>
+    <p class="masthead-kicker">Filed under</p>
     <h1 class="masthead-title" style="font-size: clamp(2.5rem, 6vw, 4.5rem);">
       <em>{humanTag}</em>
     </h1>


### PR DESCRIPTION
Swaps stale 'archive'/'homelab' framing for broader editorial copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)