### PR TITLE
content: add Sources sections to 16 posts (closes #253)

### DIFF
--- a/src/posts/2024-09-19-biomimetic-robotics.md
+++ b/src/posts/2024-09-19-biomimetic-robotics.md
@@ -366,3 +366,17 @@ Biomimetic robotics represents a fundamental shift toward working with natural p
 ---
 
 *For those interested in exploring this field further, the [Wyss Institute for Biologically Inspired Engineering](https://wyss.harvard.edu/) at Harvard and the [Soft Robotics Toolkit](https://softroboticstoolkit.com/) provide excellent resources for both research and hands-on exploration.*
+
+## Sources
+
+- [MIT Cheetah 3: Design and Control of a Robust, Dynamic Quadruped Robot](https://journals.sagepub.com/doi/10.1177/0278364917694244) — legged robot mechanics and control
+- [MIT Cheetah robot documentation](https://ieeexplore.ieee.org/document/8593885/) — IEEE
+- [Harvard RoboBee X-Wing](https://arxiv.org/abs/2411.06382) — untethered flight, arXiv
+- [Morphological intelligence: how a robot's body shapes its cognition](https://www.nature.com/articles/s41467-021-25874-z) — Nature Communications
+- [Neuromorphic computing and vision sensors](https://www.nature.com/articles/s44172-025-00492-5) — Nature
+- [Harvard Kilobot swarm research](https://dash.harvard.edu/entities/publication/73120378-a434-6bd4-e053-0100007fdf3b) — Harvard DASH repository
+- [Morphological computation in robotic swarms](https://www.science.org/doi/10.1126/scirobotics.abo6140) — Science Robotics
+- [JPL LEMUR climbing robot](https://ieeexplore.ieee.org/document/7989643/) — IEEE
+- [Soft robotics materials research](https://www.nature.com/articles/nature14543) — Nature
+- [Wyss Institute for Biologically Inspired Engineering](https://wyss.harvard.edu/) — Harvard
+- [Soft Robotics Toolkit](https://softroboticstoolkit.com/) — open hardware/software resources

--- a/src/posts/2024-10-03-quantum-computing-defense.md
+++ b/src/posts/2024-10-03-quantum-computing-defense.md
@@ -205,42 +205,15 @@ The quantum era of defense has already begun. Understanding both its promises an
 
 *For those interested in exploring quantum defense applications further, [Quantum.gov](https://www.quantum.gov/) provides updates on national quantum initiatives, while [NIST's Post-Quantum Cryptography project](https://csrc.nist.gov/Projects/post-quantum-cryptography) offers the latest on quantum-resistant security standards.*
 
-## Academic Research & Standards
+## Sources
 
-### NIST Post-Quantum Cryptography)
-)
-1. **[NIST Post-Quantum Cryptography Standardization](https://csrc.nist.gov/projects/post-quantum-cryptography)**
-   - Official NIST PQC project and selected algorithms
-   - CRYSTALS-Kyber, CRYSTALS-Dilithium, FALCON, SPHINCS+
-
-2. **[Status Report on the Third Round of the NIST PQC Standardization Process](https://nvlpubs.nist.gov/nistpubs/ir/2022/NIST.IR.8413.pdf) (2022)
-   - Detailed analysis of selected algorithms
-   - *NIST Internal Report 8413*
-
-### Quantum Computing Research
-
-1. **[Quantum Supremacy Using a Programmable Superconducting Processor](https://www.nature.com/articles/s41586-019-1666-5) (2019)
-   - Google's quantum supremacy achievement
-   - *Nature 574, 505–510*
-
-2. **[Quantum Computing: Progress and Prospects](https://www.nap.edu/catalog/25196/quantum-computing-progress-and-prospects)** (2019)
-   - National Academies comprehensive assessment
-   - *National Academies Press*
-
-### Cryptographic Migration
-
-[CISA Post-Quantum Cryptography Initiative](https://www.cisa.gov/quantum)
-
-- **[NSA Quantum Computing FAQ](https://www.nsa.gov/Cybersecurity/Quantum-Key-Distribution-QKD-and-Quantum-Cryptography-QC/)**
-[ETSI Quantum Safe Cryptography](https://www.etsi.org/technologies/quantum-safe-cryptography)
-
-
-### Key Research Papers
-
-1. **[Shor's Algorithm](https://arxiv.org/abs/quant-ph/9508027) (1995)
-   - Peter Shor's polynomial-time factoring algorithm
-   - *Foundations of Computer Science*
-
-2. **[Post-Quantum Cryptography: Current state and quantum mitigation](https://arxiv.org/abs/2105.12707) (2021)
-   - Comprehensive survey of PQC approaches
-   - *arXiv preprint*
+- [Quantum.gov](https://www.quantum.gov/) — national quantum initiative updates
+- [NIST Post-Quantum Cryptography Standardization](https://csrc.nist.gov/projects/post-quantum-cryptography) — official NIST PQC project, CRYSTALS-Kyber, CRYSTALS-Dilithium, FALCON, SPHINCS+
+- [Status Report on the Third Round of the NIST PQC Standardization Process](https://nvlpubs.nist.gov/nistpubs/ir/2022/NIST.IR.8413.pdf) — NIST Internal Report 8413 (2022)
+- [Quantum Supremacy Using a Programmable Superconducting Processor](https://www.nature.com/articles/s41586-019-1666-5) — Nature 574, 505–510 (2019)
+- [Quantum Computing: Progress and Prospects](https://www.nap.edu/catalog/25196/quantum-computing-progress-and-prospects) — National Academies Press (2019)
+- [CISA Post-Quantum Cryptography Initiative](https://www.cisa.gov/quantum)
+- [NSA Quantum Computing FAQ](https://www.nsa.gov/Cybersecurity/Quantum-Key-Distribution-QKD-and-Quantum-Cryptography-QC/)
+- [ETSI Quantum Safe Cryptography](https://www.etsi.org/technologies/quantum-safe-cryptography)
+- [Shor's Algorithm](https://arxiv.org/abs/quant-ph/9508027) — Peter Shor's polynomial-time factoring algorithm (1995)
+- [Post-Quantum Cryptography: Current state and quantum mitigation](https://arxiv.org/abs/2105.12707) — arXiv preprint (2021)

--- a/src/posts/2024-12-03-context-windows-llms.md
+++ b/src/posts/2024-12-03-context-windows-llms.md
@@ -262,3 +262,8 @@ After three months of intensive testing in my homelab (September through Decembe
 ---
 
 *For those interested in exploring context window innovations further, [Anthropic's research on long-context language models](https://www.anthropic.com/research) provides insights into optimization techniques, while the [Efficient Transformers survey paper](https://arxiv.org/abs/2009.06732) offers comprehensive coverage of architectural improvements addressing these challenges.*
+
+## Sources
+
+- [Anthropic's research on long-context language models](https://www.anthropic.com/research)
+- [Efficient Transformers: A Survey](https://arxiv.org/abs/2009.06732) — arXiv

--- a/src/posts/2025-07-22-supercharging-claude-cli-with-standards.md
+++ b/src/posts/2025-07-22-supercharging-claude-cli-with-standards.md
@@ -464,3 +464,12 @@ The future isn't just AI-assisted development. It's AI that knows how you like t
 ---
 
 *Have you built something similar? How do you maintain consistency with AI tools? Drop me a line – I'm always looking for new patterns to steal... I mean, learn from.*
+
+## Sources
+
+- [github.com/williamzujkowski/standards](https://github.com/williamzujkowski/standards) — the standards repository this post is about
+- [Setup script](https://gist.github.com/williamzujkowski/4b740d51c2921d94fea0c4603c3a85e0) — gist
+- [NIST compliance example](https://gist.github.com/williamzujkowski/f80a7dcf4890372f4eab0018ad9afd0d) — gist
+- [CLAUDE.md](https://raw.githubusercontent.com/williamzujkowski/standards/master/docs/core/CLAUDE.md) — raw source
+- [Integration script](https://gist.github.com/williamzujkowski/4c2214e2b1843b341a4ee0012fffc0d3) — gist
+- [Automated workflow example](https://gist.github.com/williamzujkowski/dc26a695bf3f8d2b7d2e96584c0ff215) — gist

--- a/src/posts/2025-07-29-building-mcp-standards-server.md
+++ b/src/posts/2025-07-29-building-mcp-standards-server.md
@@ -570,3 +570,15 @@ Sometimes that's enough.
 *Want to contribute? The code is at [github.com/williamzujkowski/mcp-standards-server](https://github.com/williamzujkowski/mcp-standards-server). Issues and PRs welcome. Especially if you know why Redis keeps disconnecting.*
 
 *Or use the original standards repo. It still works great and doesn't require Redis.*
+
+## Sources
+
+- [Model Context Protocol (MCP)](https://docs.claude.com/en/docs/mcp)
+- [github.com/williamzujkowski/mcp-standards-server](https://github.com/williamzujkowski/mcp-standards-server) — the project this post is about
+- [Redis LRU eviction policy](https://redis.io/docs/latest/develop/reference/eviction/)
+- [ChromaDB documentation](https://docs.trychroma.com)
+- [WebSocket API — MDN](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API)
+- [React hooks reference](https://react.dev/reference/react/hooks)
+- [msgpack](https://msgpack.org) — binary serialization format
+- [Python asyncio](https://docs.python.org/3/library/asyncio.html)
+- [Top Five Causes of Scope Creep](https://www.pmi.org/learning/library/top-five-causes-scope-creep-6675) — PMI

--- a/src/posts/2025-12-24-private-cloud-homelab-proxmox-security.md
+++ b/src/posts/2025-12-24-private-cloud-homelab-proxmox-security.md
@@ -487,14 +487,12 @@ After 18 months of production use, here's what I wish I'd known from the start:
 
 Don't try to implement everything at once. Each phase builds on previous work and provides learning opportunities.
 
-## Further Exploration
+## Sources
 
-Want to dive deeper? Here are resources that helped me:
-
-- **[Proxmox VE Administration Guide](https://pve.proxmox.com/pve-docs/)** - Official documentation
-- **[TrueNAS SCALE Documentation](https://www.truenas.com/docs/scale/)** - Storage platform integration
-- **[pfSense Book](https://docs.netgate.com/pfsense/en/latest/)** - Network security configuration
-- **[Prometheus Monitoring](https://prometheus.io/docs/)** - Metrics collection and alerting
-- **[Proxmox Community Forum](https://forum.proxmox.com/)** - Active community discussions
+- [Proxmox VE Administration Guide](https://pve.proxmox.com/pve-docs/) — official documentation
+- [TrueNAS SCALE Documentation](https://www.truenas.com/docs/scale/) — storage platform integration
+- [pfSense Book](https://docs.netgate.com/pfsense/en/latest/) — network security configuration
+- [Prometheus Monitoring](https://prometheus.io/docs/) — metrics collection and alerting
+- [Proxmox Community Forum](https://forum.proxmox.com/) — active community discussions
 
 Building a private cloud takes patience and iteration. Start small, learn continuously, and don't be afraid to rebuild when you discover better approaches. The knowledge gained is worth the effort invested.

--- a/src/posts/2026-02-09-building-nexus-agents-multi-model-orchestration.md
+++ b/src/posts/2026-02-09-building-nexus-agents-multi-model-orchestration.md
@@ -289,3 +289,24 @@ To be clear about what's production-tested versus experimental: the five-stage r
 The [codebase is open source](https://github.com/nexus-substrate/nexus-agents). If you're interested in multi-model orchestration, want to see how consensus voting works in practice, or need a reference implementation for MCP server development, take a look.
 
 Building this taught me that the future of AI-assisted development isn't about picking the best model. It's about building systems that use the right model for each piece of the problem. And backing those systems with real research, not vibes.
+
+## Sources
+
+- [nexus-agents](https://github.com/nexus-substrate/nexus-agents) — the project this post is about
+- [RouteLLM: Learning to Route LLMs with Preference Data](https://arxiv.org/abs/2406.18510) — arXiv
+- [Model Context Protocol (MCP)](https://modelcontextprotocol.io/)
+- [STPA safety analysis of MCP](https://arxiv.org/abs/2601.08012) — arXiv
+- [MoMA framework](https://arxiv.org/abs/2509.07571) — arXiv
+- [PILOT](https://arxiv.org/abs/2508.21141) — arXiv
+- [Multi-agent collaboration research](https://arxiv.org/abs/2501.06322) — arXiv
+- [Voting vs. consensus protocols](https://arxiv.org/abs/2502.19130) — arXiv
+- [Free-MAD anti-conformity research](https://arxiv.org/abs/2509.11035) — arXiv
+- [Higher-order voting](https://arxiv.org/abs/2510.01499) — arXiv
+- [Self-Refine: Iterative Refinement with Self-Feedback](https://arxiv.org/abs/2303.17651) — arXiv
+- [Reflexion: Language Agents with Verbal Reinforcement Learning](https://arxiv.org/abs/2303.11366) — arXiv
+- [SATER confidence-aware routing](https://arxiv.org/abs/2510.05164) — arXiv
+- [TRINITY thinker/worker/verifier pattern](https://arxiv.org/abs/2512.04695) — arXiv
+- [A-MEM agentic memory](https://arxiv.org/abs/2502.12110) — arXiv
+- [Agent-SafetyBench evaluation](https://arxiv.org/abs/2412.14470) — arXiv
+- [Zod](https://zod.dev) — TypeScript schema validation
+- [Pick and Spin efficient orchestration](https://arxiv.org/abs/2512.22402) — arXiv

--- a/src/posts/2026-03-09-handwright-paper-to-font.md
+++ b/src/posts/2026-03-09-handwright-paper-to-font.md
@@ -78,3 +78,7 @@ Handwright runs entirely locally. Docker Compose brings up the Next.js frontend 
 ## Try It
 
 Clone the repo at [github.com/williamzujkowski/handwright](https://github.com/williamzujkowski/handwright), run `docker compose up`, and point your browser at `localhost:3000`. Print the worksheet, fill it in, photograph it, and you'll have a working font file in under a minute.
+
+## Sources
+
+- [Handwright](https://github.com/williamzujkowski/handwright) — the project this post is about

--- a/src/posts/2026-03-21-trivy-supply-chain-compromise-ai-assisted-investigation.md
+++ b/src/posts/2026-03-21-trivy-supply-chain-compromise-ai-assisted-investigation.md
@@ -99,3 +99,12 @@ None of this is magic: it's the same `grep`, `gh api`, and `find` commands I'd r
 5. **Scope your CI tokens narrowly.** Limited `GITHUB_TOKEN` scope contained the potential blast radius in my case.
 
 The repos involved in this investigation: [nexus-agents](https://github.com/nexus-substrate/nexus-agents), [mcp-standards-server](https://github.com/williamzujkowski/mcp-standards-server), homelab (private), and [machine-rites](https://github.com/williamzujkowski/machine-rites).
+
+## Sources
+
+- [Trivy security advisory GHSA-69fq-xp46-6x23](https://github.com/aquasecurity/trivy/security/advisories/GHSA-69fq-xp46-6x23) — Aqua Security
+- [Trivy under attack again: GitHub Actions compromise](https://socket.dev/blog/trivy-under-attack-again-github-actions-compromise) — Socket.dev
+- [Trivy compromised: TeamPCP supply chain attack](https://www.wiz.io/blog/trivy-compromised-teampcp-supply-chain-attack) — Wiz
+- [nexus-agents](https://github.com/nexus-substrate/nexus-agents)
+- [mcp-standards-server](https://github.com/williamzujkowski/mcp-standards-server)
+- [machine-rites](https://github.com/williamzujkowski/machine-rites)

--- a/src/posts/2026-04-02-building-us-code-tracker-law-as-git-history.md
+++ b/src/posts/2026-04-02-building-us-code-tracker-law-as-git-history.md
@@ -112,3 +112,22 @@ The code is open source under the [civic-source](https://github.com/civic-source
 - [us-code](https://github.com/civic-source/us-code) — The Git-versioned statutory data
 
 The data is CC0 public domain. The code is Apache 2.0.
+
+## Sources
+
+- [Office of the Law Revision Counsel](https://uscode.house.gov/) — publishes the United States Code as XML
+- [US Code Tracker](https://civic-source.github.io/us-code-tracker/) — the live site
+- [CourtListener](https://www.courtlistener.com/) — case law source
+- [CourtListener API](https://www.courtlistener.com/api/)
+- [Turborepo](https://turbo.build/)
+- [sync-law.yml weekly cron job](https://github.com/civic-source/us-code-tracker/blob/main/.github/workflows/sync-law.yml)
+- [USLM (United States Legislative Markup)](https://github.com/usgpo/uslm)
+- [Astro 6](https://astro.build/)
+- [Svelte 5](https://svelte.dev/)
+- [Tailwind CSS](https://tailwindcss.com/)
+- [Pagefind](https://pagefind.app/)
+- [WCAG 2.1, Understanding Contrast (Minimum)](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html)
+- [Cheerio](https://cheerio.js.org/)
+- [civic-source/us-code](https://github.com/civic-source/us-code) — the Git-versioned statutory data repository
+- [Cornell LII, US Code](https://www.law.cornell.edu/uscode)
+- [civic-source/us-code-tracker](https://github.com/civic-source/us-code-tracker) — pipeline and web app source

--- a/src/posts/2026-04-10-remarque-typography-first-design-system.md
+++ b/src/posts/2026-04-10-remarque-typography-first-design-system.md
@@ -157,3 +157,13 @@ Every decision in Remarque serves that goal. The three-font constraint prevents 
 - [Source](https://github.com/williamzujkowski/remarque) — Apache 2.0.
 
 If you're building a technical site and the default Tailwind setup feels wrong but you can't name why, the answer is usually that it's a great SaaS dashboard design applied to a context that isn't a SaaS dashboard. Remarque is what I use instead.
+
+## Sources
+
+- [Remarque](https://github.com/williamzujkowski/remarque) — the project this post is about
+- [Newsreader](https://fonts.google.com/specimen/Newsreader) — Google Fonts
+- [Inter](https://rsms.me/inter/)
+- [JetBrains Mono](https://www.jetbrains.com/lp/mono/)
+- [Practical Typography](https://practicaltypography.com/)
+- [Google Fonts and GDPR litigation](https://en.wikipedia.org/wiki/General_Data_Protection_Regulation) — Wikipedia
+- [REMARQUE.md](https://github.com/williamzujkowski/remarque/blob/main/REMARQUE.md) — design system documentation

--- a/src/posts/2026-04-12-multiboxing-everquest-linux-deterministic-wine-prefixes.md
+++ b/src/posts/2026-04-12-multiboxing-everquest-linux-deterministic-wine-prefixes.md
@@ -152,3 +152,8 @@ Every one of those is a three-line fix once you know what it is. The project is 
 - [Window management scripts](https://github.com/williamzujkowski/norrath-native/tree/main/scripts) — the `wmctrl` / `xdotool` / `hyprctl` snippets I pulled out into reusable helpers.
 
 I'm still using this daily. PRs and issues on `eqclient.ini` tuning, specific distro quirks, or alternate multibox layouts are welcome. The window-management exploration is open-ended — if you've found a clean pattern for Linux window programming I haven't, I'd love to hear about it.
+
+## Sources
+
+- [Norrath-Native](https://github.com/williamzujkowski/norrath-native) — the project this post is about
+- [Window management scripts](https://github.com/williamzujkowski/norrath-native/tree/main/scripts) — `wmctrl` / `xdotool` / `hyprctl` helpers

--- a/src/posts/2026-04-14-signed-usb-rescue-boot-aegis-boot-persona-harness.md
+++ b/src/posts/2026-04-14-signed-usb-rescue-boot-aegis-boot-persona-harness.md
@@ -152,3 +152,14 @@ v1.0.0 for aegis-boot is gated on a multi-vendor physical shakedown per [aegis-b
 If you own a laptop that isn't in the persona library and aegis-boot passes its shakedown on it, I'd love the persona contribution. A YAML file with your DMI strings, Secure Boot posture, and TPM version is the minimum viable pull request.
 
 Security hygiene is a running thread across everything I've shipped this month. The OSSF Scorecard work, CVE patching, and CodeQL cleanup on nexus-agents lives in the [modularization post](/posts/2026-04-18-nexus-agents-april-month-of-modularization/). Same posture, different layer of the stack.
+
+## Sources
+
+- [aegis-boot](https://github.com/aegis-boot/aegis-boot) — the project this post is about
+- [aegis-hwsim](https://github.com/williamzujkowski/aegis-hwsim) — hardware simulation harness
+- [LAVA](https://docs.lavasoftware.org) — Linaro Automated Validation Architecture
+- [labgrid](https://github.com/labgrid-project/labgrid) — embedded board control library
+- [fwupd's QEMU CI](https://github.com/fwupd/fwupd)
+- [aegis-boot#51](https://github.com/aegis-boot/aegis-boot/issues/51)
+- [aegis-boot#109](https://github.com/aegis-boot/aegis-boot/issues/109)
+- [aegis-boot v0.13.0 release](https://github.com/aegis-boot/aegis-boot/releases/latest)

--- a/src/posts/2026-04-16-repo-health-report-six-dimension-hygiene-scores.md
+++ b/src/posts/2026-04-16-repo-health-report-six-dimension-hygiene-scores.md
@@ -133,3 +133,9 @@ The [source](https://github.com/williamzujkowski/repo-health-report) is on GitHu
 I applied these findings to nexus-agents itself. The OSSF Scorecard improvements (7.1 → 9+), CVE patches, CodeQL findings closed, and `validatePath` consolidation that landed in April are covered in the [modularization post](/posts/2026-04-18-nexus-agents-april-month-of-modularization/). If you want a worked example of how the dimensions here translate into actual cleanup work, that's the follow-up.
 
 Start with the Security dimension. That's where the biggest reduction in risk for the lowest effort lives. The hygiene is cheap. Skipping it isn't.
+
+## Sources
+
+- [repo-health-report](https://github.com/williamzujkowski/repo-health-report) — the project this post is about
+- [nexus-agents](https://github.com/nexus-substrate/nexus-agents) — scored example repo
+- [StepSecurity's ledger of compromised workflows](https://www.stepsecurity.io/)

--- a/src/posts/2026-04-18-nexus-agents-april-month-of-modularization.md
+++ b/src/posts/2026-04-18-nexus-agents-april-month-of-modularization.md
@@ -218,3 +218,11 @@ Replaced the `RouterLike` cast in the pipeline with a proper structural adapter.
 The extraction epic is [nexus-agents#1960](https://github.com/nexus-substrate/nexus-agents/issues/1960). All six sub-issues are closed. Follow-ups — Docker harness integration for real pass/fail, HumanEval and MBPP extractions — will file new issues against the standalone repos as they're prioritized.
 
 The arc I care about more is the one that made this possible. Three weeks of rigor, governance, and release hygiene turned "extract a benchmark" from a multi-day refactor into an afternoon. If you're looking at your own monorepo wondering where to start, start with the boring preconditions. The extraction itself is easy when the rest of the work has been done.
+
+## Sources
+
+- [nexus-agents](https://github.com/nexus-substrate/nexus-agents) — the project this post is about
+- [nexus-agents v2.33.2](https://www.npmjs.com/package/nexus-agents) — npm package
+- [nexus-eval-template](https://github.com/williamzujkowski/nexus-eval-template)
+- [nexus-eval-swebench](https://github.com/williamzujkowski/nexus-eval-swebench)
+- [nexus-agents#1960](https://github.com/nexus-substrate/nexus-agents/issues/1960) — the extraction epic

--- a/src/posts/2026-05-07-patch-fast-pull-slow-defending-copy-fail-shai-hulud.md
+++ b/src/posts/2026-05-07-patch-fast-pull-slow-defending-copy-fail-shai-hulud.md
@@ -141,9 +141,7 @@ Three things keep me up.
 
 Defenders are not getting more time or attention. Attackers know that, and they have organized three attack surfaces around it: the kernel, the registry, and the scanner that was supposed to watch the other two. The honest answer to the squeeze isn't to pick a side. It's to stop pretending the sides are the same problem.
 
----
-
-*Sources used in this post:*
+## Sources
 
 - [copy.fail (CVE-2026-31431)](https://copy.fail/)
 - [Copy_Fail2: Electric Boogaloo PoC](https://github.com/0xdeadbeefnetwork/Copy_Fail2-Electric_Boogaloo)


### PR DESCRIPTION
Closes the re-scoped #253. Added a `## Sources` section to all 16 posts that had inline external citations but no dedicated section — built **entirely from each post's own existing links**, zero URLs invented.

- Independently verified no fabrication: every Sources URL was confirmed present in the original post (the 2 posts with renamed sections — quantum-computing-defense, proxmox-security — checked against main: same URL set, just relocated to a `## Sources` heading).
- Also cleaned a malformed markdown block in quantum-computing-defense and converted the shai-hulud post's italic "Sources used" line to a proper heading.
- Source counts range 1–18 per post; no frontmatter/date/content changes beyond the additions.
- Build green (201 pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)