### PR TITLE
content: remove fabricated gist links, rework surrounding prose

### DIFF
--- a/src/posts/2024-06-11-zero-knowledge-authentication-homelab.md
+++ b/src/posts/2024-06-11-zero-knowledge-authentication-homelab.md
@@ -95,8 +95,6 @@ I used Groth16 ZK-SNARK construction (most widely deployed, used in Zcash and Et
 pip install py_ecc zksnark fastapi
 ```
 
-**Authentication server:** https://gist.github.com/williamzujkowski/a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6
-
 **Key components:**
 
 **1. Circuit definition (password verification):**

--- a/src/posts/2024-09-15-running-llama-raspberry-pi-pipeload.md
+++ b/src/posts/2024-09-15-running-llama-raspberry-pi-pipeload.md
@@ -148,7 +148,7 @@ pip3 install torch torchvision torchaudio --index-url https://download.pytorch.o
 pip3 install pipeload-inference
 ```
 
-**Reality check:** As of September 2024, PIPELOAD isn't a public package. The [Hermes paper](https://arxiv.org/abs/2409.04249) describes the mechanism but doesn't release code. I implemented a minimal version based on their algorithm description. Full implementation is ~450 lines of Python, available in my [GitHub gist](https://gist.github.com/williamzujkowski/pipeload-minimal).
+**Reality check:** As of September 2024, PIPELOAD isn't a public package. The [Hermes paper](https://arxiv.org/abs/2409.04249) describes the mechanism but doesn't release code. I implemented a minimal version (~450 lines of Python) based on their algorithm description. The snippets below are the core of that implementation.
 
 ### Step 2: Configure Model Loading
 
@@ -185,8 +185,6 @@ print(f"Model size: {model.size_gb():.2f}GB")  # ~4.1GB for LLaMA 7B
 ```
 
 **Why 4-bit quantization:** Reduces model size from 14GB (FP16) to 4.1GB (Q4_K_M) with minimal accuracy loss. For general text generation, perplexity increases by ~3% ([GPTQ paper](https://arxiv.org/abs/2210.17323), Table 3). For my use case (homelab experimentation), this trade-off is acceptable.
-
-**Full quantization script:** [GitHub gist](https://gist.github.com/williamzujkowski/llama-quantization-script) (52 lines)
 
 ### Step 4: Run Inference
 

--- a/src/posts/2025-01-12-privacy-preserving-federated-learning-homelab.md
+++ b/src/posts/2025-01-12-privacy-preserving-federated-learning-homelab.md
@@ -194,9 +194,7 @@ def compute_granular_balls(X, n_clusters=100, variance_threshold=0.03):
     return balls
 ```
 
-**Key difference from standard federated learning:** This function never sends raw data or per-example gradients. Only aggregated cluster statistics leave the device.
-
-For the complete implementation with Flower client/server integration, see my GitHub gist: [Federated Learning with Granular-Ball Computing](https://gist.github.com/williamzujkowski/federated-grball-example)
+**Key difference from standard federated learning:** This function never sends raw data or per-example gradients. Only aggregated cluster statistics leave the device. Wiring it into a Flower client/server loop is mechanical from here: the balls become the payload each client sends to the aggregator.
 
 ### Training Configuration
 

--- a/src/posts/2025-09-08-zero-trust-vlan-segmentation-homelab.md
+++ b/src/posts/2025-09-08-zero-trust-vlan-segmentation-homelab.md
@@ -589,17 +589,11 @@ Attempt VLAN breakout from IoT using nmap source-ip spoofing
 
 ## Troubleshooting Common Issues
 
-<!-- 📎 **Complete troubleshooting guide:**
-[All common VLAN issues and solutions](https://gist.github.com/williamzujkowski/vlan-troubleshooting) -->
-
 **DHCP issues:** Check daemon logs, tcpdump VLAN traffic on port 67
 **Routing issues:** Verify `ip_forward=1`, traceroute between VLANs
 **mDNS issues:** Verify Avahi daemon running, browse services
 
 ## Performance Optimization
-
-<!-- 📎 **Complete optimization guide:**
-[Hardware offloading and VLAN tuning](https://gist.github.com/williamzujkowski/vlan-performance-tuning) -->
 
 Enable hardware NAT offloading, increase MTU to 9000 for storage VLANs
 

--- a/src/posts/2025-09-29-proxmox-high-availability-homelab.md
+++ b/src/posts/2025-09-29-proxmox-high-availability-homelab.md
@@ -153,15 +153,9 @@ Create OSD on each disk: `pveceph osd create /dev/sdX`
 
 ### Create Ceph Pools
 
-<!-- 📎 **Complete configuration:**
-[All pools with replication settings and storage mappings](https://gist.github.com/williamzujkowski/ceph-pool-creation) -->
-
 Create pools with 3x replication (min 2), map to Proxmox storage
 
 ### Ceph Performance Tuning
-
-<!-- 📎 **Complete tuning guide:**
-[Full Ceph performance optimization settings](https://gist.github.com/williamzujkowski/ceph-performance-tuning) -->
 
 Set placement groups to 128, enable RBD caching
 
@@ -178,9 +172,6 @@ Verify HA services running, check cluster status
 
 Fencing prevents split-brain scenarios by forcibly powering off unresponsive nodes.
 
-<!-- 📎 **Complete fencing configuration:**
-[IPMI fencing setup for all nodes with testing](https://gist.github.com/williamzujkowski/ipmi-fencing-config) -->
-
 Install fence-agents, configure IPMI credentials for each node
 
 ### Enable HA for VMs
@@ -194,22 +185,13 @@ Add VMs to HA: `ha-manager add vm:100 --state started --max_restart 3`
 
 ### Simulated Node Failure
 
-<!-- 📎 **Complete test suite:**
-[Full failover testing scripts with monitoring](https://gist.github.com/williamzujkowski/ha-failover-tests) -->
-
 Power off node, watch VMs migrate within 2 minutes. This pattern integrates well with [zero trust VLAN segmentation](/posts/2025-09-08-zero-trust-vlan-segmentation-homelab) to ensure services remain isolated during failover.
 
 ### Simulated Network Partition
 
-<!-- 📎 **Complete test:**
-[Network partition testing with split-brain prevention](https://gist.github.com/williamzujkowski/network-partition-test) -->
-
 Block all traffic with iptables, verify fencing powers off minority partition
 
 ### Simulated Ceph Failure
-
-<!-- 📎 **Complete test:**
-[Ceph OSD failure scenarios and recovery](https://gist.github.com/williamzujkowski/ceph-failure-tests) -->
 
 Stop OSD daemon, verify data remains accessible via replication
 
@@ -224,9 +206,6 @@ Add PBS storage, schedule nightly snapshots at 2 AM
 
 ### Automated Backup Script
 
-<!-- 📎 **Complete script:**
-[Full cluster backup with Ceph, config, and offsite sync](https://gist.github.com/williamzujkowski/cluster-backup-script) -->
-
 Backup cluster config to tarball, sync offsite with rclone
 
 ## Monitoring and Alerting
@@ -240,15 +219,9 @@ Install exporter, configure PVE credentials, expose metrics
 
 ### Grafana Dashboard
 
-<!-- 📎 **Complete dashboard:**
-[Full Grafana dashboard JSON with all panels](https://gist.github.com/williamzujkowski/grafana-proxmox-dashboard) -->
-
 Import dashboard with cluster quorum, Ceph health, VM status panels
 
 ### Alerting Rules
-
-<!-- 📎 **Complete alerting:**
-[All Prometheus alert rules for HA cluster](https://gist.github.com/williamzujkowski/prometheus-ha-alerts) -->
 
 Alert on quorum loss, Ceph errors, node failures
 
@@ -256,15 +229,9 @@ Alert on quorum loss, Ceph errors, node failures
 
 ### Maintenance Mode
 
-<!-- 📎 **Complete procedure:**
-[Full maintenance mode workflow with VM migration](https://gist.github.com/williamzujkowski/ha-maintenance-mode) -->
-
 Migrate all VMs off node, set maintenance state, perform updates
 
 ### Rolling Updates
-
-<!-- 📎 **Complete script:**
-[Rolling update script for all nodes with zero downtime](https://gist.github.com/williamzujkowski/rolling-update-script) -->
 
 Migrate VMs, update packages, reboot node, repeat for all nodes
 
@@ -290,17 +257,11 @@ Migrate VMs, update packages, reboot node, repeat for all nodes
 
 **Manual Recovery:**
 
-<!-- 📎 **Complete recovery procedure:**
-[Full split-brain recovery with quorum restoration](https://gist.github.com/williamzujkowski/split-brain-recovery) -->
-
 Set expected votes, restart cluster services, verify quorum
 
 ### Scenario 3: Total Cluster Failure
 
 **Manual Recovery:**
-
-<!-- 📎 **Complete disaster recovery:**
-[Full cluster rebuild procedure from total failure](https://gist.github.com/williamzujkowski/total-cluster-recovery) -->
 
 Set expected=1, start VMs manually, restore quorum after nodes rejoin
 

--- a/src/posts/2025-12-17-docker-container-hardening-homelab.md
+++ b/src/posts/2025-12-17-docker-container-hardening-homelab.md
@@ -134,7 +134,15 @@ Docker containers run as root by default. User namespaces map container root (UI
 
 **Attack stopped:** Container breakout attempt via `/proc/self/setgroups` failed because container root had no actual privileges on host filesystem.
 
-**Enable user namespace remapping:** [Complete setup script](https://gist.github.com/williamzujkowski/89j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4)
+**Enable user namespace remapping** in `/etc/docker/daemon.json`:
+
+```json
+{
+  "userns-remap": "default"
+}
+```
+
+Restart Docker (`sudo systemctl restart docker`). Docker creates the `dockremap` user and maps container UID 0 to an unprivileged host UID (starting at 100000 from `/etc/subuid`).
 
 **Validation:**
 
@@ -156,7 +164,7 @@ Seccomp (secure computing) filters block dangerous system calls. Docker includes
 
 **Attack stopped:** Exploit attempting to call `create_module()` syscall (loads kernel modules) was blocked by seccomp, preventing privilege escalation.
 
-**Custom seccomp profile for web applications:** [View complete seccomp profile](https://gist.github.com/williamzujkowski/45f7e8c9a1d2b3e4f5g6h7i8j9k0l1m2)
+For web applications, start from Docker's default profile and tighten it. Apply a custom profile with `--security-opt`, then generate the allowlist from a real syscall trace (both shown below).
 
 **Apply custom profile:**
 
@@ -183,7 +191,28 @@ AppArmor enforces file access policies that root cannot bypass. I use it to prev
 
 **Attack stopped:** Container attempting to read SSH host keys (`/etc/ssh/`) was blocked by AppArmor profile denying access to `/etc/` directory.
 
-**AppArmor profile for web container:** [Complete AppArmor profile](https://gist.github.com/williamzujkowski/56g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1)
+A minimal profile for an nginx container, saved to `/etc/apparmor.d/docker-nginx`:
+
+```
+#include <tunables/global>
+
+profile docker-nginx flags=(attach_disconnected,mediate_deleted) {
+  #include <abstractions/base>
+
+  network inet tcp,
+  network inet udp,
+
+  /usr/sbin/nginx ix,
+  /var/www/** r,
+  /var/log/nginx/** w,
+  /var/cache/nginx/** rw,
+
+  # Deny the host paths a compromised container would target
+  deny /etc/** rwklx,
+  deny /proc/sys/** wklx,
+  deny /sys/** wklx,
+}
+```
 
 **Load and enforce profile:**
 
@@ -271,8 +300,6 @@ docker run \
   nginx:alpine
 ```
 
-**Docker Compose read-only configuration:** [Complete read-only setup](https://gist.github.com/williamzujkowski/90k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5)
-
 **tmpfs options:**
 
 - `noexec`: Prevent executable files in temporary directories
@@ -328,8 +355,6 @@ docker network create \
   backend-network
 ```
 
-**Multi-tier deployment:** [Complete Docker Compose configuration](https://gist.github.com/williamzujkowski/67h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2)
-
 **Network policies with UFW:**
 
 ```bash
@@ -363,9 +388,7 @@ docker run \
   nginx:alpine
 ```
 
-**Docker Compose limits:** [Resource limits configuration](https://gist.github.com/williamzujkowski/78i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3)
-
-**Monitoring resource usage:** Use `docker stats` for real-time monitoring or check cgroup files for historical usage. [Resource monitoring commands](https://gist.github.com/williamzujkowski/01l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6)
+**Monitoring resource usage:** Use `docker stats` for real-time monitoring or check the cgroup files under `/sys/fs/cgroup/` for historical usage.
 
 **Tuning guidelines:** Start with generous limits, monitor actual usage for 2 weeks, then set limits at 150% of observed maximum. This approach seems to work well, though you might need different ratios for your specific applications.
 


### PR DESCRIPTION
Closes #236.

## Problem
A review found GitHub gist links across the archive that **never existed**. Real gist IDs are hex; these were either obvious placeholders (`a1b2c3d4e5f6...`) or word-slugs (`pipeload-minimal`, `ceph-pool-creation`) that GitHub can't resolve. All 404. The original issue caught 8; the full scan found the slug-style ones too.

## What changed (6 posts)

**Live (rendered) links — reworked so prose stands on its own:**
- **docker-container-hardening** — inlined the real `userns-remap` `daemon.json` config and a compact AppArmor profile (both sections referenced "complete" profiles that were never shown); removed the dangling "Complete Docker Compose" links where the inline `docker run` examples already teach the technique; folded the seccomp note into prose.
- **zero-knowledge-authentication** — dropped the redundant "Authentication server" gist; the *Key components* section shows the implementation inline.
- **running-llama-raspberry-pi-pipeload** — dropped the "~450-line" and "52-line quantization script" gist links; reworded to point at the inline snippets.
- **privacy-preserving-federated-learning** — dropped the "complete implementation" gist; noted the Flower wiring is mechanical from the inline code.

**Dead scaffolding — removed:**
- **proxmox-high-availability** (13) and **zero-trust-vlan-segmentation** (2) carried commented-out `<!-- 📎 ... -->` blocks pointing at non-existent slug gists. They never rendered. Removed. The **live `📎` blocks that point to real hex gists are untouched.**

## Verification
- Repo-wide scan: **no** non-hex gist references remain in `src/posts/` (real hex gists untouched)
- `pnpm build` green, 193 pages
- Pre-commit build hook passed
- Spot-checked edited sections: no orphaned headings or double blanks

🤖 Generated with [Claude Code](https://claude.com/claude-code)