### PR TITLE
fix(ci): repair-links git add used a never-matching glob

### DIFF
--- a/.github/workflows/link-monitor.yml
+++ b/.github/workflows/link-monitor.yml
@@ -284,7 +284,9 @@ jobs:
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
         git checkout -b "$BRANCH"
-        git add src/posts/**/*.md
+        # Plain path, not a glob: posts sit directly in src/posts/ and the
+        # runner shell has no globstar, so 'src/posts/**/*.md' matches nothing.
+        git add src/posts
         git commit -m "fix(links): auto-repair broken links (>=95% confidence)"
         git push origin "$BRANCH"
 


### PR DESCRIPTION
Third and hopefully final layer of the link-repair onion: #258 fixed the links.json artifact crash; the forced verification run then reached `git add src/posts/**/*.md` which fatals (posts are flat in src/posts/, no globstar in the runner shell). One-line fix. Verified reasoning against the run 29668648718 logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)