### PR TITLE
feat(posts,tags): canonical site-wide piece numbers

### DIFF
--- a/astro-site/src/pages/posts/index.astro
+++ b/astro-site/src/pages/posts/index.astro
@@ -14,6 +14,12 @@ posts.forEach((post) => {
 });
 const topTags = [...tagCounts.entries()].sort((a, b) => b[1] - a[1]).slice(0, 8);
 
+// Site-wide piece number: latest post = posts.length, oldest = 1.
+// Matches landing numbering; every post has a single canonical number
+// across the whole publication.
+const pieceNumberById = new Map<string, number>();
+posts.forEach((post, i) => pieceNumberById.set(post.id, posts.length - i));
+
 const postsByYear = new Map<number, typeof posts>();
 posts.forEach((post) => {
   const year = post.data.date.getFullYear();
@@ -56,8 +62,8 @@ const years = [...postsByYear.keys()].sort((a, b) => b - a);
         <span class="year-count">{postsByYear.get(year)!.length} entries</span>
       </h2>
       <ol class="entry-list">
-        {postsByYear.get(year)!.map((post, i, arr) => (
-          <BroadsheetEntry post={post} variant="entry" number={arr.length - i} />
+        {postsByYear.get(year)!.map((post) => (
+          <BroadsheetEntry post={post} variant="entry" number={pieceNumberById.get(post.id)!} />
         ))}
       </ol>
     </section>

--- a/astro-site/src/pages/tags/[tag].astro
+++ b/astro-site/src/pages/tags/[tag].astro
@@ -4,22 +4,30 @@ import { getCollection } from 'astro:content';
 import BroadsheetEntry from '@components/BroadsheetEntry.astro';
 
 export async function getStaticPaths() {
-  const posts = await getCollection('posts', ({ data }) => !data.draft);
+  const all = await getCollection('posts', ({ data }) => !data.draft);
+  const sortedAll = all.sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
+  const total = sortedAll.length;
+  // Canonical site-wide piece number: newest = total, oldest = 1
+  const pieceById = new Map<string, number>();
+  sortedAll.forEach((post, i) => pieceById.set(post.id, total - i));
+
   const tags = new Set<string>();
-  posts.forEach((post) => {
+  sortedAll.forEach((post) => {
     (post.data.tags ?? [])
       .filter((t: string) => t !== 'posts')
       .forEach((tag: string) => tags.add(tag));
   });
-  return [...tags].map((tag) => ({
-    params: { tag },
-    props: {
-      tag,
-      posts: posts
-        .filter((p) => p.data.tags?.includes(tag))
-        .sort((a, b) => b.data.date.getTime() - a.data.date.getTime()),
-    },
-  }));
+
+  return [...tags].map((tag) => {
+    const filtered = sortedAll.filter((p) => p.data.tags?.includes(tag));
+    return {
+      params: { tag },
+      props: {
+        tag,
+        posts: filtered.map((post) => ({ post, piece: pieceById.get(post.id)! })),
+      },
+    };
+  });
 }
 
 const { tag, posts } = Astro.props;
@@ -42,8 +50,8 @@ const humanTag = tag.replace(/-/g, ' ').replace(/\b\w/g, (c: string) => c.toUppe
   </header>
 
   <ol class="entry-list">
-    {posts.map((post, i, arr) => (
-      <BroadsheetEntry post={post} variant="entry" number={arr.length - i} />
+    {posts.map(({ post, piece }) => (
+      <BroadsheetEntry post={post} variant="entry" number={piece} />
     ))}
   </ol>
 </BaseLayout>


### PR DESCRIPTION
Every post has ONE number across the whole publication (77 → 1). Year and tag filters show those same numbers rather than restarting at 1 per section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)