### PR TITLE
links: nexus-agents canonical org is nexus-substrate (#307)

### DIFF
--- a/astro-site/src/pages/projects.astro
+++ b/astro-site/src/pages/projects.astro
@@ -20,7 +20,7 @@ import BaseLayout from '@layouts/BaseLayout.astro';
       Multi-model AI orchestration platform that routes tasks to Claude, Gemini, Codex, and OpenCode based on what each model is good at. The consensus voting system — where multiple AI agents debate a proposal and vote — produces measurably better decisions than any single model alone.
     </p>
     <p>
-      <a href="https://github.com/williamzujkowski/nexus-agents">github.com/williamzujkowski/nexus-agents</a>
+      <a href="https://github.com/nexus-substrate/nexus-agents">github.com/nexus-substrate/nexus-agents</a>
     </p>
 
     <h2>Remarque</h2>

--- a/src/projects/nexus-agents.md
+++ b/src/projects/nexus-agents.md
@@ -1,7 +1,7 @@
 ---
 title: "Nexus Agents"
-description: "One tool to coordinate Claude, Gemini, Codex, and OpenCode. Routes tasks to specialized experts that collaborate on complex problems."
-url: "https://github.com/williamzujkowski/nexus-agents"
+description: "Autonomic control plane for AI coding agents with adversarial review, tamper-evident audit, and closed-loop routing."
+url: "https://github.com/nexus-substrate/nexus-agents"
 category: "ai"
 tags: ["typescript", "mcp", "multi-agent", "orchestration"]
 featured: true
@@ -9,4 +9,4 @@ status: "active"
 order: 2
 ---
 
-Multi-model AI orchestration with 24 MCP tools, 10 expert types, and 11 workflow templates. Features consensus voting, adaptive routing with circuit breakers, and graph-based workflow execution.
+Nexus Agents gives Claude Code, Codex, Gemini, and OpenCode one control plane for routing work, checking it before it ships, and recording decisions in a tamper-evident audit trail. It uses outcome telemetry and human-gated tuning to improve future routing without turning agent operations into hand-maintained glue.


### PR DESCRIPTION
Owner-confirmed canonical org. Two legacy links updated (project entry + hand-written projects page); post links were already canonical. Description refreshed from the live repo. Build green. Closes #307.

🤖 Generated with [Claude Code](https://claude.com/claude-code)