### PR TITLE
content(uses): add Steam Deck + Steam Machine, editor back to VS Code

### DIFF
--- a/astro-site/src/pages/uses.astro
+++ b/astro-site/src/pages/uses.astro
@@ -110,6 +110,31 @@ const lastUpdatedStr = lastUpdated.toLocaleDateString('en-US', {
 
         <div class="uses-row">
           <dt>
+            <span class="uses-name">Steam Deck</span>
+            <span class="uses-meta">1 TB · first-gen LCD</span>
+          </dt>
+          <dd>
+            The original LCD model, maxed out to 1 TB. Half handheld console, half
+            pocket Linux box — it runs Arch, so a fair share of its screen time is me
+            SSH'd into the homelab from the couch. Occasionally I also play games on it.
+          </dd>
+        </div>
+
+        <div class="uses-row">
+          <dt>
+            <span class="uses-name">Steam Machine</span>
+            <span class="uses-meta">512 GB · SteamOS</span>
+          </dt>
+          <dd>
+            Valve's second swing at a living-room PC, a decade after the first Steam
+            Machines quietly flopped. The 512 GB model, just arrived — a SteamOS box
+            on the TV that doubles as one more place to check whether something
+            actually runs on Linux.
+          </dd>
+        </div>
+
+        <div class="uses-row">
+          <dt>
             <span class="uses-name">Chemex 10-cup + Baratza Encore</span>
             <span class="uses-meta">coffee · $50 + $170</span>
           </dt>
@@ -204,12 +229,14 @@ const lastUpdatedStr = lastUpdated.toLocaleDateString('en-US', {
 
         <div class="uses-row">
           <dt>
-            <span class="uses-name">Neovim</span>
+            <span class="uses-name">VS Code</span>
             <span class="uses-meta">editor</span>
           </dt>
           <dd>
-            Switched from VSCode in 2023 after getting fed up with Electron memory
-            usage. Lua config, LSP integration, terminal-native. Steep curve, worth it.
+            Left it for Neovim in 2023 over Electron's memory footprint, ran a tidy Lua
+            config for two years, and quietly came back. The AI coding tools live here
+            now, and fighting my editor to reach them stopped feeling like a principled
+            stand. The RAM it eats is a rounding error next to a browser anyway.
           </dd>
         </div>
 
@@ -356,7 +383,7 @@ const lastUpdatedStr = lastUpdated.toLocaleDateString('en-US', {
             <span class="uses-meta">inline autocomplete</span>
           </dt>
           <dd>
-            Inline completion in Neovim. Good for boilerplate, comments, and small
+            Inline completion in VS Code. Good for boilerplate, comments, and small
             refactors. Never trust it with business logic.
           </dd>
         </div>


### PR DESCRIPTION
Personal updates to the uses page:

- **Hardware:** added the **Steam Deck** (1 TB, first-gen LCD) and the new **Steam Machine** (512 GB, SteamOS), written in the house voice — the Deck as "half handheld console, half pocket Linux box," the Steam Machine as "Valve's second swing at a living-room PC, a decade after the first Steam Machines quietly flopped."
- **Editor:** back to **VS Code**. Reversed the 2023 Neovim entry (kept the round-trip honest — "quietly came back… fighting my editor to reach [the AI tools] stopped feeling like a principled stand") and fixed the GitHub Copilot entry that still read "inline completion in Neovim."

The "last updated" date refreshes automatically from the file's git mtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)