### PR TITLE
content(uses): drop GitHub Copilot entry

### DIFF
--- a/astro-site/src/pages/uses.astro
+++ b/astro-site/src/pages/uses.astro
@@ -376,17 +376,6 @@ const lastUpdatedStr = lastUpdated.toLocaleDateString('en-US', {
             work never leaves my machine.
           </dd>
         </div>
-
-        <div class="uses-row">
-          <dt>
-            <span class="uses-name">GitHub Copilot</span>
-            <span class="uses-meta">inline autocomplete</span>
-          </dt>
-          <dd>
-            Inline completion in VS Code. Good for boilerplate, comments, and small
-            refactors. Never trust it with business logic.
-          </dd>
-        </div>
       </dl>
     </section>
 


### PR DESCRIPTION
Copilot is no longer in the toolchain — coding now runs through Nexus Agents + Claude Code / OpenCode, already covered by the Claude Code (daily driver) and multi-model routing entries. Removes the stale row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)