### PR TITLE
test(link-validation): add regression suite + fix bugs it caught (#237)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,35 @@
+name: Python Tests
+
+on:
+  push:
+    paths:
+      - 'scripts/**'
+      - 'pyproject.toml'
+      - '.github/workflows/tests.yml'
+  pull_request:
+    paths:
+      - 'scripts/**'
+      - 'pyproject.toml'
+      - '.github/workflows/tests.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: '3.11'
+
+      - name: Install UV
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+
+      - name: Run link-validation regression tests
+        run: uv run --with pytest python -m pytest scripts/link-validation/tests/ -q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,12 @@ dependencies = [
 dev = [
     # Code quality
     "ruff>=0.1.0",
+    # Link-validation regression tests
+    "pytest>=8.0.0",
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["scripts/link-validation/tests"]
 
 [tool.uv]
 dev-dependencies = []

--- a/scripts/link-validation/link-extractor.py
+++ b/scripts/link-validation/link-extractor.py
@@ -172,10 +172,14 @@ class LinkExtractor:
 
                 # Extract bare URLs
                 for match in re.finditer(self.PATTERNS['bare_url'], line):
-                    # Skip if this URL is part of a markdown link
-                    if not self._is_part_of_markdown_link(line, match.group(0)):
+                    # Clean trailing punctuation FIRST so the markdown-link check
+                    # matches: the bare_url regex keeps a trailing ')' from
+                    # "[text](url)", which would otherwise dodge the check and
+                    # double-count the markdown link's URL.
+                    bare = self._clean_trailing_punct(match.group(0))
+                    if not self._is_part_of_markdown_link(line, bare):
                         self._add_link(
-                            url=match.group(0),
+                            url=bare,
                             text='',
                             file_path=file_path,
                             line_number=line_num,

--- a/scripts/link-validation/simple-validator.py
+++ b/scripts/link-validation/simple-validator.py
@@ -78,8 +78,9 @@ class SimpleValidator:
         'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
         'Accept-Language': 'en-US,en;q=0.9',
     }
-    # Codes that mean "the server is gatekeeping / picky", not "the link is dead".
-    SOFT_CODES = {202, 403, 405, 406, 415, 418, 429, 451}
+    # 4xx codes that mean "the server is gatekeeping bots", not "the link is
+    # dead" -> classified needs_manual, never broken. (2xx incl. 202 = valid.)
+    SOFT_CODES = {403, 405, 406, 415, 418, 429, 451}
     DEAD_CODES = {404, 410}
     REDIRECT_CODES = {301, 302, 303, 307, 308}
     MIN_DOMAIN_INTERVAL = 0.4  # seconds between requests to the same host
@@ -117,6 +118,23 @@ class SimpleValidator:
             if wait > 0:
                 await asyncio.sleep(wait)
             self._domain_last[domain] = loop.time()
+
+    @classmethod
+    def classify_status(cls, code: int):
+        """Map a final HTTP status code to (status, issue_type).
+
+        Pure function -- no network. Only a dead resource (404/410) is 'broken';
+        soft/gatekeeping codes are 'needs_manual' so they don't inflate the
+        broken count or feed the auto-repair queue.
+        """
+        if 200 <= code < 300:
+            return 'valid', None
+        if code in cls.REDIRECT_CODES:
+            return 'redirect', 'redirect'
+        if code in cls.DEAD_CODES:
+            return 'broken', 'not_found' if code == 404 else 'gone'
+        # 403/429/451/5xx/etc. -- real server, just not a clean fetch.
+        return 'needs_manual', f'http_{code}'
 
     @staticmethod
     def _is_dns_error(exc: Exception) -> bool:
@@ -162,15 +180,8 @@ class SimpleValidator:
             if final_url != url:
                 result['notes'] = f"Final URL: {final_url}"
 
-            if 200 <= code < 300:
-                self._record(result, 'valid')
-            elif code in self.REDIRECT_CODES:
-                self._record(result, 'redirect', 'redirect')
-            elif code in self.DEAD_CODES:
-                self._record(result, 'broken', 'not_found' if code == 404 else 'gone')
-            else:
-                # 403/429/451/5xx/etc. -- real server, just not a clean fetch.
-                self._record(result, 'needs_manual', f'http_{code}')
+            status, issue_type = self.classify_status(code)
+            self._record(result, status, issue_type)
 
         except asyncio.TimeoutError:
             self._record(result, 'timeout', 'timeout')

--- a/scripts/link-validation/tests/conftest.py
+++ b/scripts/link-validation/tests/conftest.py
@@ -1,0 +1,19 @@
+"""Shared fixtures/helpers for link-validation tests.
+
+The validation scripts use hyphenated filenames (link-extractor.py,
+simple-validator.py) that aren't importable as normal modules, so we load them
+by path with importlib.
+"""
+import importlib.util
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parent.parent
+
+
+def load_script(filename: str):
+    """Load a hyphenated script module by filename from scripts/link-validation/."""
+    path = _SCRIPTS / filename
+    spec = importlib.util.spec_from_file_location(path.stem.replace("-", "_"), path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module

--- a/scripts/link-validation/tests/test_link_extractor.py
+++ b/scripts/link-validation/tests/test_link_extractor.py
@@ -1,0 +1,58 @@
+"""Regression tests for link-extractor.py.
+
+Guards the trailing-punctuation bug that produced hundreds of false-positive
+404s and broke the link/citation workflows on every run.
+"""
+import pytest
+
+from conftest import load_script
+
+le = load_script("link-extractor.py")
+clean = le.LinkExtractor._clean_trailing_punct
+
+
+@pytest.mark.parametrize("raw,expected", [
+    # Bare URLs in prose pick up trailing punctuation -> must be stripped.
+    ("https://arxiv.org/abs/2408.13687))", "https://arxiv.org/abs/2408.13687"),
+    ("https://arxiv.org/html/2405.19699v3**", "https://arxiv.org/html/2405.19699v3"),
+    ("https://github.com/williamzujkowski/nexus-agents):**",
+     "https://github.com/williamzujkowski/nexus-agents"),
+    ("https://doi.org/10.1038/s41586-020-2649-2.", "https://doi.org/10.1038/s41586-020-2649-2"),
+    ("https://example.com/path,", "https://example.com/path"),
+    ("https://example.com/x;", "https://example.com/x"),
+    # Balanced parens are legitimate URL characters -> must be preserved.
+    ("https://en.wikipedia.org/wiki/Foo_(bar)", "https://en.wikipedia.org/wiki/Foo_(bar)"),
+    ("https://en.wikipedia.org/wiki/Foo_(bar))", "https://en.wikipedia.org/wiki/Foo_(bar)"),
+    # Clean URLs are left untouched.
+    ("https://example.com/clean", "https://example.com/clean"),
+    ("https://example.com/", "https://example.com/"),
+])
+def test_clean_trailing_punct(raw, expected):
+    assert clean(raw) == expected
+
+
+def test_clean_handles_whitespace():
+    assert clean("  https://example.com/x  ") == "https://example.com/x"
+
+
+def test_extraction_skips_markdown_link_double_count(tmp_path):
+    """A markdown-link URL must not also be counted as a bare URL."""
+    post = tmp_path / "post.md"
+    post.write_text(
+        "See [the paper](https://arxiv.org/abs/1234.5678) for details.\n"
+        "Bare ref: https://example.com/raw and more text.\n",
+        encoding="utf-8",
+    )
+    extractor = le.LinkExtractor(tmp_path)
+    links = extractor.extract_all()
+    urls = sorted(link.url for link in links)
+    assert urls == ["https://arxiv.org/abs/1234.5678", "https://example.com/raw"]
+
+
+def test_extraction_cleans_bare_url_punctuation(tmp_path):
+    post = tmp_path / "post.md"
+    post.write_text("Reference: https://arxiv.org/abs/2408.13687). Done.\n", encoding="utf-8")
+    extractor = le.LinkExtractor(tmp_path)
+    urls = [link.url for link in extractor.extract_all()]
+    assert "https://arxiv.org/abs/2408.13687" in urls
+    assert all(not u.endswith(")") for u in urls)

--- a/scripts/link-validation/tests/test_simple_validator.py
+++ b/scripts/link-validation/tests/test_simple_validator.py
@@ -1,0 +1,58 @@
+"""Regression tests for simple-validator.py status classification.
+
+Locks in the rule that bot-blocking / soft codes are 'needs_manual', NOT
+'broken' -- only 404/410 and DNS failures are broken (issue #240).
+"""
+import pytest
+
+from conftest import load_script
+
+sv = load_script("simple-validator.py")
+classify = sv.SimpleValidator.classify_status
+
+
+@pytest.mark.parametrize("code,status", [
+    (200, "valid"),
+    (202, "valid"),   # accepted -> resource reachable
+    (204, "valid"),
+    (206, "valid"),   # ranged GET partial content
+    (299, "valid"),
+    (301, "redirect"),
+    (302, "redirect"),
+    (307, "redirect"),
+    (308, "redirect"),
+    (404, "broken"),
+    (410, "broken"),
+    # Soft / gatekeeping codes must NOT be broken.
+    (403, "needs_manual"),
+    (405, "needs_manual"),
+    (415, "needs_manual"),
+    (418, "needs_manual"),
+    (429, "needs_manual"),
+    (451, "needs_manual"),
+    (500, "needs_manual"),
+    (503, "needs_manual"),
+])
+def test_classify_status(code, status):
+    assert classify(code)[0] == status
+
+
+def test_only_dead_codes_are_broken():
+    """No soft code should ever be classified broken."""
+    soft = sorted(sv.SimpleValidator.SOFT_CODES) + [500, 502, 503]
+    assert all(classify(c)[0] != "broken" for c in soft)
+    assert classify(404)[0] == "broken"
+    assert classify(410)[0] == "broken"
+
+
+def test_issue_type_labels():
+    assert classify(404)[1] == "not_found"
+    assert classify(410)[1] == "gone"
+    assert classify(403)[1] == "http_403"
+    assert classify(200)[1] is None
+
+
+def test_dns_error_detection():
+    is_dns = sv.SimpleValidator._is_dns_error
+    assert is_dns(Exception("Name or service not known")) is True
+    assert is_dns(Exception("Connection reset by peer")) is False

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 
 [[package]]
@@ -284,6 +284,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "multidict"
 version = "6.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -401,6 +410,24 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "propcache"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -500,6 +527,31 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.14.5"
 source = { registry = "https://pypi.org/simple" }
@@ -558,6 +610,7 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "pytest" },
     { name = "ruff" },
 ]
 
@@ -565,6 +618,7 @@ dev = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.14.1" },
     { name = "certifi", specifier = ">=2023.0.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "tqdm", specifier = ">=4.66.0" },
 ]


### PR DESCRIPTION
Closes #237.

## What
Adds the **first Python tests** for the link-validation pipeline (previously zero), run in CI via a new `.github/workflows/tests.yml` on PRs touching `scripts/`.

### Coverage (network-free, 35 tests)
- **link-extractor `_clean_trailing_punct`** — trailing-punctuation strip with balanced-paren preservation (the bug that broke both link workflows on every run).
- **link-extractor** bare-URL vs markdown-link extraction (no double-count).
- **simple-validator `classify_status`** — 404/410 = broken; 403/429/451/5xx = `needs_manual`; 2xx = valid; redirects (#240's classification).
- **simple-validator `_is_dns_error`**.

## Bugs the tests caught (and fix here)
1. **Bare-URL scanner double-counted every markdown-link URL.** The `bare_url` regex keeps a trailing `)` from `[text](url)`, which dodged the is-part-of-markdown-link check, so the URL got added a second time as a bare link. Now the bare match is cleaned **before** the check. Extracted-link count over the 83 posts drops **2652 → 1502** — the inflation was all duplicates, which had been skewing the per-file/“total links” report numbers.
2. Refactored simple-validator's inline status mapping into a pure `classify_status()` classmethod so it's unit-testable. `202` is now `valid` (a 2xx success) rather than soft.

## Verification
- `uv run --with pytest python -m pytest scripts/link-validation/tests/ -q` → **35 passed**
- `uv.lock` updated to include `pytest` (consistent with `pyproject.toml`)
- Workflow YAML validated; actions SHA-pinned to match the repo convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)