### PR TITLE
fix(build): pin cookie to shadow ambient node_modules pollution (#354)

### DIFF
--- a/astro-site/package.json
+++ b/astro-site/package.json
@@ -33,6 +33,7 @@
     "@astrojs/svelte": "^9.0.1",
     "@resvg/resvg-js": "^2.6.2",
     "astro": "^7.1.0",
+    "cookie": "^2.0.1",
     "markdown-it": "^14.3.0",
     "rehype-mermaid": "^3.0.0",
     "remarque-tokens": "^0.5.1",

--- a/astro-site/pnpm-lock.yaml
+++ b/astro-site/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       astro:
         specifier: ^7.1.0
         version: 7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.3)(rollup@4.60.4)(yaml@2.9.0)
+      cookie:
+        specifier: ^2.0.1
+        version: 2.0.1
       markdown-it:
         specifier: ^14.3.0
         version: 14.3.0


### PR DESCRIPTION
Fixes #354 — the local pre-commit build hook failing on Astro 7.

## Root cause (not a repo/Astro bug)
Astro 7's prerenderer does a bare `import { parseCookie } from 'cookie'`. The generated prerender entry lives in `astro-site/dist/` — *outside* `node_modules` — so Node resolves that bare specifier by walking **up** the directory tree. On a dev machine with a stray `node_modules` in a parent directory (here `/home/william/node_modules/cookie@0.7.2`, a transitive of home-installed LSP servers + claude-flow), it lands on the ancient CJS `cookie` that has no `parseCookie` export → `Named export 'parseCookie' not found`.

CI never hits this (clean runner, no parent-dir pollution) — which is exactly why the build/deploy stay green while the local hook fails.

## Fix
Pin `cookie ^2.0.1` as a direct dep, so `astro-site/node_modules/cookie → 2.0.1` is found before any ambient copy during the walk-up. Harmless no-op on clean environments (2.0.1 is already in the tree via astro). Verified: the pre-commit hook build now passes locally.

## Deeper cause (env, out of scope here)
The real trigger is a `node_modules` polluting `$HOME`, which silently affects every JS project under `~/git`. Recommend relocating that home-dir tooling; this PR just makes the repo robust to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)