### PR TITLE
feat(posts): declutter archive masthead

### DIFF
--- a/astro-site/src/pages/posts/index.astro
+++ b/astro-site/src/pages/posts/index.astro
@@ -33,25 +33,22 @@ const years = [...postsByYear.keys()].sort((a, b) => b - a);
   title="Blog"
   description="Security insights, AI experiments, homelab adventures, and lessons from the field."
 >
-  <header class="broadsheet-masthead" style="margin-block-start: var(--space-6);">
-    <p class="masthead-kicker">Every piece, in order</p>
-    <h1 class="masthead-title" style="font-size: clamp(2.75rem, 6vw, 5rem);">
-      <em>Writing</em>
-    </h1>
-    <p class="masthead-dateline">
-      {posts.length} entries
-      <span class="rule" aria-hidden="true"></span>
+  <h1 class="sr-only">Dispatches — every piece</h1>
+
+  <div class="archive-intro">
+    <p class="archive-stats">
+      {posts.length} pieces
+      <span class="dot">·</span>
       {years.length} years
-      <span class="rule" aria-hidden="true"></span>
+      <span class="dot">·</span>
       {tagCounts.size} tags
     </p>
-  </header>
-
-  <div class="chip-row" style="max-width: var(--content-reading); margin: 0 auto var(--space-6); justify-content: center;">
-    {topTags.map(([tag, count]) => (
-      <a href={`/tags/${tag}/`} class="chip">{tag}<sup>{count}</sup></a>
-    ))}
-    <a href="/tags/" class="chip">all tags</a>
+    <div class="archive-filter">
+      {topTags.map(([tag, count]) => (
+        <a href={`/tags/${tag}/`} class="chip">{tag}<sup>{count}</sup></a>
+      ))}
+      <a href="/tags/" class="chip">all tags</a>
+    </div>
   </div>
 
   {years.map((year) => (

--- a/astro-site/src/styles/global.css
+++ b/astro-site/src/styles/global.css
@@ -1220,6 +1220,35 @@ div:has(> .post-card) {
   }
 }
 
+/* ===== Archive intro (/posts/) — compact stats + filter row ===== */
+.archive-intro {
+  max-width: var(--content-reading);
+  margin: var(--space-5) auto var(--space-4);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-3);
+}
+.archive-stats {
+  font-family: var(--font-mono);
+  font-size: var(--text-meta);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+  margin: 0;
+  display: inline-flex;
+  gap: 0.6em;
+  font-variant-numeric: tabular-nums lining-nums;
+}
+.archive-stats .dot { color: var(--color-border-bold); }
+.archive-filter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.5rem;
+  justify-content: center;
+  max-width: var(--content-reading);
+}
+
 /* ===== PostLayout share row ===== */
 .share-row {
   display: flex;


### PR DESCRIPTION
Drops the huge 'Writing' title + kicker + dateline. Replaces with a single compact mono stats line + chip filter row. Saves ~200px; the year dividers become the visual anchors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)