### PR TITLE
ci: wire remarque token-drift check (remarque#47/#48)

### DIFF
--- a/.github/workflows/audits.yml
+++ b/.github/workflows/audits.yml
@@ -75,7 +75,7 @@ jobs:
   # step: remarque-drift isn't published to npm yet (it lands with a
   # future remarque-tokens release), so `remarque-ref` pins this call to
   # the feature branch that adds it (williamzujkowski/remarque#71). Once
-  # that release ships, drop `remarque-ref` and repoint `@feat/drift-detection`
+  # that release ships, drop `remarque-ref` and repoint `@main`
   # at a released tag — no other change needed.
   #
   # Our one core-tier deviation (--text-display, documented in
@@ -84,10 +84,10 @@ jobs:
   token-drift:
     needs: changes
     if: needs.changes.outputs.site == 'true'
-    uses: williamzujkowski/remarque/.github/workflows/token-drift.yml@feat/drift-detection
+    uses: williamzujkowski/remarque/.github/workflows/token-drift.yml@main
     permissions:
       contents: read
     with:
       css-file: astro-site/src/styles/global.css
       package-dir: astro-site
-      remarque-ref: feat/drift-detection
+      remarque-ref: main

--- a/.github/workflows/audits.yml
+++ b/.github/workflows/audits.yml
@@ -67,3 +67,27 @@ jobs:
       - name: APCA advisory (WCAG 3 draft — informational only)
         run: node astro-site/scripts/apca-audit.mjs
         continue-on-error: true
+
+  # Token-drift check against the installed remarque-tokens package
+  # (remarque#47/#48 — consensus-armed now that 2+ sites consume the
+  # package from npm; this site is #1, tsundoku is #2). Calls remarque's
+  # reusable workflow directly rather than a plain `npx remarque-drift`
+  # step: remarque-drift isn't published to npm yet (it lands with a
+  # future remarque-tokens release), so `remarque-ref` pins this call to
+  # the feature branch that adds it (williamzujkowski/remarque#71). Once
+  # that release ships, drop `remarque-ref` and repoint `@feat/drift-detection`
+  # at a released tag — no other change needed.
+  #
+  # Our one core-tier deviation (--text-display, documented in
+  # DESIGN-DEVIATIONS.md, ratified in issue #274) is expected to
+  # classify as WARN, not FAIL — verified locally, see this PR's body.
+  token-drift:
+    needs: changes
+    if: needs.changes.outputs.site == 'true'
+    uses: williamzujkowski/remarque/.github/workflows/token-drift.yml@feat/drift-detection
+    permissions:
+      contents: read
+    with:
+      css-file: astro-site/src/styles/global.css
+      package-dir: astro-site
+      remarque-ref: feat/drift-detection


### PR DESCRIPTION
## Summary

- Wires remarque's new token-drift check (williamzujkowski/remarque#71, closing the loop on remarque#47/#48 — the consensus trigger for this CI, "2-3 consuming sites," is armed: this site and tsundoku both consume `remarque-tokens` from npm) into `audits.yml`.
- New `token-drift` job, gated on the same `changes.outputs.site` path filter as the existing `remarque` job, calling `williamzujkowski/remarque/.github/workflows/token-drift.yml@feat/drift-detection` against `astro-site/src/styles/global.css`.

## Why a direct reusable-workflow reference instead of `npx remarque-drift`

`remarque-drift` isn't published to npm yet — `scripts/drift-check.mjs` lands with a future `remarque-tokens` release (see remarque#71, not yet merged). Rather than wait, this PR calls the reusable workflow directly at `@feat/drift-detection` with `remarque-ref: feat/drift-detection` (the workflow's own pre-release fallback: it checks out remarque at that ref to source the engine since the installed package here, 0.5.1, predates it). Once a release ships the bin, this becomes a one-line change: drop `remarque-ref` and repoint `@feat/drift-detection` at a released tag/SHA.

## Proof: our one core-tier deviation classifies as WARN, not FAIL

This site overrides exactly one core-tier token (`--text-display`, documented in `DESIGN-DEVIATIONS.md`, ratified in issue #274). Ran the engine locally against this exact checkout (`astro-site/src/styles/global.css`, remarque-tokens 0.5.1 installed):

```
remarque-drift — token drift check
  consumer stylesheet: astro-site/src/styles/global.css
  installed remarque-tokens: 0.5.1 (astro-site/node_modules/remarque-tokens)
  deviation doc: astro-site/DESIGN-DEVIATIONS.md

WARN — documented core-tier deviation(s) (ratified, not a build failure):
  ⚠ --text-display (light): core ships "clamp(2.75rem, 5.5vw, 5rem)", consumer defines "clamp(2.25rem, 3.5vw, 3.5rem)" — see astro-site/DESIGN-DEVIATIONS.md

INFO — palette-tier divergence(s) (sanctioned personalization):
  ℹ --content-reading (light): package default "46rem", consumer defines "40rem"
  ℹ --content-reading (dark): package default "46rem", consumer defines "40rem"
  ℹ --color-bg / --color-bg-subtle / --color-fg / --color-fg-muted / --color-muted
  ℹ --color-border / --color-border-bold / --color-surface
  ℹ --color-accent / --color-accent-hover / --color-selection-bg / --color-selection-fg
  ℹ --color-code-bg / --color-code-fg
  (full Palette B "Departure" repalette — 15 tokens, both themes where applicable)

Summary: 0 FAIL, 1 WARN, 15 INFO
```

**Exit code: `0`.** Confirms the classification rule from remarque's spec: a documented core-tier deviation warns, it does not fail the build.

## Test plan
- [x] `node <remarque-checkout>/scripts/drift-check.mjs --css-file astro-site/src/styles/global.css --package-dir astro-site` run locally — output above, exit 0
- [x] `.github/workflows/audits.yml` YAML validated (`yaml.safe_load`)
- [ ] CI run on this PR (the new `token-drift` job)

Not merging — this PR pins to remarque's unmerged `feat/drift-detection` branch until that PR lands and remarque-tokens releases a version shipping `scripts/drift-check.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
