### PR TITLE
feat(masthead): drop redundant eyebrow, tighten padding

### DIFF
--- a/astro-site/src/layouts/BaseLayout.astro
+++ b/astro-site/src/layouts/BaseLayout.astro
@@ -208,13 +208,6 @@ function isActiveLink(linkHref: string): boolean {
     <!-- Masthead -->
     <header role="banner" aria-label="Site header" class="site-masthead">
       <div class="site-masthead-inner">
-        <p class="site-masthead-eyebrow">
-          <span>Transmission {siteStats.latestISO}</span><span class="dot">·</span>
-          <span>Vol. {siteStats.volume}</span><span class="dot">·</span>
-          <span>No. {siteStats.postCount}</span><span class="dot">·</span>
-          <span>Est. {siteStats.established}</span>
-        </p>
-
         <div class="site-masthead-top">
           <div class="site-masthead-tools-left" aria-hidden="true"></div>
           <a href="/" class="site-nameplate" aria-label="William Zujkowski's Field Notes — home">

--- a/astro-site/src/styles/global.css
+++ b/astro-site/src/styles/global.css
@@ -225,27 +225,11 @@ a:hover { color: var(--color-accent-hover); }
 .site-masthead-inner {
   max-width: 64rem;
   margin-inline: auto;
-  padding: var(--space-5) var(--space-4) var(--space-3);
+  padding: var(--space-3) var(--space-4) var(--space-2);
   display: flex;
   flex-direction: column;
-  gap: var(--space-3);
+  gap: var(--space-2);
 }
-
-.site-masthead-eyebrow {
-  font-family: var(--font-mono);
-  font-size: var(--text-micro);
-  letter-spacing: 0.2em;
-  text-transform: uppercase;
-  color: var(--color-muted);
-  margin: 0;
-  display: inline-flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 0.5em;
-  text-align: center;
-  align-self: center;
-}
-.site-masthead-eyebrow .dot { color: var(--color-border-bold); }
 
 .site-masthead-top {
   display: grid;
@@ -329,10 +313,10 @@ a:hover { color: var(--color-accent-hover); }
 .site-sections {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.25rem 1.5rem;
+  gap: 0 1.25rem;
   justify-content: center;
   align-self: center;
-  padding-block-start: var(--space-2);
+  padding-block-start: var(--space-1);
   border-top: 1px solid var(--color-border);
   width: 100%;
   font-family: var(--font-mono);


### PR DESCRIPTION
Header was 3 rows ≈ 200px before content; eyebrow was just duplicating what the landing's issue label already shows. Now 2 rows ≈ 120px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)