### PR TITLE
content(about): add agentic-coding work, defender-first framing

### DIFF
--- a/astro-site/src/pages/about.astro
+++ b/astro-site/src/pages/about.astro
@@ -11,8 +11,10 @@ import themeCredits from '@/data/theme-deck-attribution.json';
     <p class="lede">
       Senior InfoSec Engineer at <a href="https://cloud.gov">Cloud.gov</a>.
       Cloud platform security, identity federation, and compliance automation —
-      the kind you can actually ship. Homelab enthusiast, reformed
-      small-business technician, perpetual tinkerer.
+      the kind you can actually ship. Lately: making AI coding agents safe
+      enough for government work, because the adversaries aren't waiting.
+      Homelab enthusiast, reformed small-business technician, perpetual
+      tinkerer.
     </p>
 
     <p class="disclaimer">Views are my own, not my employer's.</p>
@@ -41,7 +43,7 @@ import themeCredits from '@/data/theme-deck-attribution.json';
           <span class="uses-name">Cloud.gov</span>
           <span class="uses-meta">2023 – present</span>
         </dt>
-        <dd>Cloud security architecture and federal compliance for a FedRAMP Moderate platform. NIST 800-53 Rev 4 → Rev 5 transition.</dd>
+        <dd>Cloud security architecture and federal compliance for a FedRAMP Moderate platform: vulnerability management, security tooling, incident response, and the NIST 800-53 Rev 4 → Rev 5 transition. On top of the day job, initiated and lead GSA/TTS's agentic-coding assessment — building the guardrails so federal developers can use AI coding agents safely.</dd>
       </div>
       <div class="uses-row">
         <dt>
@@ -71,6 +73,8 @@ import themeCredits from '@/data/theme-deck-attribution.json';
       Automation isn't about replacing people. It's about freeing them from clicking
       buttons so they can do interesting work. AI security is about governance as much as
       tech: the hard problems are the humans, policies, and processes around the models.
+      And attackers already use AI — defenders should get it too, with guardrails instead
+      of workarounds.
     </p>
 
     <h2>Outside work</h2>

--- a/astro-site/src/pages/about.astro
+++ b/astro-site/src/pages/about.astro
@@ -43,7 +43,7 @@ import themeCredits from '@/data/theme-deck-attribution.json';
           <span class="uses-name">Cloud.gov</span>
           <span class="uses-meta">2023 – present</span>
         </dt>
-        <dd>Cloud security architecture and federal compliance for a FedRAMP Moderate platform: vulnerability management, security tooling, incident response, and the NIST 800-53 Rev 4 → Rev 5 transition. On top of the day job, initiated and lead GSA/TTS's agentic-coding assessment — building the guardrails so federal developers can use AI coding agents safely.</dd>
+        <dd>Cloud security architecture and federal compliance for a FedRAMP Moderate platform: vulnerability management, security tooling, incident response, and the NIST 800-53 Rev 4 → Rev 5 transition. On top of the day job, I lead an initiative to build the guardrails that let federal developers use AI coding agents safely.</dd>
       </div>
       <div class="uses-row">
         <dt>


### PR DESCRIPTION
The About page predated the agentic-coding assessment entirely. This adds it in three places, all at public-tier disclosure:

- **Lede:** one clause — "Lately: making AI coding agents safe enough for government work, because the adversaries aren't waiting."
- **Career → Cloud.gov:** lists the security AoRs (vulnerability management, security tooling, incident response) and adds the assessment as an on-top-of-the-day-job initiative.
- **How I think about security:** closing thesis line — attackers already use AI; defenders should get it too, with guardrails instead of workarounds.

Framing follows the role-shape rule: platform security is the primary role; the agentic work is mission-driven additional duty. No repo names, mechanisms, or counts (pre-release OPSEC tier — specifics restore when the agentic-coding repos go public).

Left alone intentionally: the theme-credits "545" count (tracked separately as a dataset-reconciliation issue across oklch-terminal-themes / works-on-my-resume).

Note: the local pre-commit build hook fails on a pre-existing ESM/CJS interop error (`parseCookie` from `cookie` inside astro's prerenderer) unrelated to this change — worth its own issue; CI here is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)