### PR TITLE
fix(content): correct stale tsundoku counts in project entry

### DIFF
--- a/src/projects/tsundoku.md
+++ b/src/projects/tsundoku.md
@@ -1,6 +1,6 @@
 ---
 title: Tsundoku
-description: "Digital bookshelf with 3,500+ books across 29 categories. Multi-API enrichment pipeline (Open Library, Gutenberg, LibriVox, Wikipedia), search, reading progress, and stats dashboard."
+description: "Digital bookshelf with 3,584 books across 28 categories. Multi-API enrichment pipeline (Open Library, Gutenberg, LibriVox, Wikipedia), search, reading progress, and stats dashboard."
 url: https://github.com/williamzujkowski/tsundoku
 category: tools
 tags: [astro, svelte, python, reading, static-site, open-data]


### PR DESCRIPTION
Closes #336.

QA sweep found `src/projects/tsundoku.md` still citing "3,500+ books across 29 categories" while the live app and the blog post are at 3,584 / 28. Nothing user-facing changes today (`projects.astro` is hand-authored and doesn't read this collection), but the file is schema-validated at build and a stale-data trap for future edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)