### PR TITLE
fix: broken cross-links, robots sitemap, unused fonts (discovery sweep)

### DIFF
--- a/astro-site/package.json
+++ b/astro-site/package.json
@@ -30,8 +30,6 @@
     "@astrojs/svelte": "^8.0.0",
     "@fontsource-variable/fraunces": "^5.2.9",
     "@fontsource-variable/inter": "^5.2.8",
-    "@fontsource-variable/jetbrains-mono": "^5.2.8",
-    "@fontsource-variable/newsreader": "^5.2.10",
     "@fontsource/ibm-plex-mono": "^5.2.7",
     "astro": "^6.4.8",
     "markdown-it": "^14.2.0",

--- a/astro-site/pnpm-lock.yaml
+++ b/astro-site/pnpm-lock.yaml
@@ -31,12 +31,6 @@ importers:
       '@fontsource-variable/inter':
         specifier: ^5.2.8
         version: 5.2.8
-      '@fontsource-variable/jetbrains-mono':
-        specifier: ^5.2.8
-        version: 5.2.8
-      '@fontsource-variable/newsreader':
-        specifier: ^5.2.10
-        version: 5.2.10
       '@fontsource/ibm-plex-mono':
         specifier: ^5.2.7
         version: 5.2.7
@@ -426,12 +420,6 @@ packages:
 
   '@fontsource-variable/inter@5.2.8':
     resolution: {integrity: sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==}
-
-  '@fontsource-variable/jetbrains-mono@5.2.8':
-    resolution: {integrity: sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q==}
-
-  '@fontsource-variable/newsreader@5.2.10':
-    resolution: {integrity: sha512-MdI2iRwrqWpMOU/2aV2BgfZ4dJNlj/XlYaY8Zb7t87mWqHskYW0XiUANkt1cyOCiEfW2VQ0bQ5vZgGPp6B2B4w==}
 
   '@fontsource/ibm-plex-mono@5.2.7':
     resolution: {integrity: sha512-MKAb8qV+CaiMQn2B0dIi1OV3565NYzp3WN5b4oT6LTkk+F0jR6j0ZN+5BKJiIhffDC3rtBULsYZE65+0018z9w==}
@@ -3265,10 +3253,6 @@ snapshots:
   '@fontsource-variable/fraunces@5.2.9': {}
 
   '@fontsource-variable/inter@5.2.8': {}
-
-  '@fontsource-variable/jetbrains-mono@5.2.8': {}
-
-  '@fontsource-variable/newsreader@5.2.10': {}
 
   '@fontsource/ibm-plex-mono@5.2.7': {}
 

--- a/astro-site/public/robots.txt
+++ b/astro-site/public/robots.txt
@@ -3,4 +3,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://williamzujkowski.github.io/sitemap.xml
+Sitemap: https://williamzujkowski.github.io/sitemap-index.xml

--- a/astro-site/src/pages/projects.astro
+++ b/astro-site/src/pages/projects.astro
@@ -25,7 +25,7 @@ import BaseLayout from '@layouts/BaseLayout.astro';
 
     <h2>Remarque</h2>
     <p>
-      A typography-first design system for editorial, technical, and personal web projects. Three fonts (Newsreader, Inter, JetBrains Mono), OKLCH colors, 17px body text, 46rem reading column. AI-native — designed to be consumed by Claude Code, Cursor, and Copilot with zero aesthetic drift. This site is built with it.
+      A typography-first design system for editorial, technical, and personal web projects. Three fonts (Fraunces, Inter, IBM Plex Mono), OKLCH colors, 17px body text, 46rem reading column. AI-native — designed to be consumed by Claude Code, Cursor, and Copilot with zero aesthetic drift. This site is built with it.
     </p>
     <p>
       <a href="https://github.com/williamzujkowski/remarque">github.com/williamzujkowski/remarque</a> · <a href="https://williamzujkowski.github.io/remarque/">demo</a>

--- a/src/posts/2026-04-14-signed-usb-rescue-boot-aegis-boot-persona-harness.md
+++ b/src/posts/2026-04-14-signed-usb-rescue-boot-aegis-boot-persona-harness.md
@@ -153,4 +153,4 @@ v1.0.0 for aegis-boot is gated on a multi-vendor physical shakedown per [aegis-b
 
 If you own a laptop that isn't in the persona library and aegis-boot passes its shakedown on it, I'd love the persona contribution. A YAML file with your DMI strings, Secure Boot posture, and TPM version is the minimum viable pull request.
 
-Security hygiene is a running thread across everything I've shipped this month. The OSSF Scorecard work, CVE patching, and CodeQL cleanup on nexus-agents lives in the [modularization post](/posts/nexus-agents-april-month-of-modularization/). Same posture, different layer of the stack.
+Security hygiene is a running thread across everything I've shipped this month. The OSSF Scorecard work, CVE patching, and CodeQL cleanup on nexus-agents lives in the [modularization post](/posts/2026-04-18-nexus-agents-april-month-of-modularization/). Same posture, different layer of the stack.

--- a/src/posts/2026-04-16-repo-health-report-six-dimension-hygiene-scores.md
+++ b/src/posts/2026-04-16-repo-health-report-six-dimension-hygiene-scores.md
@@ -132,6 +132,6 @@ npx repo-health-report <your-own-repo>  # humbling, recommended
 
 The [source](https://github.com/williamzujkowski/repo-health-report) is on GitHub. The methodology is explicitly a work in progress — I'll take PRs and issues on the scoring heuristics. The findings it surfaces are not WIP. They're consistent and they're fixable.
 
-I applied these findings to nexus-agents itself. The OSSF Scorecard improvements (7.1 → 9+), CVE patches, CodeQL findings closed, and `validatePath` consolidation that landed in April are covered in the [modularization post](/posts/nexus-agents-april-month-of-modularization/). If you want a worked example of how the dimensions here translate into actual cleanup work, that's the follow-up.
+I applied these findings to nexus-agents itself. The OSSF Scorecard improvements (7.1 → 9+), CVE patches, CodeQL findings closed, and `validatePath` consolidation that landed in April are covered in the [modularization post](/posts/2026-04-18-nexus-agents-april-month-of-modularization/). If you want a worked example of how the dimensions here translate into actual cleanup work, that's the follow-up.
 
 Start with the Security dimension. That's where the biggest reduction in risk for the lowest effort lives. The hygiene is cheap. Skipping it isn't.

--- a/src/posts/2026-04-18-nexus-agents-april-month-of-modularization.md
+++ b/src/posts/2026-04-18-nexus-agents-april-month-of-modularization.md
@@ -31,7 +31,7 @@ Seven releases landed in that window: v2.30.x through v2.33.2. Most were patch b
 
 ## Why modularization now
 
-The immediate trigger was packaging hygiene. A `repo-health-report` pass (covered in the [follow-up post](/posts/repo-health-report-six-dimension-hygiene-scores/)) flagged that nexus-agents' npm tarball shipped 1.3MB of benchmark code that external users didn't need. SWE-bench alone was 840KB across 143 files.
+The immediate trigger was packaging hygiene. A `repo-health-report` pass (covered in the [follow-up post](/posts/2026-04-16-repo-health-report-six-dimension-hygiene-scores/)) flagged that nexus-agents' npm tarball shipped 1.3MB of benchmark code that external users didn't need. SWE-bench alone was 840KB across 143 files.
 
 The deeper trigger was that the benchmarks had started coupling to nexus-agents' release cadence. Every SWE-bench iteration required a nexus-agents version bump. Every nexus-agents release risked breaking benchmark CI. The two things were connected by history, not by design.
 


### PR DESCRIPTION
Quick safe fixes surfaced by a proactive QA discovery sweep (read-only subagent). All verified against the build.

### Broken internal cross-links (reader-facing 404s)
Three mutual follow-up links between the April posts pointed at **date-stripped** slugs (`/posts/<slug>/`), but post URLs are date-prefixed, so they 404:
- `repo-health-report…:135` and `aegis-boot…:156` → `/posts/2026-04-18-nexus-agents-april-month-of-modularization/`
- `nexus-agents…:34` → `/posts/2026-04-16-repo-health-report-six-dimension-hygiene-scores/`

### robots.txt → wrong sitemap
`robots.txt` advertised `/sitemap.xml`, but `@astrojs/sitemap` emits **`sitemap-index.xml`** (confirmed in `dist/`). Crawlers following robots.txt hit a 404. Fixed the filename.

### Unused fonts + inaccurate blurb
Removed two **unused** font deps (`@fontsource-variable/jetbrains-mono`, `@fontsource-variable/newsreader`) — only Inter, Fraunces, and IBM Plex Mono are imported. Also corrected `projects.astro`'s design-system blurb, which claimed "Three fonts (Newsreader, Inter, JetBrains Mono)" while the card says "This site is built with it" and the site actually ships **Fraunces, Inter, IBM Plex Mono**. _(If that blurb was meant to describe Remarque's upstream defaults rather than this site, it's a one-line revert.)_

### Verification
`pnpm build` green, 193 pages; cross-link targets + `sitemap-index.xml` present in `dist`; fonts gone from lockfile.

Two more discovery findings handled separately: a CI workflow PR (audits.yml missing deps → APCA audit silently never ran; a11y.yml missing pnpm cache) and a content-debt issue (~40 posts without citation sections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)