### PR TITLE
fix(content): land the dropped #360 changes (handwright + collection-schema removal)

### DIFF
--- a/astro-site/src/content.config.ts
+++ b/astro-site/src/content.config.ts
@@ -19,18 +19,9 @@ const posts = defineCollection({
     .passthrough(),
 });
 
-const projects = defineCollection({
-  loader: glob({ pattern: '**/*.md', base: '../src/projects' }),
-  schema: z.object({
-    title: z.string(),
-    description: z.string(),
-    url: z.string(),
-    category: z.enum(['ai', 'security', 'infrastructure', 'tools']),
-    tags: z.array(z.string()).default([]),
-    featured: z.boolean().default(false),
-    status: z.enum(['active', 'experimental', 'archived']).default('active'),
-    order: z.number().default(99),
-  }),
-});
-
-export const collections = { posts, projects };
+// The `projects` collection was orphaned — nothing ever called
+// getCollection('projects'), so its markdown never rendered (the /projects
+// page is hand-authored in pages/projects.astro). Removed with its 10 source
+// files (#360) to kill the stale-data trap; the hand-written page is the
+// single source of truth.
+export const collections = { posts };

--- a/astro-site/src/pages/projects.astro
+++ b/astro-site/src/pages/projects.astro
@@ -71,6 +71,14 @@ import BaseLayout from '@layouts/BaseLayout.astro';
       <a href="https://github.com/williamzujkowski/tsundoku">github.com/williamzujkowski/tsundoku</a> · <a href="/posts/2026-02-23-building-tsundoku-digital-bookshelf/">write-up</a>
     </p>
 
+    <h2>Handwright</h2>
+    <p>
+      Turns your actual handwriting into a font. Fill out a worksheet, scan it, and Handwright traces the glyphs (OpenCV and potrace) and assembles a real <code>.ttf</code> — or strings them back into notes that look convincingly hand-written. Local-first and self-hostable, on the theory that handing your handwriting to someone else's server to generate "personal" notes rather defeats the personal part.
+    </p>
+    <p>
+      <a href="https://github.com/williamzujkowski/handwright">github.com/williamzujkowski/handwright</a> · <a href="/posts/2026-03-09-handwright-paper-to-font/">write-up</a>
+    </p>
+
     <h2>Live-Coding Music MCP</h2>
     <p>
       A Model Context Protocol server that hands Claude direct control of <a href="https://strudel.cc">Strudel.cc</a> — generating patterns, applying effects, and bending tempo through natural language, all by driving the real site in a real browser rather than mocking it. An unaffiliated fan project, and my first real attempt at steering a live browser from an agent; the music was mostly the excuse.


### PR DESCRIPTION
**Bug found while working #366.** PR #364 (closes #360) was meant to remove the orphaned `projects` content-collection schema *and* add Handwright to the projects page — but only the 10 `src/projects/*.md` deletions actually committed. The `git add` silently no-op'd on an empty-dir pathspec (`fatal: pathspec 'src/projects/' did not match any files`), so the `content.config.ts` schema removal and the `projects.astro` handwright entry were left uncommitted in the working tree and never merged.

Live-site impact: Handwright is missing from the projects page, and the `projects` collection schema is still defined but globs an empty directory. This PR lands both dropped changes, actually completing #360.

Verified: build green, handwright renders on the projects page, collection schema gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)