### PR TITLE
fix(ci): repair link/citation validation workflows + correct stale docs

### DIFF
--- a/.github/workflows/link-monitor.yml
+++ b/.github/workflows/link-monitor.yml
@@ -16,6 +16,12 @@ on:
       - 'src/posts/**/*.md'
       - 'src/pages/**/*.md'
 
+# Default to least privilege. The check-links job needs to open an issue on
+# scheduled failures; the repair-links job overrides this to push auto-fixes.
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   check-links:
     runs-on: ubuntu-latest
@@ -196,6 +202,8 @@ jobs:
     needs: check-links
     if: github.event.inputs.force_check == 'true' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # commit and push high-confidence auto-fixes
 
     steps:
     - name: Checkout Repository

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ __pycache__/
 .mcp/
 .playwright-mcp/
 .nexus-agents/
+runs/
 
 # Legacy tool artifacts
 .claude-flow/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 **Status:** Authoritative
 **Last Updated:** 2026-04-22
-**Project:** Personal website and technical blog (Astro 6 + Svelte 5 + Tailwind CSS 4)
+**Project:** Personal website and technical blog (Astro 6 + Svelte 5 + hand-written CSS / Remarque design tokens)
 
 This file is the canonical guidance for AI coding agents working in this repo (Claude Code, Codex, Cursor, Aider, etc.). Harness-specific entry points (e.g. `CLAUDE.md`) import this file — edit here, not there.
 
@@ -14,33 +14,37 @@ Additional rules: `@.rules/nexus-agents.md`
 
 ```bash
 cd astro-site
-npm install
-npm run dev          # Dev server at localhost:4321
-npm run build        # Production build → dist/
-npm run preview      # Preview production build
-npm run check        # Astro type checking
+pnpm install
+pnpm dev             # Dev server at localhost:4321
+pnpm build           # Production build → dist/
+pnpm preview         # Preview production build
+pnpm check           # Astro type checking
 ```
 
-**Prerequisites:** Node.js 22+, npm, Git. Python 3.11+ and [UV](https://docs.astral.sh/uv/) for link validation scripts only.
+**Prerequisites:** Node.js 22+, pnpm, Git. Python 3.11+ and [UV](https://docs.astral.sh/uv/) for link validation scripts only. The repo is pnpm-only (`astro-site/pnpm-lock.yaml`); CI and the pre-commit hook both run `pnpm`.
 
 ---
 
 ## Project Structure
 
 ```
+├── src/                       # Content collections (loaded by astro-site)
+│   ├── posts/                 # Blog posts (Markdown) — astro-site/src/content.config.ts globs ../src/posts
+│   └── projects/              # Project entries (Markdown)
 ├── astro-site/                # Website source (Astro 6 + Svelte 5)
 │   ├── src/
 │   │   ├── components/        # Svelte & Astro components
-│   │   ├── content/blog/      # Blog posts (Markdown, content collections)
+│   │   ├── content.config.ts  # Content collection schemas (points at ../src/posts, ../src/projects)
 │   │   ├── layouts/           # Page layouts (BaseLayout.astro)
 │   │   ├── pages/             # Route pages
-│   │   └── styles/            # Global CSS (Tailwind 4)
+│   │   └── styles/            # Global CSS (hand-written; Remarque design tokens)
 │   ├── public/                # Static assets
 │   ├── astro.config.mjs       # Astro configuration
-│   └── package.json           # Node.js dependencies
-├── scripts/                   # Link validation CI pipeline (8 Python scripts)
+│   └── package.json           # Node.js dependencies (pnpm)
+├── scripts/                   # Python tooling
 │   ├── lib/logging_config.py  # Shared logging module
-│   └── link-validation/       # Citation and link health checking
+│   ├── link-validation/       # Citation and link health checking (7 scripts)
+│   └── blog-audit/            # Blog audit helpers
 ├── tests/unit/                # Unit tests (JS)
 ├── docs/                      # Research and link validation docs
 ├── .github/workflows/         # CI/CD (6 workflows)
@@ -234,7 +238,7 @@ Dependencies managed via `pyproject.toml` (3 deps: aiohttp, certifi, tqdm). Inst
 
 - **Astro:** `astro-site/astro.config.mjs` (integrations, prefetch, syntax highlighting)
 - **TypeScript:** `astro-site/tsconfig.json` (strict mode, path aliases)
-- **Tailwind CSS:** CSS-only config via `@tailwindcss/vite` plugin
+- **Styling:** Hand-written CSS with Remarque design tokens in `astro-site/src/styles/` (no Tailwind)
 - **Content schemas:** `astro-site/src/content.config.ts` (Zod validation)
 
 ---

--- a/scripts/link-validation/citation-report.py
+++ b/scripts/link-validation/citation-report.py
@@ -271,12 +271,15 @@ def main() -> int:
             if r.get('status') == 'broken'
         ])
 
+        # Report generation succeeded. The broken-link count is surfaced to the
+        # workflow via the `validate` step's output, so a successful report must
+        # exit 0 -- returning non-zero here fails the step under `bash -eo
+        # pipefail` and (via implicit success()) skips the issue-creation step.
         if broken_count > 0:
             logger.warning(f"Found {broken_count} broken citation links")
-            return 1
         else:
             logger.info("All citation links are valid")
-            return 0
+        return 0
 
     except Exception as e:
         logger.error(f"Fatal error generating citation report: {e}", exc_info=True)

--- a/scripts/link-validation/link-extractor.py
+++ b/scripts/link-validation/link-extractor.py
@@ -196,10 +196,29 @@ class LinkExtractor:
         ]
         return any(pattern in line for pattern in patterns)
 
+    @staticmethod
+    def _clean_trailing_punct(url: str) -> str:
+        """Strip trailing prose punctuation that markdown bare-URL parsing absorbs.
+
+        Bare URLs in prose ("see https://arxiv.org/abs/2408.13687).") pick up
+        trailing ``)``, ``.``, ``,``, ``*`` etc., which then 404 as false
+        positives. Closing brackets are only stripped when unbalanced, so real
+        URLs like https://en.wikipedia.org/wiki/Foo_(bar) keep their tail.
+        """
+        url = url.strip()
+        while url and url[-1] in ')].,;:!?\'"*`>':
+            if url[-1] == ')' and url.count('(') >= url.count(')'):
+                break
+            if url[-1] == ']' and url.count('[') >= url.count(']'):
+                break
+            url = url[:-1]
+        return url
+
     def _add_link(self, url: str, text: str, file_path: Path,
                   line_number: int, position: int, lines: List[str],
                   line_idx: int):
         """Add a link with its context"""
+        url = self._clean_trailing_punct(url)
         # Get context (±50 words or ±3 lines)
         context_before = self._get_context(lines, line_idx, -3, 50)
         context_after = self._get_context(lines, line_idx, 3, 50)
@@ -212,7 +231,7 @@ class LinkExtractor:
         link_hash = hashlib.md5(hash_input.encode()).hexdigest()[:8]
 
         link_context = LinkContext(
-            url=url.strip(),
+            url=url,
             text=text,
             type=link_type,
             context_before=context_before,


### PR DESCRIPTION
## Summary

Both scheduled link-validation workflows have **failed on every run**. This fixes the root causes and corrects stale docs found during the review.

### CI fixes (the real bugs)
- **Link extractor false positives.** `link-extractor.py` absorbed trailing prose punctuation into bare URLs (`...2408.13687))`, `...v3**`, `...nexus-agents):**`), so they 404'd as false positives — ~84% of reported "broken" citation links and most "internal broken" links were this artifact. Added `_clean_trailing_punct()` with **balanced-paren handling** so real URLs like `.../Foo_(bar)` keep their tail. End-to-end run over all 83 posts now yields **0** URLs with junk trailing punctuation (was hundreds).
- **link-monitor.yml missing permissions.** No `permissions:` block + repo read-only default token ⇒ "Create Issue for Broken Links" crashed with `Resource not accessible by integration`. **No link-health issue was ever filed.** Added least-privilege permissions (`issues: write` at workflow level; `contents: write` scoped to the `repair-links` auto-push job).
- **citation-report.py exit code.** It returned `exit 1` whenever broken links existed; under `bash -eo pipefail` that failed the "Generate markdown report" step, and the implicit `success()` gate then **skipped** issue creation. The broken count is already surfaced via the `validate` step output, so the report now exits 0.
- Created the `automated` / `citation-validation` / `maintenance` labels the citation workflow applies (they didn't exist).

### Doc + hygiene fixes
- **AGENTS.md Quick Start** said `npm`; the repo is **pnpm-only** (CI + pre-commit hook both use pnpm).
- **AGENTS.md Project Structure** pointed posts at `astro-site/src/content/blog/`; they actually live in root `src/posts/` (globbed by `astro-site/src/content.config.ts`).
- Removed three **Tailwind** references — the site uses hand-written CSS / Remarque tokens (corroborates #206).
- Added `runs/` (nexus-agents orchestration output) to `.gitignore`.

## Verification
- `node tests/test-runner.js` → all pass
- Extractor smoke test over 83 posts: 2652 links, 0 with junk trailing punctuation
- YAML + Python syntax validated
- Pre-commit build hook passed on commit

## Not included (follow-ups filed separately)
- Fabricated gist links in 2 posts (content decision — separate issue)
- In-range dependency lockfile bumps for the security alerts (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)