### PR TITLE
feat: zine marginalia layer — hand-drawn diagrams, wobbly chrome, header theme control

### DIFF
--- a/astro-site/astro.config.mjs
+++ b/astro-site/astro.config.mjs
@@ -162,6 +162,19 @@ export default defineConfig({
       styles: ['normal', 'italic'],
       subsets: ['latin'],
     },
+    {
+      // Zine accent voice — hand-lettered marginalia ONLY. Approved usage
+      // (design-review ratified): .hand-note, 404 page, doodle captions.
+      // Never body copy, never nav/meta.
+      provider: fontProviders.fontsource(),
+      name: 'Shantell Sans',
+      cssVariable: '--font-accent',
+      fallbacks: ['Comic Sans MS', 'cursive'],
+      optimizedFallbacks: false,
+      weights: ['400 500'],
+      styles: ['normal'],
+      subsets: ['latin'],
+    },
   ],
   vite: {
     build: {
@@ -188,8 +201,12 @@ export default defineConfig({
     rehypePlugins: [
       [rehypeMermaid, {
         strategy: 'img-svg',
-        mermaidConfig: { theme: 'default' },
-        dark: { theme: 'dark' },
+        // handDrawn (rough.js) look for the zine aesthetic; fixed seed keeps
+        // builds reproducible. Colors stay baked per light/dark at build time
+        // — the reader theme deck does not propagate into diagrams (known
+        // limitation, documented in the zine-layer issue).
+        mermaidConfig: { theme: 'default', look: 'handDrawn', handDrawnSeed: 42 },
+        dark: { theme: 'dark', look: 'handDrawn', handDrawnSeed: 42 },
       }],
       rehypeMermaidDualTheme,
       rehypeScrollWrap,

--- a/astro-site/src/components/ThemeDeck.astro
+++ b/astro-site/src/components/ThemeDeck.astro
@@ -4,14 +4,32 @@
 // token values are generated + contrast-validated by scripts/theme-deck/.
 import themes from '@/data/theme-deck.json';
 
+interface Props {
+  variant?: 'footer' | 'header';
+}
+const { variant = 'footer' } = Astro.props;
+
 const darkThemes = themes.filter((t) => t.isDark);
 const lightThemes = themes.filter((t) => !t.isDark);
 ---
 
-<details class="theme-deck" id="theme-deck">
-  <summary>
-    <span class="deck-label">Terminal theme</span>
-    <span class="deck-current" id="theme-deck-current">Remarque</span>
+<details class={`theme-deck theme-deck--${variant}`} id="theme-deck">
+  <summary aria-label="Terminal theme picker">
+    {
+      variant === 'header' ? (
+        <span class="deck-mini" aria-hidden="true">
+          {/* Live tokens, deliberately: the mini swatch previews the ACTIVE palette. */}
+          <span class="deck-mini-chip" style="background: var(--color-accent)" />
+          <span class="deck-mini-chip" style="background: var(--color-fg)" />
+          <span class="deck-mini-chip" style="background: var(--color-bg-subtle)" />
+        </span>
+      ) : (
+        <>
+          <span class="deck-label">Terminal theme</span>
+          <span class="deck-current" id="theme-deck-current">Remarque</span>
+        </>
+      )
+    }
   </summary>
 
   <div class="deck-panel" role="radiogroup" aria-label="Site color theme">
@@ -139,6 +157,47 @@ const lightThemes = themes.filter((t) => !t.isDark);
     margin: 0.6rem 0 0;
     color: var(--color-muted);
   }
+
+  /* Header variant: compact swatch button, panel drops down right-aligned */
+  .theme-deck--header {
+    position: relative;
+    margin-top: 0;
+  }
+  .theme-deck--header summary {
+    padding: 0.35rem;
+    width: 2.75rem; /* match the toggle's 44px touch target */
+    height: 2.75rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 0.25rem;
+  }
+  .theme-deck--header summary::before,
+  .theme-deck--header[open] summary::before {
+    content: '';
+  }
+  .deck-mini {
+    display: inline-flex;
+    gap: 2px;
+    transform: rotate(-6deg); /* a zine-appropriate tilt */
+  }
+  .deck-mini-chip {
+    width: 0.55rem;
+    height: 0.9rem;
+    border-radius: 2px 1px 3px 1px / 1px 3px 1px 2px;
+    border: 1px solid var(--color-border-bold);
+  }
+  .theme-deck--header .deck-panel {
+    position: absolute;
+    right: 0;
+    top: calc(100% + 0.4rem);
+    width: min(22rem, calc(100vw - 2rem));
+    max-height: min(70vh, 30rem);
+    overflow-y: auto;
+    background: var(--color-bg);
+    z-index: 50;
+    box-shadow: 0 4px 16px var(--color-shadow);
+  }
 </style>
 
 <script is:inline>
@@ -216,6 +275,20 @@ const lightThemes = themes.filter((t) => !t.isDark);
         var next = options[(i + delta + options.length) % options.length];
         next.focus();
         next.click(); // arrow moves selection, matching native radio behavior
+      });
+    }
+
+    // Header popover manners: close on outside click or Escape.
+    var deck = document.getElementById('theme-deck');
+    if (deck) {
+      document.addEventListener('click', function (e) {
+        if (deck.open && !deck.contains(e.target)) deck.open = false;
+      });
+      document.addEventListener('keydown', function (e) {
+        if (e.key === 'Escape' && deck.open) {
+          deck.open = false;
+          deck.querySelector('summary').focus();
+        }
       });
     }
 

--- a/astro-site/src/layouts/BaseLayout.astro
+++ b/astro-site/src/layouts/BaseLayout.astro
@@ -1,6 +1,7 @@
 ---
 import '@/styles/global.css';
 import '@/styles/theme-deck.css'; // must follow global.css: deck tokens override Remarque defaults
+import '@/styles/zine.css'; // zine marginalia layer — last, decorates both
 import { Font } from 'astro:assets';
 import { SITE_CONFIG } from '@/lib/siteConfig';
 import Search from '@components/Search.svelte';
@@ -229,7 +230,7 @@ function isActiveLink(linkHref: string): boolean {
     <a href="#main" class="skip-to-main">Skip to main content</a>
 
     <!-- Masthead -->
-    <header role="banner" aria-label="Site header" class="site-masthead">
+    <header role="banner" aria-label="Site header" class="site-masthead zine-grain wobble-rule">
       <div class="site-masthead-inner">
         <div class="site-masthead-top">
           <div class="site-masthead-tools-left" aria-hidden="true"></div>
@@ -239,6 +240,7 @@ function isActiveLink(linkHref: string): boolean {
           </a>
           <div class="site-masthead-tools-right">
             <Search client:load />
+            <ThemeDeck variant="header" />
             <ThemeToggle />
           </div>
         </div>
@@ -264,14 +266,18 @@ function isActiveLink(linkHref: string): boolean {
     </main>
 
     <!-- Footer -->
-    <footer role="contentinfo" aria-label="Site footer" class="site-footer">
+    <footer role="contentinfo" aria-label="Site footer" class="site-footer zine-grain">
       <p>
         &copy; {currentYear} William Zujkowski.
         <a href={SITE_CONFIG.social.github}>GitHub</a> &middot;
         <a href={SITE_CONFIG.social.linkedin}>LinkedIn</a> &middot;
         <a href="/feed.xml">RSS</a>
       </p>
-      <ThemeDeck />
+      <p class="footer-theme-credit">
+        Terminal themes via
+        <a href="https://github.com/williamzujkowski/oklch-terminal-themes">oklch&#8209;terminal&#8209;themes</a>
+        (<a href="/about/#theme-credits">credits</a>) — picker lives in the masthead.
+      </p>
     </footer>
 
     <CodeCopy client:idle />

--- a/astro-site/src/layouts/BaseLayout.astro
+++ b/astro-site/src/layouts/BaseLayout.astro
@@ -167,6 +167,7 @@ function isActiveLink(linkHref: string): boolean {
     <Font cssVariable="--font-display" preload />
     <Font cssVariable="--font-body" preload />
     <Font cssVariable="--font-mono" />
+    <Font cssVariable="--font-accent" /><!-- zine accent voice; deliberately not preloaded -->
 
     <!-- Favicons -->
     <link rel="icon" type="image/svg+xml" href="/assets/images/favicon.svg" />

--- a/astro-site/src/pages/404.astro
+++ b/astro-site/src/pages/404.astro
@@ -11,7 +11,8 @@ const recentPosts = allPosts.sort((a, b) => b.data.date.getTime() - a.data.date.
   <div class="prose" style="text-align: center; margin-top: var(--space-9);">
     {/* Hand-drawn "lost packet" doodle — strokes inherit theme tokens via
         currentColor, so it repaints under every terminal theme. */}
-    <svg class="lost-doodle" viewBox="0 -8 260 158" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" role="img" aria-label="Hand-drawn doodle of a lost network packet wandering off the map">
+    {/* Decorative: the visible hand-note caption below carries the meaning. */}
+    <svg class="lost-doodle" viewBox="0 -8 260 158" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
       <!-- crumpled map outline -->
       <path d="M28 38 Q 24 34 30 30 L 96 22 Q 103 20 108 26 L 112 30 L 178 24 Q 186 22 189 30 L 196 96 Q 198 104 190 106 L 122 114 L 116 110 L 50 120 Q 41 122 39 113 Z" />
       <!-- fold creases -->

--- a/astro-site/src/pages/404.astro
+++ b/astro-site/src/pages/404.astro
@@ -9,6 +9,26 @@ const recentPosts = allPosts.sort((a, b) => b.data.date.getTime() - a.data.date.
 
 <BaseLayout title="Page Not Found" description="The page you're looking for doesn't exist." noindex>
   <div class="prose" style="text-align: center; margin-top: var(--space-9);">
+    {/* Hand-drawn "lost packet" doodle — strokes inherit theme tokens via
+        currentColor, so it repaints under every terminal theme. */}
+    <svg class="lost-doodle" viewBox="0 -8 260 158" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" role="img" aria-label="Hand-drawn doodle of a lost network packet wandering off the map">
+      <!-- crumpled map outline -->
+      <path d="M28 38 Q 24 34 30 30 L 96 22 Q 103 20 108 26 L 112 30 L 178 24 Q 186 22 189 30 L 196 96 Q 198 104 190 106 L 122 114 L 116 110 L 50 120 Q 41 122 39 113 Z" />
+      <!-- fold creases -->
+      <path d="M108 26 L 116 110" stroke-dasharray="1 5" opacity="0.6" />
+      <path d="M34 74 Q 100 62 192 66" stroke-dasharray="1 6" opacity="0.4" />
+      <!-- wandering dashed route that exits the map -->
+      <path class="doodle-accent" d="M52 96 Q 70 78 92 88 Q 116 98 126 76 Q 136 55 160 62 Q 180 68 186 50 Q 191 37 206 30 Q 220 24 232 14" stroke="currentColor" stroke-dasharray="4 7" stroke-width="2.6" />
+      <!-- the lost packet: a little envelope with worry lines, off-map -->
+      <g class="doodle-wander">
+        <rect x="222" y="6" width="26" height="18" rx="3" transform="rotate(8 235 15)" />
+        <path d="M223 9 L 235 19 L 247 8" transform="rotate(8 235 15)" />
+        <path d="M218 2 L 215 -1 M 252 4 L 256 1 M 250 26 L 254 30" opacity="0.7" />
+      </g>
+      <!-- "you are here" X ... where the route began -->
+      <path class="doodle-accent" d="M48 92 L 58 102 M 58 92 L 48 102" stroke="currentColor" stroke-width="3" />
+    </svg>
+    <p class="hand-note hand-note--accent">route to host lost — last seen leaving the map</p>
     <p style="font-family: var(--font-mono); font-size: var(--text-display); color: var(--color-muted); opacity: 0.4; margin: 0;">404</p>
     <h1 style="margin-top: var(--space-3);">Page not found</h1>
     <p>The page you're looking for doesn't exist or has been moved.</p>

--- a/astro-site/src/styles/zine.css
+++ b/astro-site/src/styles/zine.css
@@ -1,0 +1,151 @@
+/* Zine marginalia layer — hand-drawn accents over the Remarque system.
+ * Design-review ratified (7-0): geometry + masks + scoped texture only;
+ * body typography untouched; every color derives from theme tokens so all
+ * 14 palettes (light, dark, 12 terminal themes) keep working.
+ * Load order: global.css -> theme-deck.css -> zine.css.
+ */
+
+/* ---------- shared ingredients ---------------------------------------- */
+
+:root {
+  /* Wobbly horizontal rule, used as a mask so color stays token-driven. */
+  --zine-rule-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='7' viewBox='0 0 120 7'%3E%3Cpath d='M0 3.5 Q 8 1.5 17 3.4 T 34 3.8 T 52 2.6 T 71 4.1 T 89 3 T 106 3.9 T 120 3.2' fill='none' stroke='black' stroke-width='2.2' stroke-linecap='round'/%3E%3C/svg%3E");
+
+  /* Hand-drawn double quote mark (blockquotes). */
+  --zine-quote-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='28' height='22' viewBox='0 0 28 22'%3E%3Cpath d='M3 14 Q 2 6 9 3 Q 6 8 8 10 Q 12 10 12 14.5 Q 12 19 7.5 19 Q 3 19 3 14 Z M 17 14 Q 16 6 23 3 Q 20 8 22 10 Q 26 10 26 14.5 Q 26 19 21.5 19 Q 17 19 17 14 Z' fill='black'/%3E%3C/svg%3E");
+
+  /* Paper grain: procedural feTurbulence noise. Scoped to chrome surfaces
+   * only (never body text) per design review — token-based contrast CI
+   * cannot observe composited texture, so we keep it off reading surfaces. */
+  --zine-grain: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='240' height='240'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='240' height='240' filter='url(%23n)' opacity='0.55'/%3E%3C/svg%3E");
+}
+
+/* ---------- squiggle boxes (geometry only; radii vary per component so
+ * the wobble never reads as a uniform theme pack) ----------------------- */
+
+.callout,
+.callout-accent {
+  border: 1px solid var(--color-border-bold);
+  border-radius: 255px 15px 225px 15px / 15px 225px 15px 255px;
+}
+
+.series-nav {
+  border-radius: 15px 225px 15px 255px / 255px 15px 225px 15px;
+}
+
+.deck-panel {
+  border-radius: 225px 12px 245px 14px / 12px 245px 14px 225px;
+}
+
+pre[data-title]::before {
+  border-radius: 12px 4px 10px 5px / 4px 10px 5px 12px;
+}
+
+/* ---------- wobbly rules (mask keeps color token-driven) --------------- */
+
+.wobble-rule {
+  border: none !important;
+  position: relative;
+}
+
+.wobble-rule::after {
+  content: '';
+  position: absolute;
+  inset: auto 0 -4px 0;
+  height: 7px;
+  background: var(--color-border-bold);
+  mask: var(--zine-rule-mask) repeat-x center / 120px 7px;
+  pointer-events: none;
+}
+
+/* The nav's straight top hairline is redundant next to the masthead's
+ * wavy bottom edge — one rule is enough (and the wavy one is ours). */
+.wobble-rule .site-sections {
+  border-top: none;
+}
+
+/* Homepage issue-label hairlines become tiny wobbles too. */
+.landing-issue-label .rule {
+  background: none;
+  height: 7px;
+  mask: none;
+  -webkit-mask: var(--zine-rule-mask) repeat-x center / 60px 7px;
+  mask: var(--zine-rule-mask) repeat-x center / 60px 7px;
+  background-color: var(--color-border-bold);
+}
+
+/* ---------- blockquote quote mark -------------------------------------- */
+
+article .prose blockquote {
+  position: relative;
+  padding-top: 0.35rem;
+}
+
+article .prose blockquote::before {
+  content: '';
+  position: absolute;
+  top: -0.4rem;
+  left: -2.35rem;
+  width: 1.6rem;
+  height: 1.25rem;
+  background: var(--color-accent);
+  -webkit-mask: var(--zine-quote-mask) no-repeat center / contain;
+  mask: var(--zine-quote-mask) no-repeat center / contain;
+  opacity: 0.85;
+}
+
+/* ---------- scoped paper grain (chrome surfaces only) ------------------ */
+
+.zine-grain {
+  position: relative;
+}
+
+/* ::before, deliberately — wobble-rule owns ::after and the masthead
+ * carries both classes. */
+.zine-grain::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: var(--zine-grain);
+  mix-blend-mode: soft-light;
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+@media print {
+  .zine-grain::before { display: none; }
+}
+
+/* ---------- hand-note voice (STRICT whitelist: .hand-note, 404) -------- */
+
+.hand-note {
+  font-family: var(--font-accent);
+  font-size: 1.05rem;
+  line-height: 1.45;
+  color: var(--color-fg-muted);
+  transform: rotate(-1.2deg);
+  display: inline-block;
+}
+
+.hand-note--accent { color: var(--color-accent); }
+
+/* ---------- 404 doodle -------------------------------------------------- */
+
+.lost-doodle {
+  width: min(260px, 60vw);
+  margin-inline: auto;
+  color: var(--color-fg-muted);
+  display: block;
+}
+
+.lost-doodle .doodle-accent { color: var(--color-accent); }
+
+@media (prefers-reduced-motion: no-preference) {
+  .lost-doodle .doodle-wander {
+    animation: zine-wander 6s ease-in-out infinite alternate;
+  }
+  @keyframes zine-wander {
+    from { transform: rotate(-2deg) translateX(-2px); }
+    to { transform: rotate(2.5deg) translateX(3px); }
+  }
+}

--- a/astro-site/src/styles/zine.css
+++ b/astro-site/src/styles/zine.css
@@ -29,6 +29,12 @@
   border-radius: 255px 15px 225px 15px / 15px 225px 15px 255px;
 }
 
+/* The border shorthand above would otherwise erase global.css's accent
+ * left edge on .callout-accent (equal specificity, later file wins). */
+.callout-accent {
+  border-color: var(--color-accent);
+}
+
 .series-nav {
   border-radius: 15px 225px 15px 255px / 255px 15px 225px 15px;
 }
@@ -54,6 +60,7 @@ pre[data-title]::before {
   inset: auto 0 -4px 0;
   height: 7px;
   background: var(--color-border-bold);
+  -webkit-mask: var(--zine-rule-mask) repeat-x center / 120px 7px;
   mask: var(--zine-rule-mask) repeat-x center / 120px 7px;
   pointer-events: none;
 }
@@ -66,11 +73,9 @@ pre[data-title]::before {
 
 /* Homepage issue-label hairlines become tiny wobbles too. */
 .landing-issue-label .rule {
-  background: none;
   height: 7px;
-  mask: none;
-  -webkit-mask: var(--zine-rule-mask) repeat-x center / 60px 7px;
-  mask: var(--zine-rule-mask) repeat-x center / 60px 7px;
+  -webkit-mask: var(--zine-rule-mask) no-repeat center / 100% 7px;
+  mask: var(--zine-rule-mask) no-repeat center / 100% 7px;
   background-color: var(--color-border-bold);
 }
 

--- a/astro-site/tests/e2e/theme-deck.spec.ts
+++ b/astro-site/tests/e2e/theme-deck.spec.ts
@@ -78,7 +78,11 @@ test('base light/dark toggle clears an active deck theme', async ({ page }) => {
   await expect(page.locator('html')).not.toHaveAttribute('data-theme-deck');
   const stored = await page.evaluate(() => localStorage.getItem('themeDeck'));
   expect(stored).toBeNull();
-  await expect(page.locator('#theme-deck-current')).toHaveText('Remarque');
+  // Header variant has no text label — assert selection state instead.
+  await expect(page.locator('.deck-option[data-deck-slug=""]')).toHaveAttribute(
+    'aria-checked',
+    'true'
+  );
 });
 
 test('picking a light theme pins light mode', async ({ page }) => {


### PR DESCRIPTION
The zine layer (epic #269): hand-drawn everything, readability untouched. Design-review ratified 7-0 with all conditions applied (grain scoped to chrome only, accent font whitelisted, per-instance wobble variation, procedural art primary).

**What changed**
- All 111 Mermaid diagrams across 44 posts now render hand-drawn (rough.js via mermaid `look: 'handDrawn'`, fixed seed — build-time only, zero runtime cost)
- Theme deck promoted to a header popover (live-token swatch button) — the #274 discoverability item; footer keeps a credit line
- Wobbly masthead rule + issue-label rules (CSS mask + token background), squiggle-cornered boxes with varied radii, margin quote-glyphs on blockquotes, chrome-scoped paper grain
- Shantell Sans as `--font-accent` under a strict whitelist (.hand-note + 404)
- 404 page: hand-drawn "lost packet" doodle in currentColor (repaints under every terminal theme), reduced-motion-safe wander

**Verification**: build green, Playwright 35/35, all four Remarque design audits pass, astro check clean. Iterated visually in Chrome (Remarque dark + Dracula), including a caught-and-fixed pseudo-element collision between grain and wobble layers.

Known limitation (documented): hand-drawn diagram colors stay light/dark-baked; the reader theme deck doesn't propagate into diagrams — tracked in follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)