### PR TITLE
fix(theme-deck): theme picker overflowed the viewport on mobile

### DIFF
--- a/astro-site/src/components/ThemeDeck.astro
+++ b/astro-site/src/components/ThemeDeck.astro
@@ -198,6 +198,22 @@ const lightThemes = themes.filter((t) => !t.isDark);
     z-index: 50;
     box-shadow: 0 4px 16px var(--color-shadow);
   }
+
+  /* On narrow viewports the swatch button sits mid-masthead, so a
+     button-anchored dropdown (right: 0) runs off the left edge. Drop the
+     button as the anchor and position the panel against the masthead
+     instead, spanning the width with even margins so it always fits. */
+  @media (max-width: 700px) {
+    .theme-deck--header {
+      position: static;
+    }
+    .theme-deck--header .deck-panel {
+      left: 1rem;
+      right: 1rem;
+      width: auto;
+      max-width: none;
+    }
+  }
 </style>
 
 <script is:inline>


### PR DESCRIPTION
The header-variant theme picker's panel ran off the left edge on narrow screens (the swatch button sits mid-masthead, and the `right:0` dropdown extended left past the viewport, clipping the DARK/LIGHT labels).

Fix: on ≤700px, anchor the panel to the masthead (not the button) and span it with 1rem margins so it always fits. Diagnosed and verified in Chrome at a sub-700px viewport — panel now sits fully on-screen (32–569px within a 616px viewport, labels intact). CSS-only, no effect on the desktop dropdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)