### PR TITLE
fix: design-review a11y + token fixes (#321 #322 #323 #325)

### DIFF
--- a/astro-site/scripts/apca-audit.mjs
+++ b/astro-site/scripts/apca-audit.mjs
@@ -72,11 +72,13 @@ const pairs = [
   ['light', 'muted', 'bg', 60, 'metadata text'],
   ['light', 'border-bold', 'bg', 30, 'interactive border (non-text)'],
   ['light', 'accent', 'bg', 60, 'accent links'],
+  ['light', 'accent-hover', 'bg', 55, 'accent hover (#323)'],
   ['dark', 'fg', 'bg', 75, 'body copy'],
   ['dark', 'fg-muted', 'bg', 75, 'body-adjacent (fg-muted)'],
   ['dark', 'muted', 'bg', 60, 'metadata text'],
   ['dark', 'border-bold', 'bg', 30, 'interactive border (non-text)'],
   ['dark', 'accent', 'bg', 60, 'accent links'],
+  ['dark', 'accent-hover', 'bg', 55, 'accent hover (#323)'],
 ];
 
 function apcaLc(theme, textKey, bgKey) {

--- a/astro-site/scripts/contrast-audit.mjs
+++ b/astro-site/scripts/contrast-audit.mjs
@@ -57,11 +57,13 @@ const required = [
   ['light', 'muted', 'bg', 4.5, 'muted text'],
   ['light', 'border-bold', 'bg', 3.0, 'interactive border (WCAG 1.4.11)'],
   ['light', 'accent', 'bg', 4.5, 'accent text'],
+  ['light', 'accent-hover', 'bg', 4.5, 'accent hover (#323)'],
   ['dark', 'fg', 'bg', 4.5, 'body text'],
   ['dark', 'fg-muted', 'bg', 7.0, 'fg-muted (AAA body-adjacent)'],
   ['dark', 'muted', 'bg', 4.5, 'muted text'],
   ['dark', 'border-bold', 'bg', 3.0, 'interactive border (WCAG 1.4.11)'],
   ['dark', 'accent', 'bg', 4.5, 'accent text'],
+  ['dark', 'accent-hover', 'bg', 4.5, 'accent hover (#323)'],
 ];
 
 let failed = 0;

--- a/astro-site/src/components/Search.svelte
+++ b/astro-site/src/components/Search.svelte
@@ -217,6 +217,7 @@
           oninput={search}
           type="text"
           placeholder="Search site..."
+          aria-label="Search posts"
           class="search-input"
         />
         <kbd class="search-esc">ESC</kbd>
@@ -317,14 +318,14 @@
     box-shadow: 0 25px 50px -12px var(--color-shadow);
     overflow: hidden;
     background-color: var(--color-surface);
-    border: 1px solid var(--color-border);
+    border: 1px solid var(--color-border-bold);
   }
   .search-input-row {
     display: flex;
     align-items: center;
     gap: 0.75rem;
     padding: 1rem;
-    border-bottom: 1px solid var(--color-border);
+    border-bottom: 1px solid var(--color-border-bold);
   }
   .search-input-icon {
     width: 1.25rem;
@@ -340,6 +341,17 @@
     outline: none;
     font: inherit;
     color: var(--color-fg);
+  }
+  /* Visible keyboard-focus indicator — same convention as the site-wide
+     `*:focus-visible` rule in global.css (2px solid accent, 2px offset).
+     Restated here (rather than relying on the global rule) because this
+     component's <style> is scoped and `.search-input { outline: none }`
+     above would otherwise leave keyboard users with zero focus indication
+     inside the dialog (#321). */
+  .search-input:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+    border-radius: 2px;
   }
   .search-esc {
     display: none;
@@ -377,7 +389,7 @@
     font-weight: 500;
   }
   .search-result-excerpt {
-    font-size: 0.875rem;
+    font-size: var(--text-meta);
     margin-top: 0.25rem;
     color: var(--color-muted);
     display: -webkit-box;
@@ -392,7 +404,7 @@
     color: var(--color-muted);
   }
   .search-state.is-hint {
-    font-size: 0.875rem;
+    font-size: var(--text-meta);
   }
 
   /* Style Pagefind highlight marks */

--- a/astro-site/src/layouts/BaseLayout.astro
+++ b/astro-site/src/layouts/BaseLayout.astro
@@ -173,8 +173,12 @@ function isActiveLink(linkHref: string): boolean {
     <link rel="icon" type="image/svg+xml" href="/assets/images/favicon.svg" />
     <link rel="apple-touch-icon" sizes="180x180" href="/assets/images/apple-touch-icon.png" />
     <link rel="manifest" href="/manifest.json" />
-    <meta name="theme-color" content="#fafaf9" media="(prefers-color-scheme: light)" />
-    <meta name="theme-color" content="#0c0a09" media="(prefers-color-scheme: dark)" />
+    <!-- theme-color must be a literal hex — browsers don't resolve CSS
+         custom properties here. Keep in sync with --color-bg in global.css:
+         light = oklch(0.95 0.015 75) -> #f5ede4, dark = oklch(0.14 0.015 140) -> #060b05.
+         Recompute (OKLCH -> linear sRGB -> hex) whenever --color-bg changes. -->
+    <meta name="theme-color" content="#f5ede4" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#060b05" media="(prefers-color-scheme: dark)" />
 
     <!-- Open Graph -->
     <meta property="og:title" content={title === 'Home' ? siteTitle : title} />

--- a/astro-site/src/styles/global.css
+++ b/astro-site/src/styles/global.css
@@ -95,7 +95,7 @@
   --color-border-bold: oklch(0.62 0.02 25);   /* 3.16:1 WCAG 1.4.11 / APCA 54.2 */
   --color-surface: oklch(0.93 0.015 75);
   --color-accent: oklch(0.48 0.15 140);       /* radar green — 5.35:1 / APCA 70.4 */
-  --color-accent-hover: oklch(0.55 0.14 75);  /* flight-deck amber (hover state) */
+  --color-accent-hover: oklch(0.50 0.10 75);  /* flight-deck amber (hover) — 5.27:1 AA, in-gamut */
   --color-code-bg: oklch(0.92 0.015 75);
   --color-code-fg: oklch(0.18 0.04 25);
   --color-selection-bg: oklch(0.88 0.10 140); /* tinted green */
@@ -414,7 +414,10 @@ a:hover { color: var(--color-accent-hover); }
   .site-masthead-top { grid-template-columns: 1fr; }
   .site-masthead-tools-left { display: none; }
   .site-masthead-tools-right { justify-self: center; }
-  .site-sections { gap: 0.15rem 0.85rem; font-size: var(--text-micro); }
+  /* Primary nav is not fine print — keep it at --text-meta (14px), the
+     site's own floor for non-timestamp text, even on mobile. Tighten gap
+     and letter-spacing instead of shrinking below --text-micro (#322). */
+  .site-sections { gap: 0.1rem 0.6rem; letter-spacing: 0.04em; }
 }
 
 /* ===== Post Article Header ===== */


### PR DESCRIPTION
Groomed batch closing four auto-filed issues. Fixes verified against current code (independently re-checked the #323 color math) plus the missing CI coverage added.

Closes #321, closes #322, closes #323, closes #325.

- **#321** search: aria-label + :focus-visible ring + --color-border-bold dialog boundary
- **#322** mobile nav no longer 13px — held at the 14px floor
- **#323** --color-accent-hover was out-of-gamut (4.27:1) -> in-gamut 5.27:1, AND added to contrast/apca audits so CI now covers it
- **#325** theme-color meta hex matches --color-bg; hardcoded search sizes -> --text-meta

Contrast + APCA + build + accent-font lint all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)