### PR TITLE
fix: UTC date formatting + minor correctness hardening

### DIFF
--- a/astro-site/src/components/BroadsheetEntry.astro
+++ b/astro-site/src/components/BroadsheetEntry.astro
@@ -29,6 +29,7 @@ const dateStr = post.data.date.toLocaleDateString('en-US', {
   year: 'numeric',
   month: 'short',
   day: 'numeric',
+  timeZone: 'UTC', // dates are UTC-midnight; format in UTC so text matches <time datetime>
 });
 ---
 

--- a/astro-site/src/components/PostCard.astro
+++ b/astro-site/src/components/PostCard.astro
@@ -25,6 +25,7 @@ const formattedDate = post.data.date.toLocaleDateString('en-US', {
   year: 'numeric',
   month: 'short',
   day: 'numeric',
+  timeZone: 'UTC', // dates are UTC-midnight; format in UTC so text matches <time datetime>
 });
 const isoDate = post.data.date.toISOString().split('T')[0];
 ---

--- a/astro-site/src/components/RelatedPosts.astro
+++ b/astro-site/src/components/RelatedPosts.astro
@@ -40,7 +40,7 @@ const related = scored.slice(0, 3);
       <ul>
         {related.map(({ post }) => {
           const readTime = getReadingTime(post.body ?? '');
-          const dateStr = post.data.date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+          const dateStr = post.data.date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC' });
           return (
             <li>
               <a href={`/posts/${post.id}/`}>{post.data.title}</a>

--- a/astro-site/src/layouts/BaseLayout.astro
+++ b/astro-site/src/layouts/BaseLayout.astro
@@ -70,7 +70,7 @@ if (type === 'article') {
     mainEntityOfPage: { '@type': 'WebPage', '@id': canonicalUrl },
   };
   if (wordCount) blogPosting.wordCount = wordCount;
-  if (image !== '/assets/images/og/default-og.png') {
+  if (ogImage || image !== '/assets/images/og/default-og.png') {
     blogPosting.image = {
       '@type': 'ImageObject',
       url: ogImageUrl,

--- a/astro-site/src/layouts/PostLayout.astro
+++ b/astro-site/src/layouts/PostLayout.astro
@@ -34,6 +34,7 @@ const formattedDate = date.toLocaleDateString('en-US', {
   year: 'numeric',
   month: 'long',
   day: 'numeric',
+  timeZone: 'UTC', // dates are UTC-midnight; format in UTC so text matches <time datetime>
 });
 
 const humanTag = (t: string) =>

--- a/astro-site/src/lib/siteStats.ts
+++ b/astro-site/src/lib/siteStats.ts
@@ -76,5 +76,6 @@ export function formatDate(d: Date): string {
     year: 'numeric',
     month: 'long',
     day: 'numeric',
+    timeZone: 'UTC', // dates are UTC-midnight; format in UTC so text matches <time datetime>
   });
 }

--- a/astro-site/src/lib/utils.ts
+++ b/astro-site/src/lib/utils.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-import { resolve, join } from 'node:path';
+import { resolve, sep } from 'node:path';
 
 /**
  * Extract image URL from post data.
@@ -27,7 +27,7 @@ export function getValidImageUrl(image: string | { url?: string; src?: string } 
   try {
     const publicDir = resolve(process.cwd(), 'public');
     const filePath = resolve(publicDir, url.replace(/^\//, ''));
-    if (!filePath.startsWith(publicDir)) return undefined;
+    if (filePath !== publicDir && !filePath.startsWith(publicDir + sep)) return undefined;
     if (existsSync(filePath)) return url;
   } catch {
     return undefined;

--- a/astro-site/src/pages/feed.xml.ts
+++ b/astro-site/src/pages/feed.xml.ts
@@ -8,6 +8,15 @@ import { getValidImageUrl } from '@/lib/utils';
 
 const parser = new MarkdownIt();
 
+/** Escape a string for safe interpolation into an HTML attribute value. */
+function escapeHtmlAttr(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
 export async function GET(context: APIContext) {
   const posts = await getCollection('posts', ({ data }) => !data.draft);
   const sortedPosts = posts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
@@ -28,7 +37,7 @@ export async function GET(context: APIContext) {
       });
       // Prepend cover image to content if available
       const contentWithImage = imageUrl
-        ? `<p><img src="${imageUrl}" alt="${post.data.title}" width="1200" height="630" /></p>${renderedContent}`
+        ? `<p><img src="${imageUrl}" alt="${escapeHtmlAttr(post.data.title)}" width="1200" height="630" /></p>${renderedContent}`
         : renderedContent;
 
       return {

--- a/astro-site/src/pages/og/[slug].png.ts
+++ b/astro-site/src/pages/og/[slug].png.ts
@@ -13,6 +13,7 @@ export const GET: APIRoute = async ({ props }) => {
     year: 'numeric',
     month: 'long',
     day: 'numeric',
+    timeZone: 'UTC', // dates are UTC-midnight; format in UTC for consistency
   });
   const tag = post.data.tags?.[0];
   const subtitle = tag ? `${date} · ${tag}` : date;


### PR DESCRIPTION
Findings from a deep-correctness discovery pass (read-only subagent), all verified.

### Timezone off-by-one (main fix)
Post dates use **date-only** frontmatter (`date: 2024-06-11`), which `z.coerce.date()` parses as **UTC midnight**. The `<time datetime>` attribute used UTC (`toISOString`), but the human-visible text used `toLocaleDateString` in the **build machine's local zone** — so any non-UTC build rendered every post date **a day earlier** than its own `datetime` attribute (and just plain wrong).

Reproduced: `TZ=America/New_York` → `2024-06-11` rendered as "June 10, 2024" while `datetime="2024-06-11"`. Production was masked only because GitHub Actions runners are UTC.

Fix: added `timeZone: 'UTC'` to all six post-date formatters — `PostLayout`, `PostCard`, `BroadsheetEntry`, `RelatedPosts`, `siteStats.formatDate`, and the OG card route. **Verified** a `TZ=America/New_York` build now renders `<time datetime="2024-06-11">June 11, 2024</time>` (consistent).

### Minor hardening (same pass)
- **Dead import:** dropped unused `join` from `lib/utils.ts` (clears the long-standing build warning).
- **Path-traversal guard:** `getValidImageUrl` now checks a separator boundary (`publicDir + sep`) rather than a bare `startsWith` prefix (a sibling like `publicsomething/` would have passed). Non-exploitable here (trusted frontmatter) but the function is explicitly a traversal guard.
- **RSS:** HTML-escape the post title interpolated into the cover-image `alt` (one current title contains `ATT&CK`).
- **JSON-LD:** `BlogPosting.image` now emits whenever a generated OG card exists (gates on `ogImage`), not only when a custom hero differs from the default.

### Verification
`pnpm build` green (including under `TZ=America/New_York`), 193 pages.

The deep pass otherwise ruled out issues in the RSS completeness/ordering, pagination/draft-leakage, 404, ThemeToggle/CodeCopy/Search listener cleanup, and OG font-subset glyph coverage (no tofu on any current title).

🤖 Generated with [Claude Code](https://claude.com/claude-code)