### PR TITLE
fix(citation-validator): reclassify 403/paywall/401 as 'restricted', not 'broken' (closes #366)

### DIFF
--- a/.github/workflows/citation-validation.yml
+++ b/.github/workflows/citation-validation.yml
@@ -53,10 +53,19 @@ jobs:
             --max-retries 3 \
             --timeout 30
 
-          # Check if any broken links found
+          # Check if any GENUINELY broken links found (404 / 5xx / ssl_error /
+          # dns_error / timeout). Access-restricted responses (403 / 401 /
+          # paywall) are classified separately as "restricted" -- they're
+          # publisher WAF blocks / login walls that a human reader can usually
+          # still see fine, so they must NOT drive this alarm.
           BROKEN_COUNT=$(jq '[.results[] | select(.status == "broken")] | length' citation-validation.json)
           echo "broken_count=$BROKEN_COUNT" >> $GITHUB_OUTPUT
           echo "Found $BROKEN_COUNT broken citation links"
+
+          # Access-restricted / unverifiable links (advisory only, not an alarm)
+          RESTRICTED_COUNT=$(jq '[.results[] | select(.status == "restricted")] | length' citation-validation.json)
+          echo "restricted_count=$RESTRICTED_COUNT" >> $GITHUB_OUTPUT
+          echo "Found $RESTRICTED_COUNT access-restricted (unverifiable) citation links"
 
           # Extract validation stats
           VALID_COUNT=$(jq '.stats.valid' citation-validation.json)
@@ -82,6 +91,7 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         env:
           BROKEN_COUNT: ${{ steps.validate.outputs.broken_count }}
+          RESTRICTED_COUNT: ${{ steps.validate.outputs.restricted_count }}
           VALID_COUNT: ${{ steps.validate.outputs.valid_count }}
           REDIRECT_COUNT: ${{ steps.validate.outputs.redirect_count }}
           TIMEOUT_COUNT: ${{ steps.validate.outputs.timeout_count }}
@@ -93,6 +103,11 @@ jobs:
             const report = fs.readFileSync('citation-report.md', 'utf8');
             const date = new Date().toISOString().split('T')[0];
 
+            // Title/threshold/decision count only genuinely-broken links
+            // (status 'broken': 404 / 5xx / ssl_error / dns_error / timeout).
+            // Access-restricted responses (403 / 401 / paywall) are advisory
+            // only -- surfaced in the body, but never in the alarm count or
+            // title, since this whole step only runs when broken_count > 0.
             const title = '🔗 Broken Citation Links Detected';
             const body = [
               '## Citation Validation Report',
@@ -102,6 +117,7 @@ jobs:
               '**Validation Results:**',
               `- ✅ Valid: ${process.env.VALID_COUNT}`,
               `- ❌ Broken: ${process.env.BROKEN_COUNT}`,
+              `- 🔒 Access-restricted (unverifiable, likely valid): ${process.env.RESTRICTED_COUNT}`,
               `- ↪️  Redirects: ${process.env.REDIRECT_COUNT}`,
               `- ⏱️  Timeouts: ${process.env.TIMEOUT_COUNT}`,
               `- ⚠️  Errors: ${process.env.ERROR_COUNT}`,
@@ -154,7 +170,10 @@ jobs:
       - name: Comment on success
         if: steps.validate.outputs.broken_count == 0
         run: |
-          echo "✅ All ${{ steps.extract.outputs.total_citations }} citation links are valid!"
+          echo "✅ No genuinely broken citation links found (${{ steps.extract.outputs.total_citations }} checked)."
+          if [ "${{ steps.validate.outputs.restricted_count }}" -gt 0 ]; then
+            echo "🔒 ${{ steps.validate.outputs.restricted_count }} link(s) are access-restricted (403/401/paywall) -- unverifiable by CI, not an alarm."
+          fi
 
       - name: Upload artifacts
         if: always()

--- a/scripts/link-validation/citation-report.py
+++ b/scripts/link-validation/citation-report.py
@@ -61,111 +61,169 @@ def generate_citation_report(validation_data: Dict, links_data: Dict) -> str:
     # Map validation results by URL
     validation_map = {r['url']: r for r in validation_data.get('results', [])}
 
-    # Group broken links by blog post
+    # Group links by blog post, split into two buckets:
+    #   - broken_by_post: genuinely broken (404 / 5xx / ssl_error / dns_error / timeout)
+    #   - restricted_by_post: access-restricted / unverifiable (403 / 401 / paywall) --
+    #     these are publisher WAF blocks or login walls that usually work fine for a
+    #     human reader; CI just can't verify them. They're advisory, not alarms.
     broken_by_post = defaultdict(list)
+    restricted_by_post = defaultdict(list)
 
     for link in links_data.get('links', []):
         url = link['url']
         validation = validation_map.get(url, {})
+        status = validation.get('status')
 
-        if validation.get('status') == 'broken':
-            post_path = Path(link['file_path'])
-            broken_by_post[post_path.name].append({
-                'url': url,
-                'line': link['line_number'],
-                'text': link.get('text', 'No link text'),
-                'issue_type': validation.get('issue_type', 'unknown'),
-                'status_code': validation.get('status_code'),
-                'error_message': validation.get('error_message'),
-                'context': link.get('context_before', '')[:100]
-            })
+        if status not in ('broken', 'restricted'):
+            continue
+
+        post_path = Path(link['file_path'])
+        entry = {
+            'url': url,
+            'line': link['line_number'],
+            'text': link.get('text', 'No link text'),
+            'issue_type': validation.get('issue_type', 'unknown'),
+            'status_code': validation.get('status_code'),
+            'error_message': validation.get('error_message'),
+            'context': link.get('context_before', '')[:100]
+        }
+
+        if status == 'broken':
+            broken_by_post[post_path.name].append(entry)
+        else:
+            restricted_by_post[post_path.name].append(entry)
 
     # Generate report
     report = []
     report.append("# Broken Citation Links by Blog Post")
     report.append("")
 
-    if not broken_by_post:
+    if not broken_by_post and not restricted_by_post:
         report.append("✅ No broken citation links found!")
         return '\n'.join(report)
 
-    # Sort posts by number of broken links (most broken first)
-    sorted_posts = sorted(
-        broken_by_post.items(),
-        key=lambda x: len(x[1]),
-        reverse=True
-    )
+    if not broken_by_post:
+        report.append("✅ No genuinely broken citation links found!")
+        report.append("")
+    else:
+        # Sort posts by number of broken links (most broken first)
+        sorted_posts = sorted(
+            broken_by_post.items(),
+            key=lambda x: len(x[1]),
+            reverse=True
+        )
 
-    for post_name, broken_links in sorted_posts:
-        report.append(f"## 📄 {post_name} ({len(broken_links)} broken links)")
+        for post_name, broken_links in sorted_posts:
+            report.append(f"## 📄 {post_name} ({len(broken_links)} broken links)")
+            report.append("")
+
+            for i, link_info in enumerate(broken_links, 1):
+                report.append(f"### {i}. Line {link_info['line']}")
+                report.append("")
+                report.append(f"**URL:** `{link_info['url']}`")
+                report.append("")
+                report.append(f"**Link Text:** {link_info['text']}")
+                report.append("")
+                report.append(f"**Issue:** {link_info['issue_type']}")
+
+                if link_info['status_code']:
+                    report.append(f"**HTTP Status:** {link_info['status_code']}")
+
+                if link_info['error_message']:
+                    report.append(f"**Error:** {link_info['error_message']}")
+
+                report.append("")
+                report.append(f"**Context:** `...{link_info['context']}...`")
+                report.append("")
+
+                # Suggest actions based on issue type
+                issue_type = link_info['issue_type']
+                if issue_type == '404':
+                    report.append("**Suggested Action:** 🔍 Search for updated URL or find alternative source")
+                elif issue_type == 'timeout':
+                    report.append("**Suggested Action:** ⏱️ Retry later or find more reliable source")
+                elif issue_type == 'ssl_error':
+                    report.append("**Suggested Action:** 🔒 Check if site has valid HTTPS or find alternative")
+                elif issue_type == 'redirect':
+                    report.append("**Suggested Action:** ↪️ Update to final URL")
+                else:
+                    report.append("**Suggested Action:** 🔧 Investigate and find replacement")
+
+                report.append("")
+                report.append("---")
+                report.append("")
+
+        # Add summary statistics
+        report.append("## 📊 Summary Statistics")
         report.append("")
 
-        for i, link_info in enumerate(broken_links, 1):
-            report.append(f"### {i}. Line {link_info['line']}")
+        total_broken = sum(len(links) for links in broken_by_post.values())
+        total_posts = len(broken_by_post)
+
+        report.append(f"- **Total Posts with Broken Links:** {total_posts}")
+        report.append(f"- **Total Broken Citation Links:** {total_broken}")
+        report.append(f"- **Average Broken Links per Post:** {total_broken / total_posts:.1f}")
+        report.append("")
+
+        # Issue type breakdown
+        issue_counts = defaultdict(int)
+        for links in broken_by_post.values():
+            for link in links:
+                issue_counts[link['issue_type']] += 1
+
+        report.append("### Issue Types")
+        report.append("")
+        report.append("| Issue Type | Count | Percentage |")
+        report.append("|------------|-------|------------|")
+
+        for issue_type, count in sorted(issue_counts.items(), key=lambda x: x[1], reverse=True):
+            percentage = (count / total_broken) * 100
+            report.append(f"| {issue_type} | {count} | {percentage:.1f}% |")
+
+        report.append("")
+
+    # Access-restricted / unverifiable links -- de-emphasized, advisory section.
+    # These are 403 / 401 / paywall responses: CI can't verify them (publisher
+    # WAF blocks, login walls), but a human reader can usually still see the
+    # page fine. Not an alarm -- verify manually if you have doubts.
+    if restricted_by_post:
+        total_restricted = sum(len(links) for links in restricted_by_post.values())
+        report.append("<details>")
+        report.append(
+            f"<summary>🔒 Access-restricted / unverifiable ({total_restricted} links, "
+            "likely valid -- verify manually)</summary>"
+        )
+        report.append("")
+        report.append(
+            "> These links returned a 403, 401, or paywall response to our automated "
+            "checker. That's usually a publisher WAF block or login wall, not a dead "
+            "link -- a human visiting the URL in a browser can typically still read "
+            "it. They are **not** counted in the broken-links total above."
+        )
+        report.append("")
+
+        sorted_restricted_posts = sorted(
+            restricted_by_post.items(),
+            key=lambda x: len(x[1]),
+            reverse=True
+        )
+
+        for post_name, restricted_links in sorted_restricted_posts:
+            report.append(f"#### 📄 {post_name} ({len(restricted_links)} restricted links)")
             report.append("")
-            report.append(f"**URL:** `{link_info['url']}`")
-            report.append("")
-            report.append(f"**Link Text:** {link_info['text']}")
-            report.append("")
-            report.append(f"**Issue:** {link_info['issue_type']}")
 
-            if link_info['status_code']:
-                report.append(f"**HTTP Status:** {link_info['status_code']}")
-
-            if link_info['error_message']:
-                report.append(f"**Error:** {link_info['error_message']}")
+            for i, link_info in enumerate(restricted_links, 1):
+                report.append(
+                    f"{i}. Line {link_info['line']} -- `{link_info['url']}` "
+                    f"({link_info['issue_type']}"
+                    + (f", HTTP {link_info['status_code']}" if link_info['status_code'] else "")
+                    + ")"
+                )
 
             report.append("")
-            report.append(f"**Context:** `...{link_info['context']}...`")
-            report.append("")
 
-            # Suggest actions based on issue type
-            issue_type = link_info['issue_type']
-            if issue_type == '404':
-                report.append("**Suggested Action:** 🔍 Search for updated URL or find alternative source")
-            elif issue_type == 'paywall':
-                report.append("**Suggested Action:** 🔓 Find open-access alternative or use Wayback Machine")
-            elif issue_type == 'timeout':
-                report.append("**Suggested Action:** ⏱️ Retry later or find more reliable source")
-            elif issue_type == 'ssl_error':
-                report.append("**Suggested Action:** 🔒 Check if site has valid HTTPS or find alternative")
-            elif issue_type == 'redirect':
-                report.append("**Suggested Action:** ↪️ Update to final URL")
-            else:
-                report.append("**Suggested Action:** 🔧 Investigate and find replacement")
-
-            report.append("")
-            report.append("---")
-            report.append("")
-
-    # Add summary statistics
-    report.append("## 📊 Summary Statistics")
-    report.append("")
-
-    total_broken = sum(len(links) for links in broken_by_post.values())
-    total_posts = len(broken_by_post)
-
-    report.append(f"- **Total Posts with Broken Links:** {total_posts}")
-    report.append(f"- **Total Broken Citation Links:** {total_broken}")
-    report.append(f"- **Average Broken Links per Post:** {total_broken / total_posts:.1f}")
-    report.append("")
-
-    # Issue type breakdown
-    issue_counts = defaultdict(int)
-    for links in broken_by_post.values():
-        for link in links:
-            issue_counts[link['issue_type']] += 1
-
-    report.append("### Issue Types")
-    report.append("")
-    report.append("| Issue Type | Count | Percentage |")
-    report.append("|------------|-------|------------|")
-
-    for issue_type, count in sorted(issue_counts.items(), key=lambda x: x[1], reverse=True):
-        percentage = (count / total_broken) * 100
-        report.append(f"| {issue_type} | {count} | {percentage:.1f}% |")
-
-    report.append("")
+        report.append("</details>")
+        report.append("")
 
     # Add repair recommendations
     report.append("## 🔧 Repair Recommendations")
@@ -270,6 +328,10 @@ def main() -> int:
             r for r in validation_data.get('results', [])
             if r.get('status') == 'broken'
         ])
+        restricted_count = len([
+            r for r in validation_data.get('results', [])
+            if r.get('status') == 'restricted'
+        ])
 
         # Report generation succeeded. The broken-link count is surfaced to the
         # workflow via the `validate` step's output, so a successful report must
@@ -279,6 +341,11 @@ def main() -> int:
             logger.warning(f"Found {broken_count} broken citation links")
         else:
             logger.info("All citation links are valid")
+        if restricted_count > 0:
+            logger.info(
+                f"{restricted_count} citation links are access-restricted "
+                "(403/401/paywall) -- unverifiable by CI, not counted as broken"
+            )
         return 0
 
     except Exception as e:

--- a/scripts/link-validation/link-validator.py
+++ b/scripts/link-validation/link-validator.py
@@ -74,10 +74,10 @@ import certifi
 class ValidationResult:
     """Result of link validation"""
     url: str
-    status: str  # valid, broken, redirect, timeout, error
+    status: str  # valid, broken, restricted, redirect, timeout, error
     status_code: Optional[int]
     final_url: Optional[str]
-    issue_type: Optional[str]  # 404, 403, timeout, wrong_content, paywall, redirect, ssl_error
+    issue_type: Optional[str]  # 404, 403, http_401, timeout, wrong_content, paywall, redirect, ssl_error
     error_message: Optional[str]
     response_time: float
     content_type: Optional[str]
@@ -109,7 +109,7 @@ class LinkValidator:
     # User agents for different validation strategies
     USER_AGENTS = {
         'bot': 'Mozilla/5.0 (compatible; LinkValidator/1.0; +https://williamzujkowski.github.io)',
-        'browser': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
+        'browser': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
     }
 
     def __init__(self, max_retries: int = 3, timeout: int = 30):
@@ -123,6 +123,7 @@ class LinkValidator:
             'total': 0,
             'valid': 0,
             'broken': 0,
+            'restricted': 0,
             'redirects': 0,
             'timeouts': 0,
             'errors': 0,
@@ -138,7 +139,7 @@ class LinkValidator:
         )
         self.session = aiohttp.ClientSession(
             connector=connector,
-            headers={'User-Agent': self.USER_AGENTS['bot']}
+            headers={'User-Agent': self.USER_AGENTS['browser']}
         )
 
         # Initialize Playwright if available
@@ -237,6 +238,8 @@ class LinkValidator:
             # Update stats
             if result.status == 'broken':
                 self.stats['broken'] += 1
+            elif result.status == 'restricted':
+                self.stats['restricted'] += 1
             elif result.status == 'redirect':
                 self.stats['redirects'] += 1
             elif result.status == 'timeout':
@@ -282,9 +285,16 @@ class LinkValidator:
                 page_title = title_match.group(1) if title_match else None
 
                 # Determine status and issue type
+                #
+                # 403/401/paywall are access-restricted responses (publisher WAF
+                # blocks, login walls) that a human reader can usually still see
+                # fine -- CI simply can't verify them. Classify those as
+                # 'restricted' (unverifiable, advisory) rather than 'broken'
+                # (genuinely dead) so the weekly report only alarms on real
+                # breakage: 404 / 5xx / ssl_error / dns_error / timeout.
                 if response.status == 200:
                     if has_paywall:
-                        status = 'broken'
+                        status = 'restricted'
                         issue_type = 'paywall'
                     elif is_redirect:
                         status = 'redirect'
@@ -296,8 +306,11 @@ class LinkValidator:
                     status = 'broken'
                     issue_type = '404'
                 elif response.status == 403:
-                    status = 'broken'
+                    status = 'restricted'
                     issue_type = '403'
+                elif response.status == 401:
+                    status = 'restricted'
+                    issue_type = 'http_401'
                 elif response.status >= 500:
                     status = 'broken'
                     issue_type = f'{response.status}_error'
@@ -496,6 +509,7 @@ class LinkValidator:
             logger.info(f"✅ Validated {self.stats['total']} links")
             logger.info(f"✔️  Valid: {self.stats['valid']}")
             logger.info(f"❌ Broken: {self.stats['broken']}")
+            logger.info(f"🔒 Restricted (unverifiable): {self.stats['restricted']}")
             logger.info(f"↪️  Redirects: {self.stats['redirects']}")
             logger.info(f"⏱️  Timeouts: {self.stats['timeouts']}")
             logger.info(f"💾 Results saved to {output_file}")


### PR DESCRIPTION
Root-cause fix for #257's chronic false-positive noise. Of its 82 'broken' citations (66 unique), ~48 are publisher WAF blocks / paywalls that work fine for humans — CI can't verify them, which isn't the same as broken.

- **link-validator.py**: aiohttp session now uses a complete modern Chrome UA (was a transparent `LinkValidator/1.0` bot string publishers block); 403/401/paywall → new `restricted` status; 404/5xx/ssl/dns/timeout stay `broken`. Playwright fallback can still upgrade `restricted`→`valid`.
- **citation-report.py**: splits Broken (alarm) from a collapsed 'Access-restricted / unverifiable (likely valid)' advisory section; broken count excludes restricted.
- **citation-validation.yml**: adds an advisory `restricted_count`; the issue threshold/title key off genuine `broken_count` only, so the weekly #257 issue fires on real breakage, not WAF blocks.

43 existing pytest tests pass; smoke-tested across broken/restricted/mixed/clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)