### PR TITLE
ci: install deps for APCA audit + cache pnpm in a11y workflow

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -11,12 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6
-        with:
-          node-version: '22'
       - uses: pnpm/action-setup@a0ea98b2dc7d387a59324835f7421c1d5f8357b4  # v6.0.5
         with:
           version: 10
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+          cache-dependency-path: astro-site/pnpm-lock.yaml
       - name: Install deps
         run: cd astro-site && pnpm install --frozen-lockfile
       - name: Install Playwright chromium

--- a/.github/workflows/audits.yml
+++ b/.github/workflows/audits.yml
@@ -11,9 +11,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: pnpm/action-setup@a0ea98b2dc7d387a59324835f7421c1d5f8357b4  # v6.0.5
+        with:
+          version: 10
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6
         with:
           node-version: '22'
+          cache: 'pnpm'
+          cache-dependency-path: astro-site/pnpm-lock.yaml
+      - name: Install deps (apca-w3 for the APCA audit)
+        run: cd astro-site && pnpm install --frozen-lockfile
       - name: Contrast audit (WCAG AA / AAA / 1.4.11)
         run: node astro-site/scripts/contrast-audit.mjs
       - name: Typography floor audit (USWDS 13px min)


### PR DESCRIPTION
Two CI fixes from the proactive discovery sweep.

### `audits.yml` — the APCA audit silently never ran
The job ran the four Remarque audit `.mjs` scripts straight after `setup-node` with **no `pnpm install`**. Three use only `node:` builtins (fine), but `apca-audit.mjs` imports **`apca-w3`** (a devDependency) — so that step threw "module not found" on every run, **masked by `continue-on-error: true`**. The APCA advisory audit had effectively never executed.

Fix: added `pnpm/action-setup` + `pnpm install --frozen-lockfile` (with `cache: 'pnpm'`). Verified locally that the audit now runs and **all pairs pass** the APCA draft targets.

### `a11y.yml` — no dependency caching
It set up pnpm *after* `setup-node` and never cached, so every run reinstalled deps cold (on top of Playwright + a full build — the slowest workflow). Reordered `pnpm-setup` before `setup-node` and added `cache: 'pnpm'` + `cache-dependency-path`.

Both YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)