### PR TITLE
feat: consume remarque-tokens@0.3.0 — core tier + local palette (closes #324)

### DIFF
--- a/astro-site/DESIGN-DEVIATIONS.md
+++ b/astro-site/DESIGN-DEVIATIONS.md
@@ -1,0 +1,160 @@
+# Design Deviations
+
+This site consumes [`remarque-tokens`](https://www.npmjs.com/package/remarque-tokens)
+(v0.3.0) for the **core tier** — type scale, rhythm, spacing, content
+widths, radius, motion, and base prose/typography machinery — via
+`@import "remarque-tokens/core";` in `src/styles/global.css`. The
+**palette tier** (fonts, colors, `--content-reading`) stays local, as
+designed: overriding palette-tier tokens is *authored* customization, not
+a fork (see "Token Tiers" in remarque's `REMARQUE.md`).
+
+This document records every place this site's CSS differs from what the
+package ships out of the box, and why — so a future audit doesn't
+re-litigate a ratified decision as an accidental drift. Migration tracked
+in issue #324; upstream tiering proposal in remarque#47 (ratified 6-1).
+
+## 1. Core-tier token override
+
+One core-tier token is deliberately overridden locally, in
+`global.css`'s `/* ─── Core-tier deviations ─── */` block:
+
+| Token | Core (`remarque-tokens/core`) | This site | Rationale |
+|---|---|---|---|
+| `--text-display` | `clamp(2.75rem, 5.5vw, 5rem)` (44–80px) | `clamp(2.25rem, 3.5vw, 3.5rem)` (36–56px) | Editorial restraint, ratified in issue #274 ("Phosphor broadsheet," 7-0): this site's display type deliberately reads smaller/less-fluid than the package default across the two-voice (serif/mono) system. |
+
+Every other token this site previously hand-declared (~32 of them: full
+type scale minus `--text-display`, all line-heights, all letter-spacing
+except `--tracking-body` which core adds and this site didn't have, all
+three font weights, `--space-1`…`--space-9`, `--content-standard`,
+`--radius-sm`/`--radius-md`, all three motion tokens) was **byte-identical**
+to core's value and has been deleted from `global.css` — core now supplies
+it, with no shadowing duplicate left behind to rot out of sync.
+
+## 2. Palette-tier tokens (sanctioned override surface, not deviations)
+
+These stay local by design — palette tier is meant to be overridden:
+
+- **Fonts**: Fraunces (display), Source Serif 4 (body), IBM Plex Mono
+  (mono) — registered via Astro 6's Fonts API in `astro.config.mjs` and
+  injected onto the root element by `<Font>` in `BaseLayout.astro`, so
+  they are intentionally *not* redeclared as CSS custom properties in
+  `global.css` (see the comment at the top of that file).
+- **Colors**: "Palette B — Departure" (photosensitive ivory + ferric ink
+  + radar green, light; CRT phosphor on black-green, dark) — both themes
+  independently APCA/WCAG-audited (`pnpm audit`).
+- **`--content-reading: 40rem`** — **this is NOT a deviation.** It is the
+  sanctioned measure-compensation value for a Source Serif 4 body font,
+  which remarque's own docs (`REMARQUE.md`'s "Measure Compensation"
+  table) cite this site as the reference example for: core's palette
+  default of 46rem is tuned for Inter (~70ch/line); the same width in a
+  text serif runs ~86ch, well past comfortable, so this site measured its
+  actual rendered text and landed on 40rem (~71ch/line at 17px Source
+  Serif 4). Ratified alongside the rest of #274's measure/rhythm item.
+  Per remarque#47's ratification notes, this flagship adoption — palette-
+  tier-only overrides — *is* the acceptance test for the upstream tiering
+  epic.
+
+## 3. Fourth font slot: `--font-accent`
+
+Core's font system is a strict three-slot model (display / body / mono).
+This site adds a fourth, `--font-accent` (Shantell Sans, hand-lettered),
+restricted by CI (`scripts/accent-font-audit.mjs`) to `.hand-note` only —
+marginalia, never prose, nav, or meta. remarque#47 explicitly names this
+site's fourth-slot precedent as the basis for the "optional accent/
+marginalia slot" rule under consideration upstream.
+
+## 4. Zine marginalia layer (`zine.css` / `theme-deck.css`)
+
+Design-review ratified 7-0: hand-drawn geometry, masks, and scoped
+texture over the Remarque system — body typography untouched, every
+color still derives from theme tokens. Per the 2026-07-20 multi-agent
+review's governance disposition, this layer stays **site-local by
+design** (not a packaging candidate); `theme-deck.css` (14 terminal
+palettes keyed on `[data-theme-deck]`) is slated to graduate into an
+official upstream module, with this site becoming its first consumer
+instead of its only home. Neither is adopted as a package dependency in
+this migration.
+
+Specific ratified deviations from a stock Remarque presentation, all
+issue #274 ("Direction B," 7-0) unless noted:
+
+- **Share links in post footers** (`.share-row` / `.share-label` in
+  `PostLayout.astro`) — not part of core Remarque's prose machinery.
+- **Zine border-radii** — `zine.css`'s squiggle-box radii (e.g.
+  `255px 15px 225px 15px / 15px 225px 15px 255px` on `.callout`) vary
+  per component so the wobble never reads as a uniform theme pack;
+  deliberately not the flat `--radius-sm`/`--radius-md` scale.
+  Design-review ratified 7-0 (zine layer).
+- **Decorative accent usage** — e.g. the 404 doodle's wandering path
+  (`.doodle-wander`, reduced-motion-guarded — see next item) and the
+  landing-issue-label's terminal prompt glyph (`❯`), both accent-colored,
+  purely decorative.
+- **6-entry front page** — `src/pages/index.astro`'s
+  `posts.slice(0, 6)` lead + 5-entry split, not a Remarque default.
+- **404 ambient animation** — `.lost-doodle .doodle-wander`'s
+  `@keyframes zine-wander`, scoped inside
+  `@media (prefers-reduced-motion: no-preference)` in `zine.css`, so it's
+  fully inert for anyone with a reduced-motion preference (WCAG 2.3.3).
+- **Pill tag chips** — `.chip` tag/filter chips (`PostCard.astro`,
+  `tags/index.astro`) with small-caps typography and a token-driven
+  border; a presentational choice layered on top of core's typography
+  machinery, not part of it.
+
+## 5. Theming attribute convention
+
+This site keys themes on `:root.dark` / `:root.light` classes plus
+`[data-theme-deck='<name>']` for the 12 terminal-theme deck (generated,
+`theme-deck.css`). Upstream remarque-tokens keys on `[data-theme="dark"]`
+/ `[data-theme="light"]` attributes (see `tokens-palette.css`'s "Manual
+dark mode toggle support" block) and a bare `@media
+(prefers-color-scheme: dark) :root { ... }` query.
+
+This is remarque#47's item 4, "One theme-switching convention" — not yet
+unified upstream. It's the reason this migration does **not** adopt the
+imported core's own dark-tier declarations (core tier ships none — colors
+are palette tier — so no conflict there) nor treat `[data-theme]` as a
+target selector anywhere in this codebase.
+
+## 6. Audit tooling: NOT yet adopted (`npx remarque-audit`)
+
+remarque-tokens ships an `npx remarque-audit` CLI. This site does **not**
+adopt it in this migration and keeps its own five local audit scripts
+(`scripts/contrast-audit.mjs`, `apca-audit.mjs`, `typography-audit.mjs`,
+`color-token-audit.mjs`, `accent-font-audit.mjs`, run via `pnpm audit`).
+
+Reason: the upstream audit's dark-theme extraction is built around
+`[data-theme="dark"]` (and/or a bare prefers-color-scheme media query on
+`:root`) — see §5 above — and cannot parse this site's `:root.dark` /
+`:root.light` class-based theming convention. Adopting it today would
+either silently audit the wrong (or no) dark-theme block, or require
+forking the audit script, defeating the point of consuming it. This is
+explicitly blocked on remarque#47 item 4 (theme-attribute unification).
+Tracked as a follow-up once upstream unifies the convention; until then,
+the local scripts (which already parse this site's actual `:root` /
+`:root.dark` blocks directly, per-property, and independently validate
+both WCAG 2 and APCA/WCAG 3 draft contrast) remain CI's gate.
+
+## 7. `html` base-reset neutralization
+
+Core's base reset sets `html { font-family; font-size: 100%; line-height;
+color; background-color: var(--color-bg); ... }`. Every property except
+`background-color` is a no-op here — `body` already sets its own
+`font-family`/`font-size`/`line-height`/`color` explicitly to the same
+values, and nothing renders directly on `<html>`. `background-color`,
+though, would newly paint the gutter beyond `body`'s
+`max-width: var(--content-standard)` on wide viewports with
+`var(--color-bg)`, replacing the browser's own `color-scheme`-aware
+canvas default (white in light mode, UA dark in dark mode) — a real
+rendering change. `global.css`'s own `html {}` rule (unchanged selector,
+positioned after the `@import`, so it wins on equal specificity) adds an
+explicit `background-color: transparent;` — background-color's own
+initial value — to restore exactly the pre-migration appearance. See the
+inline comment in `global.css` for the full reasoning.
+
+## References
+
+- Issue #324 (this migration)
+- Issue #274 ("Phosphor broadsheet," Direction B, ratified 7-0)
+- remarque#47 ("Layered token architecture," ratified 6-1) — Token
+  Tiers doc: `remarque-tokens`'s `REMARQUE.md`
+- Issue #283 (accent-font lint, `--font-accent` allowlist)

--- a/astro-site/package.json
+++ b/astro-site/package.json
@@ -34,6 +34,7 @@
     "astro": "^6.4.8",
     "markdown-it": "^14.2.0",
     "rehype-mermaid": "^3.0.0",
+    "remarque-tokens": "^0.3.0",
     "sanitize-html": "^2.17.4",
     "satori": "^0.26.0",
     "svelte": "^5.55.7",

--- a/astro-site/pnpm-lock.yaml
+++ b/astro-site/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       rehype-mermaid:
         specifier: ^3.0.0
         version: 3.0.0(playwright@1.59.1)
+      remarque-tokens:
+        specifier: ^0.3.0
+        version: 0.3.0
       sanitize-html:
         specifier: ^2.17.4
         version: 2.17.4
@@ -2518,6 +2521,11 @@ packages:
 
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+
+  remarque-tokens@0.3.0:
+    resolution: {integrity: sha512-+4FPnuNUbnLH+O+scrbhIJj8eV0tHrS4zTgJ6EYAMf+kRwb6J3WPqWOQ/7z1pNeQ8mQ5WEKyyEWJHiBQR2EXLA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   request-light@0.5.8:
     resolution: {integrity: sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg==}
@@ -5768,6 +5776,8 @@ snapshots:
       '@types/mdast': 4.0.4
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
+
+  remarque-tokens@0.3.0: {}
 
   request-light@0.5.8: {}
 

--- a/astro-site/src/styles/global.css
+++ b/astro-site/src/styles/global.css
@@ -5,7 +5,15 @@
  * See: https://github.com/williamzujkowski/remarque
  */
 
-/* Fonts — Fraunces (display), Inter (body), IBM Plex Mono (mono) are
+/* consumes remarque-tokens v0.3.0 (core tier) + local palette layer.
+ * Core tier (type scale, rhythm, spacing, content-standard/wide, radius,
+ * motion, base resets, prose/typography machinery) is imported below;
+ * this file keeps only the PALETTE tier (fonts, colors, --content-reading)
+ * plus one documented core-tier deviation. See DESIGN-DEVIATIONS.md for
+ * the full rationale and the audit-adoption deferral (issue #324). */
+@import "remarque-tokens/core";
+
+/* Fonts — Fraunces (display), Source Serif 4 (body), IBM Plex Mono (mono) are
  * registered via Astro 6's Fonts API in astro.config.mjs and preloaded
  * by <Font> in BaseLayout.astro. That component injects the --font-*
  * custom properties on the root element itself, so they are intentionally
@@ -20,49 +28,23 @@
   navigation: auto;
 }
 
-/* ===== Remarque Design Tokens (oklch) ===== */
+/* ===== Remarque Design Tokens (oklch) =====
+ * Type scale, rhythm, spacing, --content-standard/wide, radius, and motion
+ * now come from remarque-tokens/core (imported above) — those ~33 tokens
+ * were byte-identical to this site's own values and have been deleted from
+ * here rather than kept as shadowing duplicates. What remains below is:
+ *   (1) one core-tier value this site deliberately overrides (--text-display)
+ *   (2) the palette tier — fonts (via Astro's Font API, see comment above),
+ *       colors, and --content-reading — the sanctioned customization surface
+ * See DESIGN-DEVIATIONS.md for the full token-by-token diff against core.
+ */
 
 :root {
-  /* Type scale */
-  --text-display: clamp(2.25rem, 3.5vw, 3.5rem); /* 36-56px — editorial restraint */
-  --text-title: clamp(1.875rem, 3.5vw, 3rem);
-  --text-section: clamp(1.375rem, 2.25vw, 2rem);
-  --text-body-lg: 1.1875rem;
-  --text-body: 1.0625rem;
-  --text-meta: 0.875rem;       /* 14px — USWDS minimum for small text */
-  --text-micro: 0.8125rem;     /* 13px — USWDS floor for timestamps/fine print */
+  /* ─── Core-tier deviations (see DESIGN-DEVIATIONS.md) ─── */
+  --text-display: clamp(2.25rem, 3.5vw, 3.5rem); /* 36-56px — editorial restraint; core ships clamp(2.75rem, 5.5vw, 5rem) */
 
-  /* Line heights */
-  --leading-display: 1.05;
-  --leading-title: 1.15;
-  --leading-section: 1.2;
-  --leading-body: 1.75;
-  --leading-meta: 1.5;          /* USWDS minimum for short text */
-
-  /* Letter spacing */
-  --tracking-display: -0.02em;
-  --tracking-title: -0.015em;
-  --tracking-meta: 0.02em;
-  --tracking-caps: 0.06em;
-
-  /* Font weights */
-  --weight-regular: 400;
-  --weight-medium: 500;
-  --weight-semibold: 600;
-
-  /* Spacing */
-  --space-1: 0.25rem;
-  --space-2: 0.5rem;
-  --space-3: 0.75rem;
-  --space-4: 1rem;
-  --space-5: 1.5rem;
-  --space-6: 2rem;
-  --space-7: 3rem;
-  --space-8: 4rem;
-  --space-9: 6rem;
-
-  /* Content widths.
-   * --content-reading is the single shared column width for the whole
+  /* ─── Palette tier: content width ─── */
+  /* --content-reading is the single shared column width for the whole
    * reading rail — prose AND the mono-voice surfaces that flank it
    * (breadcrumb, post header, TOC, tables, cards) all share one value so
    * the column stays visually aligned edge-to-edge; it is intentionally
@@ -72,20 +54,14 @@
    * at --text-body (17px) in Source Serif 4, 40rem ≈ 71ch — close to
    * the ~68ch editorial target (was 46rem ≈ 86ch under Inter, too wide
    * for a text serif). Adjusted conservatively, not dropped straight to
-   * the raw 38.25rem (68ch) measurement. */
+   * the raw 38.25rem (68ch) measurement. This is NOT a deviation — it's
+   * the sanctioned measure-compensation value core's own docs cite this
+   * site as the reference example for (see REMARQUE.md's "Measure
+   * Compensation" table). core's own palette default is 46rem, tuned for
+   * Inter; this site's body font is Source Serif 4, hence 40rem. */
   --content-reading: 40rem;
-  --content-standard: 72rem;
 
-  /* Border radius — restrained */
-  --radius-sm: 0.25rem;
-  --radius-md: 0.5rem;
-
-  /* Motion — minimal */
-  --motion-fast: 120ms;
-  --motion-normal: 180ms;
-  --motion-easing: ease-out;
-
-  /* Colors — Palette B "Departure": photosensitive ivory + ferric ink + radar green */
+  /* ─── Palette tier: colors — Palette B "Departure": photosensitive ivory + ferric ink + radar green ─── */
   --color-bg: oklch(0.95 0.015 75);
   --color-bg-subtle: oklch(0.93 0.015 75);
   --color-fg: oklch(0.18 0.04 25);            /* ferric red-black */
@@ -101,6 +77,24 @@
   --color-selection-bg: oklch(0.88 0.10 140); /* tinted green */
   --color-overlay: oklch(0 0 0 / 0.5);        /* modal backdrop scrim */
   --color-shadow: oklch(0 0 0 / 0.5);         /* drop-shadow color */
+
+  /* Semantic vars core's machinery (`.remarque-prose a`, `:focus-visible`,
+   * `::selection`) consumes that this site didn't previously need, since
+   * its own rules set these directly (`a { color: var(--color-accent); }`,
+   * `*:focus-visible { outline-color: var(--color-accent); }`, etc.) and
+   * win the cascade on equal specificity by coming later in this file.
+   * Defined here for core-tier compatibility. Each is a var() reference to
+   * an already-themed token above, so it resolves correctly in both themes
+   * without redeclaration — CSS custom properties are substituted lazily,
+   * using whatever --color-accent/-fg computes to AT THE ELEMENT (:root)
+   * where the more specific .dark/media-query rule also lives. Repeated
+   * explicitly in :root.dark and the dark media block below anyway, to
+   * match this file's existing convention of never relying on that
+   * indirection alone for color tokens. */
+  --color-link: var(--color-accent);
+  --color-link-hover: var(--color-accent-hover);
+  --color-focus-ring: var(--color-accent);
+  --color-selection-fg: var(--color-fg);
 
   color-scheme: light;
 }
@@ -121,6 +115,12 @@
   --color-code-fg: oklch(0.88 0.03 140);
   --color-selection-bg: oklch(0.30 0.10 140);
 
+  /* Core-consumed semantic vars (see the base :root block's comment) */
+  --color-link: var(--color-accent);
+  --color-link-hover: var(--color-accent-hover);
+  --color-focus-ring: var(--color-accent);
+  --color-selection-fg: var(--color-fg);
+
   color-scheme: dark;
 }
 
@@ -139,6 +139,12 @@
     --color-code-bg: oklch(0.17 0.015 140);
     --color-code-fg: oklch(0.88 0.03 140);
     --color-selection-bg: oklch(0.30 0.10 140);
+
+    /* Core-consumed semantic vars (see the base :root block's comment) */
+    --color-link: var(--color-accent);
+    --color-link-hover: var(--color-accent-hover);
+    --color-focus-ring: var(--color-accent);
+    --color-selection-fg: var(--color-fg);
 
     --bg: var(--color-bg);
     --text: var(--color-fg);
@@ -164,6 +170,18 @@ html {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
+  /* Neutralizes core's `html { background-color: var(--color-bg); }`
+   * (tokens-core.css base reset). Without this, the gutter beyond body's
+   * `max-width: var(--content-standard)` on wide viewports would paint
+   * --color-bg instead of the browser's own `color-scheme`-aware canvas
+   * default (white in light mode, UA dark in dark mode) — a real, if
+   * subtle, rendering change. `transparent` is background-color's own
+   * initial value, so this restores pre-migration behavior exactly.
+   * core's other new `html` declarations (font-family/font-size/
+   * line-height/color) are harmless no-ops here: `body` below already
+   * sets each of those explicitly to the same values, and nothing renders
+   * directly on `<html>` itself. See DESIGN-DEVIATIONS.md. */
+  background-color: transparent;
 }
 
 body {


### PR DESCRIPTION
## What moved to the package

`astro-site/src/styles/global.css` now does `@import "remarque-tokens/core";`
as its first statement, consuming `remarque-tokens@0.3.0`'s **core tier**:
type scale, line-heights, letter-spacing, font weights, `--space-1`…`--space-9`
(plus new `--space-10/11/12`), `--content-standard`/`--content-wide`, radius,
motion, base resets, and the `.text-*`/`.content-*`/`.remarque-prose`/
`:focus-visible` machinery.

**33 tokens** this site previously hand-declared were byte-identical to
core's values and have been **deleted** from `global.css` (no more
shadowing duplicates to drift out of sync): the full type scale except
`--text-display`, all 5 line-heights, 4 of 5 letter-spacings, all 3 font
weights, `--space-1`…`--space-9`, `--content-standard`, both radii, and
all 3 motion tokens.

## What stayed, and why

- **1 core-tier deviation**, kept under a `/* ─── Core-tier deviations ─── */`
  marker: `--text-display` (smaller/less-fluid than core's default —
  ratified editorial restraint, issue #274).
- **Palette tier** (fonts via Astro's Font API, all `--color-*`,
  `--content-reading: 40rem`) — this is the sanctioned override surface
  and stays local by design. `--content-reading` is explicitly **not** a
  deviation: it's the measure-compensation value core's own docs now cite
  this site as the reference example for.
- **4 semantic vars core's machinery consumes** (`--color-link`,
  `--color-link-hover`, `--color-focus-ring`, `--color-selection-fg`)
  were missing locally (the site's own rules set these directly and win
  the cascade already) — added as `var()` references to already-themed
  tokens, in both themes, for core-tier compatibility.
- **One neutralization**: core's `html { background-color: var(--color-bg); }`
  base reset would have painted the gutter beyond `body`'s
  `max-width: var(--content-standard)` on wide viewports — this site's own
  `html {}` rule (which wins on equal specificity by coming later) now
  explicitly sets `background-color: transparent` to restore the exact
  pre-migration canvas behavior.
- `zine.css` / `theme-deck.css` stay site-local (unchanged) — the
  2026-07-20 multi-agent review's governance disposition keeps the zine
  layer local by design; `theme-deck.css` is a graduation candidate for a
  future upstream module, not adopted as a dependency here.

Full token-by-token diff, both themes, and every ratified Direction-B
deviation (share links in post footers, zine border-radii, decorative
accent usage, 6-entry front page, reduced-motion-guarded 404 ambient
animation, pill tag chips, the fourth `--font-accent` marginalia slot,
and the `:root.dark`/`[data-theme-deck]` vs upstream `[data-theme]`
theming convention) are recorded in **`astro-site/DESIGN-DEVIATIONS.md`**.

## Audit-adoption deferral

This migration does **not** adopt upstream's `npx remarque-audit` CLI.
The site's own five local audit scripts
(`contrast-audit`/`apca-audit`/`typography-audit`/`color-token-audit`/
`accent-font-audit`, run via `pnpm audit`) stay as the CI gate.

Reason: upstream's audit keys dark-theme extraction on
`[data-theme="dark"]`, which cannot parse this site's `:root.dark` /
`:root.light` class-based theming convention (remarque#47 item 4, "one
theme-switching convention" — not yet unified upstream). Adopting the
audit today would either silently check the wrong theme block or require
forking the script. Deferred until upstream ships the unification;
tracked in DESIGN-DEVIATIONS.md §6.

## Zero-visual-change verification

- Built `main` and this branch in isolated worktrees, diffed the bundled
  `BaseLayout.*.css` (structurally, via a postcss-based pretty-printer,
  since it's minified). Of the ~217 added lines, every one is either (a)
  a core rule the site's markup doesn't use (`.text-display`,
  `.remarque-prose`, `.content-wide`, …), (b) an identical-value
  duplicate token now sourced from core instead of locally, or (c)
  losing the cascade to a same-specificity, later-declared site rule
  (`html`, `::selection`, `:focus-visible`). The only 5 "removed-position"
  lines are relocations of `@view-transition` and `--text-display`/
  `--content-reading` to their new spot in the file — same final
  computed value, confirmed unchanged.
- `pnpm build` (Astro build + pagefind indexing, 201 pages / 822k words)
  — clean, no errors.
- `pnpm audit` — all 5 scripts pass (contrast, APCA, typography floor,
  color-token, accent-font).
- `pnpm check` (astro check) — 0 errors, 0 warnings.
- `pnpm lint` — clean (1 pre-existing, unrelated warning).
- Playwright `smoke.spec.ts` (16/16 pass) and `a11y.spec.ts` +
  `theme-deck.spec.ts` (25/25 pass, light + dark) — both exercise real
  page renders and are unaffected by this change.
- Playwright `visual-baselines.spec.ts` (local-only tool; self-skips in
  CI) reported 20/24 failures against this machine's pre-existing
  baseline PNGs (captured 2026-07-19). Inspected every diff image: all
  20 are confined to pages that render the live post corpus (home,
  posts-index, and the two individual posts' "related posts" sections,
  plus 404's "recent posts") and show text-content ghosting — new posts
  published between the baseline capture and this build shifted post
  order/dates, not any style property. The **`about`** page — the one
  page in the suite with no dynamic post-list content — passed with a
  clean diff in all 4/4 theme states; if this migration had shifted any
  color, spacing, or typography value, `about` would have shown it too,
  since it shares the exact same global reset/typography rules as every
  other page. Several of the largest diffs are additionally explained by
  a pre-existing, already-documented limit noted in `global.css` itself:
  this sandbox's software-rendered (swiftshader) headless Chromium
  corrupts full-page screenshots past ~16384px tall, unrelated to any
  CSS change and already present on `main`. Given this, the built-CSS
  structural diff above — not the screenshot suite — is the authoritative
  zero-visual-change evidence for this PR; the screenshot run is included
  for transparency, not as a pass/fail gate.

Closes #324.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
