### PR TITLE
fix(content): repoint moved-repo links + delink private homelab (#243)

### DIFF
--- a/src/posts/2026-01-15-routellm-contextual-bandits-model-router-research.md
+++ b/src/posts/2026-01-15-routellm-contextual-bandits-model-router-research.md
@@ -142,4 +142,4 @@ If I were starting over, I'd probably skip the Preference Router and fold its lo
 - [OptiRoute: Cost-Efficient LLM Routing](https://arxiv.org/abs/2502.16696) - Cascade routing approach
 - [Cross-Attention Routing](https://arxiv.org/abs/2509.09782) - Attention-based model selection
 
-The [nexus-agents repository](https://github.com/williamzujkowski/nexus-agents) implements the full pipeline. The routing code lives in `src/cli-adapters/composite-router.ts` and the bandit in `src/cli-adapters/linucb-bandit.ts`.
+The [nexus-agents repository](https://github.com/nexus-substrate/nexus-agents) implements the full pipeline. The routing code lives in `src/cli-adapters/composite-router.ts` and the bandit in `src/cli-adapters/linucb-bandit.ts`.

--- a/src/posts/2026-01-28-consensus-voting-ai-models-multi-agent.md
+++ b/src/posts/2026-01-28-consensus-voting-ai-models-multi-agent.md
@@ -166,7 +166,7 @@ After roughly six months of multi-model consensus voting across 500+ proposals:
 
 **Voting builds an audit trail.** Every consensus vote produces a record: who voted, how, why, at what confidence. When something goes wrong six months later, I can look back and understand the decision context. This is probably the most underrated benefit.
 
-The [nexus-agents repository](https://github.com/williamzujkowski/nexus-agents) implements the full consensus engine. The voting code lives in `src/consensus/engine.ts`. If you want to try multi-model voting on your own proposals, the CLI exposes it directly: `nexus-agents vote --proposal "your proposal" --strategy supermajority`.
+The [nexus-agents repository](https://github.com/nexus-substrate/nexus-agents) implements the full consensus engine. The voting code lives in `src/consensus/engine.ts`. If you want to try multi-model voting on your own proposals, the CLI exposes it directly: `nexus-agents vote --proposal "your proposal" --strategy supermajority`.
 
 ## Papers Referenced
 

--- a/src/posts/2026-02-09-building-nexus-agents-multi-model-orchestration.md
+++ b/src/posts/2026-02-09-building-nexus-agents-multi-model-orchestration.md
@@ -14,7 +14,7 @@ readingTime: "12 min read"
 
 About a year ago, I started building a routing script in my homelab because I was tired of switching between AI models manually. Claude produced better architecture docs. Gemini handled broad research faster. Codex was solid for focused code generation. I wanted one system that could pick the right model for each task automatically.
 
-That routing script grew into [nexus-agents](https://github.com/williamzujkowski/nexus-agents), a multi-model orchestration platform built on published research from roughly 68 arXiv papers. Consensus voting, graph workflows, a plugin pipeline, adaptive bandit routing, a full TUI. I tried probably 30 different approaches before landing on the architecture that stuck. Here's what I found.
+That routing script grew into [nexus-agents](https://github.com/nexus-substrate/nexus-agents), a multi-model orchestration platform built on published research from roughly 68 arXiv papers. Consensus voting, graph workflows, a plugin pipeline, adaptive bandit routing, a full TUI. I tried probably 30 different approaches before landing on the architecture that stuck. Here's what I found.
 
 ## The Problem With Single-Model Workflows
 
@@ -288,6 +288,6 @@ The AgentPlanner (code-named AOrchestra) is the newest component, drawing from [
 
 To be clear about what's production-tested versus experimental: the five-stage router, consensus voting, graph workflows, and security pipeline are all running daily. I use them to develop nexus-agents itself. AOrchestra and higher-order voting are newer, behind feature flags, and haven't seen enough traffic to measure their impact yet. The adaptive LinUCB routing is somewhere in between. It runs in production but I'm honestly not sure how much it improves over static weights. Maybe it plateaus quickly, maybe it keeps improving. Time will tell.
 
-The [codebase is open source](https://github.com/williamzujkowski/nexus-agents). If you're interested in multi-model orchestration, want to see how consensus voting works in practice, or need a reference implementation for MCP server development, take a look.
+The [codebase is open source](https://github.com/nexus-substrate/nexus-agents). If you're interested in multi-model orchestration, want to see how consensus voting works in practice, or need a reference implementation for MCP server development, take a look.
 
 Building this taught me that the future of AI-assisted development isn't about picking the best model. It's about building systems that use the right model for each piece of the problem. And backing those systems with real research, not vibes.

--- a/src/posts/2026-03-21-trivy-supply-chain-compromise-ai-assisted-investigation.md
+++ b/src/posts/2026-03-21-trivy-supply-chain-compromise-ai-assisted-investigation.md
@@ -24,7 +24,7 @@ The malicious `entrypoint.sh` harvested CI environment variables, runner memory,
 
 I maintain several personal repos that use `trivy-action` for security scanning — my personal site, homelab infrastructure, and various side projects. When I saw the advisory, the question was: did any CI runs execute the compromised code during the attack window?
 
-Rather than manually checking each repo, I used [nexus-agents](https://github.com/williamzujkowski/nexus-agents) — a multi-model AI orchestration tool I've been building — to help with the investigation. The AI agents:
+Rather than manually checking each repo, I used [nexus-agents](https://github.com/nexus-substrate/nexus-agents) — a multi-model AI orchestration tool I've been building — to help with the investigation. The AI agents:
 
 1. **Searched all local repos** for `trivy-action` references
 2. **Classified risk** by comparing each repo's pinned version against the known-compromised tag list
@@ -100,4 +100,4 @@ None of this is magic: it's the same `grep`, `gh api`, and `find` commands I'd r
 4. **Monitor your dependencies' security advisories.** Don't rely on social media for incident notification.
 5. **Scope your CI tokens narrowly.** Limited `GITHUB_TOKEN` scope contained the potential blast radius in my case.
 
-The repos involved in this investigation: [nexus-agents](https://github.com/williamzujkowski/nexus-agents), [mcp-standards-server](https://github.com/williamzujkowski/mcp-standards-server), [homelab](https://github.com/williamzujkowski/homelab), [machine-rites](https://github.com/williamzujkowski/machine-rites).
+The repos involved in this investigation: [nexus-agents](https://github.com/nexus-substrate/nexus-agents), [mcp-standards-server](https://github.com/williamzujkowski/mcp-standards-server), homelab (private), and [machine-rites](https://github.com/williamzujkowski/machine-rites).

--- a/src/posts/2026-04-14-signed-usb-rescue-boot-aegis-boot-persona-harness.md
+++ b/src/posts/2026-04-14-signed-usb-rescue-boot-aegis-boot-persona-harness.md
@@ -10,7 +10,7 @@ author: William Zujkowski
 
 There's a specific pain in being the "family IT person" with Secure Boot enabled on every machine. You get a call, you need to boot a rescue distro, you want to keep Secure Boot enforcing, and your options are: (a) disable Secure Boot for 30 minutes and forget to re-enable it, (b) enroll a shared MOK that effectively trusts every kernel Ventoy ever boots, or (c) pick one specific ISO and dd it onto a stick. None of those are defensible positions.
 
-[aegis-boot](https://github.com/williamzujkowski/aegis-boot) is option (d): a signed UEFI rescue environment that lets you drop any `.iso` onto a data partition and `kexec` into it, with kernel-level signature verification keeping the chain of trust intact. [aegis-hwsim](https://github.com/williamzujkowski/aegis-hwsim) is the companion project that simulates ~100 real-hardware configurations in QEMU so I can validate the full flow without waiting on physical Framework / ThinkPad / Dell / HP hardware to arrive.
+[aegis-boot](https://github.com/aegis-boot/aegis-boot) is option (d): a signed UEFI rescue environment that lets you drop any `.iso` onto a data partition and `kexec` into it, with kernel-level signature verification keeping the chain of trust intact. [aegis-hwsim](https://github.com/williamzujkowski/aegis-hwsim) is the companion project that simulates ~100 real-hardware configurations in QEMU so I can validate the full flow without waiting on physical Framework / ThinkPad / Dell / HP hardware to arrive.
 
 Both are Rust. Both ship CI that actually exercises the full pipeline. Both exist because years of system administration taught me that "works on my laptop" is the least interesting claim a tool can make about UEFI.
 
@@ -86,7 +86,7 @@ QEMU's `-smbios` flag spoofs the DMI strings the kernel reads from `/sys/class/d
 
 [fwupd's QEMU CI](https://github.com/fwupd/fwupd) and the LVFS empirical data from Richard Hughes and Mario Limonciello puts QEMU's coverage of capsule-flow bugs at roughly 60-70%. The remaining 30-40% are EC-specific, firmware-vendor-specific, reproducible only on metal.
 
-aegis-boot's scope is narrower than fwupd's — we're testing the USB rescue-stick signed-chain flow, not capsule updates. My estimate is ~80% of aegis-boot's testable failure modes reproduce in aegis-hwsim. The remaining ~20% require physical hardware shakedown, which is what [aegis-boot#51](https://github.com/williamzujkowski/aegis-boot/issues/51) tracks for v1.0.0.
+aegis-boot's scope is narrower than fwupd's — we're testing the USB rescue-stick signed-chain flow, not capsule updates. My estimate is ~80% of aegis-boot's testable failure modes reproduce in aegis-hwsim. The remaining ~20% require physical hardware shakedown, which is what [aegis-boot#51](https://github.com/aegis-boot/aegis-boot/issues/51) tracks for v1.0.0.
 
 This is a known limitation, called out in both READMEs. The thing aegis-hwsim buys you is fast iteration on the 80%. Writing a new aegis-boot feature, validating it against 11 personas, seeing the matrix go green in CI — that's a tight loop. Adding "ship it on a physical Framework and retest" to every feature would kill the cadence.
 
@@ -118,11 +118,11 @@ This mirrors what the TPM and Secure Boot specs actually say the operator should
 - Cosign-signed prebuilt binaries.
 - A Homebrew tap.
 - Attestation receipts on every flash — a Sigstore-style log of what image was flashed, what ISO catalog was included, what keys were enrolled.
-- Real-hardware shakedown validated on Alpine + Ubuntu under Secure Boot enforcing ([aegis-boot#109](https://github.com/williamzujkowski/aegis-boot/issues/109)).
+- Real-hardware shakedown validated on Alpine + Ubuntu under Secure Boot enforcing ([aegis-boot#109](https://github.com/aegis-boot/aegis-boot/issues/109)).
 
 **aegis-hwsim** is in Phase 1: CI exercises the full QEMU + OVMF + swtpm pipeline against the 11-persona library on every PR via the `qemu-boots-ovmf` smoke scenario. The roadmap adds more scenarios (MOK enrollment, kexec signature rejection, attestation roundtrip) and more personas (older ThinkPads with TPM 1.2, non-x86 reference platforms).
 
-v1.0.0 for aegis-boot is gated on a multi-vendor physical shakedown per [aegis-boot#51](https://github.com/williamzujkowski/aegis-boot/issues/51). I'll post a follow-up once that clears.
+v1.0.0 for aegis-boot is gated on a multi-vendor physical shakedown per [aegis-boot#51](https://github.com/aegis-boot/aegis-boot/issues/51). I'll post a follow-up once that clears.
 
 ## Numbers
 
@@ -148,7 +148,7 @@ v1.0.0 for aegis-boot is gated on a multi-vendor physical shakedown per [aegis-b
 
 ## Try it
 
-- [aegis-boot v0.13.0](https://github.com/williamzujkowski/aegis-boot/releases/latest) — signed prebuilt binaries. Install one-liner in the README.
+- [aegis-boot v0.13.0](https://github.com/aegis-boot/aegis-boot/releases/latest) — signed prebuilt binaries. Install one-liner in the README.
 - [aegis-hwsim](https://github.com/williamzujkowski/aegis-hwsim) — clone, `cargo test`, add a persona.
 
 If you own a laptop that isn't in the persona library and aegis-boot passes its shakedown on it, I'd love the persona contribution. A YAML file with your DMI strings, Secure Boot posture, and TPM version is the minimum viable pull request.

--- a/src/posts/2026-04-16-repo-health-report-six-dimension-hygiene-scores.md
+++ b/src/posts/2026-04-16-repo-health-report-six-dimension-hygiene-scores.md
@@ -79,7 +79,7 @@ The tradeoff: the tool can't assess code-level quality. It sees that a test runn
 
 ## The AI flag
 
-There's an optional `--ai` flag that hands findings to a [nexus-agents](https://github.com/williamzujkowski/nexus-agents) session for deeper analysis:
+There's an optional `--ai` flag that hands findings to a [nexus-agents](https://github.com/nexus-substrate/nexus-agents) session for deeper analysis:
 
 ```sh
 npx repo-health-report owner/repo --ai

--- a/src/posts/2026-04-18-nexus-agents-april-month-of-modularization.md
+++ b/src/posts/2026-04-18-nexus-agents-april-month-of-modularization.md
@@ -12,7 +12,7 @@ seriesOrder: 4
 
 The visible work today was extracting SWE-bench out of nexus-agents into its own standalone package with a shared `BenchmarkAdapter` contract. The whole arc took about six hours across three npm releases. That speed wasn't an accident — it was possible because of three weeks of invisible work that preceded it.
 
-This post covers the whole April 2026 arc on [nexus-agents](https://github.com/williamzujkowski/nexus-agents). The extraction is the capstone. The governance, skills, pipeline discipline, and security hardening that came before are the actual story.
+This post covers the whole April 2026 arc on [nexus-agents](https://github.com/nexus-substrate/nexus-agents). The extraction is the capstone. The governance, skills, pipeline discipline, and security hardening that came before are the actual story.
 
 ## The shape of the month
 
@@ -217,6 +217,6 @@ Replaced the `RouterLike` cast in the pipeline with a proper structural adapter.
 - [nexus-eval-template](https://github.com/williamzujkowski/nexus-eval-template) — click "Use this template"
 - [nexus-eval-swebench](https://github.com/williamzujkowski/nexus-eval-swebench) — `npx nexus-eval-swebench --variant lite --limit 5`
 
-The extraction epic is [nexus-agents#1960](https://github.com/williamzujkowski/nexus-agents/issues/1960). All six sub-issues are closed. Follow-ups — Docker harness integration for real pass/fail, HumanEval and MBPP extractions — will file new issues against the standalone repos as they're prioritized.
+The extraction epic is [nexus-agents#1960](https://github.com/nexus-substrate/nexus-agents/issues/1960). All six sub-issues are closed. Follow-ups — Docker harness integration for real pass/fail, HumanEval and MBPP extractions — will file new issues against the standalone repos as they're prioritized.
 
 The arc I care about more is the one that made this possible. Three weeks of rigor, governance, and release hygiene turned "extract a benchmark" from a multi-day refactor into an afternoon. If you're looking at your own monorepo wondering where to start, start with the boring preconditions. The extraction itself is easy when the rest of the work has been done.


### PR DESCRIPTION
Closes #243.

## What
`nexus-agents` and `aegis-boot` were transferred to GitHub **orgs**. GitHub's transfer redirect handles repo roots but not deep paths, so the issue deep-links 404'd for readers. Verified via authenticated `gh api` that the issues exist at the new org paths (all 200), then repointed every `github.com` link to those two repos across **6 posts**:

- `github.com/williamzujkowski/nexus-agents…` → `github.com/nexus-substrate/nexus-agents…`
- `github.com/williamzujkowski/aegis-boot…` → `github.com/aegis-boot/aegis-boot…`

Plus: **delinked `homelab`** in the trivy post — that repo is **private** (`gh api private=true`), so the link 404s for everyone. Now reads `homelab (private)` as plain text.

## Diagnosis note
The original "broken" verdicts were partly GitHub **anonymous rate-limiting** (the #240 class of false positive) — but the genuine root cause for the deep links is the org transfer, confirmed via the authenticated API (`html_url` points at the org). The repo-root links still redirect today, but I updated them too for durability.

## Verification
- All canonical org URLs return 200 (repo roots, issues #1960/#51/#109, releases/latest)
- `pnpm build` green, 193 pages
- No `williamzujkowski/{nexus-agents,aegis-boot}` github links remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)