### PR TITLE
fix(content): align frontmatter dates with filename/publish dates (#244)

### DIFF
--- a/src/posts/2024-08-13-high-performance-computing.md
+++ b/src/posts/2024-08-13-high-performance-computing.md
@@ -1,6 +1,6 @@
 ---
 
-date: 2024-04-07
+date: 2024-08-13
 description: Deploy high-performance computing with parallel processing and distributed systems—access supercomputer capabilities through cloud HPC for AI workloads.
 title: 'The Evolution of High-Performance Computing: Key Trends and Innovations'
 tags:

--- a/src/posts/2024-08-27-zero-trust-security-principles.md
+++ b/src/posts/2024-08-27-zero-trust-security-principles.md
@@ -1,6 +1,6 @@
 ---
 
-date: 2024-04-14
+date: 2024-08-27
 description: Deploy zero trust security with continuous verification and identity-centric controls—implement never-trust-always-verify for Federal EO 14028 compliance.
 title: 'Implementing Zero Trust Security: Never Trust, Always Verify'
 tags:

--- a/src/posts/2024-09-09-embodied-ai-teaching-agents.md
+++ b/src/posts/2024-09-09-embodied-ai-teaching-agents.md
@@ -1,6 +1,6 @@
 ---
 
-date: 2024-04-21
+date: 2024-09-09
 description: Train embodied AI agents with vision, language, and physical interaction—build robots that learn from real environments using reinforcement learning.
 title: 'Teaching AI Agents to Ask for Help: A Breakthrough in Human-Robot Interaction'
 tags:

--- a/src/posts/2024-09-19-biomimetic-robotics.md
+++ b/src/posts/2024-09-19-biomimetic-robotics.md
@@ -1,6 +1,6 @@
 ---
 
-date: 2024-04-28
+date: 2024-09-19
 description: Design biomimetic robots inspired by nature—implement gecko adhesion, swarm intelligence, and soft robotics using billions of years of evolution.
 title: 'Learning from Nature: How Biomimetic Robotics is Revolutionizing Engineering'
 tags:

--- a/src/posts/2024-10-03-quantum-computing-defense.md
+++ b/src/posts/2024-10-03-quantum-computing-defense.md
@@ -1,6 +1,6 @@
 ---
 
-date: 2024-05-05
+date: 2024-10-03
 description: Prepare for quantum computing threats with post-quantum cryptography—protect RSA and ECC encryption from quantum attacks using NIST-approved algorithms.
 title: 'Quantum Computing and Defense: The Double-Edged Sword of Tomorrow''s Technology'
 tags:

--- a/src/posts/2024-10-22-ai-edge-computing.md
+++ b/src/posts/2024-10-22-ai-edge-computing.md
@@ -1,6 +1,6 @@
 ---
 
-date: 2024-05-19
+date: 2024-10-22
 description: Deploy AI edge computing with YOLOv8 and TensorFlow Lite—achieve 15ms latency for real-time inference on Raspberry Pi with local processing for privacy.
 title: 'AI Meets Edge Computing: Transforming Real-Time Intelligence'
 tags:

--- a/src/posts/2024-11-05-pizza-calculator.md
+++ b/src/posts/2024-11-05-pizza-calculator.md
@@ -1,6 +1,6 @@
 ---
 
-date: 2024-05-26
+date: 2024-11-05
 author: William Zujkowski
 description: "A Saturday afternoon coding project that taught me more about assumptions than algorithms."
 title: 'The Pizza Calculator: A Weekend Project in Humility'

--- a/src/posts/2024-11-19-llms-smart-contract-vulnerability.md
+++ b/src/posts/2024-11-19-llms-smart-contract-vulnerability.md
@@ -1,6 +1,6 @@
 ---
 
-date: 2024-06-02
+date: 2024-11-19
 description: Test LLM smart contract security with GPT-4 and Claude—achieve 80% reentrancy detection accuracy but manage 38% false positives in production workflows.
 title: 'Large Language Models for Smart Contract Security: Promise and Limitations'
 tags:

--- a/src/posts/2024-12-03-context-windows-llms.md
+++ b/src/posts/2024-12-03-context-windows-llms.md
@@ -1,6 +1,6 @@
 ---
 
-date: 2024-06-09
+date: 2024-12-03
 description: Understand LLM context windows from 2K to 2M tokens—optimize model performance and prevent hallucinations at 28K token boundaries.
 title: 'Context Windows in Large Language Models: The Memory That Shapes AI'
 tags:

--- a/src/posts/2025-08-07-supercharging-development-claude-flow.md
+++ b/src/posts/2025-08-07-supercharging-development-claude-flow.md
@@ -1,7 +1,7 @@
 ---
 
 author: William Zujkowski
-date: 2025-08-03
+date: 2025-08-07
 description: Deploy Claude-Flow AI agent swarms for development—achieve 84.8% SWE-Bench solve rate with neural learning and multi-agent orchestration for complex tasks.
 title: 'Supercharging Development with Claude-Flow: AI Swarm Intelligence for Modern Engineering'
 tags:


### PR DESCRIPTION
Closes #244.

## Problem
10 posts had a frontmatter `date` months earlier than their filename date, so the rendered publish date disagreed with the URL slug.

## Decision
The filename (`YYYY-MM-DD-slug`) is the canonical publish convention and drives the URL; the early frontmatter dates were stale draft dates. The tell: `2025-08-07-supercharging-development-claude-flow` had a frontmatter date only **4 days** earlier (2025-08-03) — a draft-vs-publish gap, not an alternate publish date. Aligned each `date:` to the filename date.

| Post | old date | new date |
|---|---|---|
| high-performance-computing | 2024-04-07 | 2024-08-13 |
| zero-trust-security-principles | 2024-04-14 | 2024-08-27 |
| embodied-ai-teaching-agents | 2024-04-21 | 2024-09-09 |
| biomimetic-robotics | 2024-04-28 | 2024-09-19 |
| quantum-computing-defense | 2024-05-05 | 2024-10-03 |
| ai-edge-computing | 2024-05-19 | 2024-10-22 |
| pizza-calculator | 2024-05-26 | 2024-11-05 |
| llms-smart-contract-vulnerability | 2024-06-02 | 2024-11-19 |
| context-windows-llms | 2024-06-09 | 2024-12-03 |
| supercharging-development-claude-flow | 2025-08-03 | 2025-08-07 |

## Verification
`pnpm build` green, 193 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)