### PR TITLE
fix(citations): remove 9 misattributed academic citations in the #257 cluster (#368)

### DIFF
--- a/src/posts/2024-11-19-llms-smart-contract-vulnerability.md
+++ b/src/posts/2024-11-19-llms-smart-contract-vulnerability.md
@@ -13,7 +13,7 @@ tags:
 
 I spun up three different models on my RTX 3090 (running Llama 3 70B locally) and connected to GPT-4 Turbo (version 1106-preview) and Claude 3.5 Sonnet via API. My plan was simple: feed them 47 Ethereum smart contracts with known vulnerabilities and see what they caught. The results surprised me, though not in the way I expected. This builds on [foundational secure coding practices](/posts/2024-01-08-writing-secure-code-developers-guide/) but applies AI specifically to blockchain security.
 
-GPT-4 Turbo identified 12 of 15 reentrancy vulnerabilities (80% success rate), but it also flagged 18 false positives in patterns that were actually safe. That's a 38% false positive rate, which made me realize this technology isn't ready to replace traditional tools yet. I remember reading about [the DAO hack where $60 million was drained through a reentrancy vulnerability](https://doi.org/10.1007/978-3-319-70972-7_30) that human reviewers missed. The immutable nature of blockchain means vulnerable contracts can lead to catastrophic losses.
+GPT-4 Turbo identified 12 of 15 reentrancy vulnerabilities (80% success rate), but it also flagged 18 false positives in patterns that were actually safe. That's a 38% false positive rate, which made me realize this technology isn't ready to replace traditional tools yet. I remember reading about the DAO hack, where $60 million was drained through a reentrancy vulnerability that human reviewers missed. The immutable nature of blockchain means vulnerable contracts can lead to catastrophic losses.
 
 After spending three weeks and $127.34 in API costs testing these models, I found the reality is more nuanced than either the hype or the skepticism suggests. This mirrors broader concerns about [AI's role in cybersecurity](/posts/2024-05-14-ai-new-frontier-cybersecurity/) where promise and limitations coexist.
 
@@ -198,12 +198,12 @@ What would really help is better integration tooling. Right now, stitching toget
 
 ### LLM Security Research
 
-1. **[Large Language Models for Code: Security Hardening and Adversarial Testing](https://arxiv.org/abs/2302.08468)** (2023)
+1. **[Large Language Models for Code: Security Hardening and Adversarial Testing](https://arxiv.org/abs/2302.05319)** (2023)
    - Analysis of security vulnerabilities in LLM-generated code
    - *arXiv preprint*
 
 2. **[Examining Zero-Shot Vulnerability Repair with Large Language Models](https://arxiv.org/abs/2112.02125)** (2022)
-   - Stanford research on LLM vulnerability detection capabilities
+   - Research on LLM zero-shot vulnerability repair capabilities
    - *IEEE Symposium on Security and Privacy*
 
 ### Smart Contract Security

--- a/src/posts/2025-08-09-ai-cognitive-infrastructure.md
+++ b/src/posts/2025-08-09-ai-cognitive-infrastructure.md
@@ -301,11 +301,6 @@ The answer depends on the choices we make now, while we still have the cognitive
     - Clark & Chalmers' foundational work, updated for AI age
     - *Analysis, Volume 58*
 
-### Future Projections
-
-13. **[Quantum-AI Integration Roadmap](https://arxiv.org/abs/2401.09241)** (2024)
-    - Projections for quantum computing impact on AI
-    - *arXiv preprint*
 
 14. **[AGI Timeline Predictions: Expert Survey](https://www.fhi.ox.ac.uk/reports/agi-timeline-surveys/)** (2024)
     - 50% probability of AGI by 2040-2050

--- a/src/posts/2025-09-14-threat-intelligence-mitre-attack-dashboard.md
+++ b/src/posts/2025-09-14-threat-intelligence-mitre-attack-dashboard.md
@@ -19,12 +19,12 @@ Years ago, I learned the hard way that reading threat reports isn't enough. Afte
 
 Threat intelligence works best when integrated with [vulnerability prioritization](/posts/2025-09-20-vulnerability-prioritization-epss-kev) and complementary security monitoring tools.
 
-According to [research from the Cyber Threat Alliance (2024)](https://www.cyberthreatalliance.org/resources/), organizations receive 10,000 threat indicators daily, but only 3% are relevant to their specific environment. The [MITRE ATT&CK framework](https://doi.org/10.1109/cyber-rci59474.2023.10671555) changes this by providing a common language for threat behaviors (see [Suricata network monitoring](/posts/2025-08-25-network-traffic-analysis-suricata-homelab) for detection patterns). Instead of tracking millions of IoCs, we focus on techniques that matter to our environment.
+According to [research from the Cyber Threat Alliance (2024)](https://www.cyberthreatalliance.org/resources/), organizations receive 10,000 threat indicators daily, but only 3% are relevant to their specific environment. The [MITRE ATT&CK framework](https://attack.mitre.org/) changes this by providing a common language for threat behaviors (see [Suricata network monitoring](/posts/2025-08-25-network-traffic-analysis-suricata-homelab) for detection patterns). Instead of tracking millions of IoCs, we focus on techniques that matter to our environment.
 
 
 ## Understanding MITRE ATT&CK
 
-**The Pareto principle applies:** [Recent analysis by Georgiadou et al. (2023)](https://doi.org/10.1016/j.cose.2023.103097) shows that 89% of real-world attacks map to just 20% of ATT&CK techniques. We achieve substantial coverage by focusing on the most commonly used techniques.
+**The Pareto principle applies:** a small subset of ATT&CK techniques shows up in the large majority of real-world attacks, so focusing on the most commonly used ones buys you substantial coverage for comparatively little effort.
 
 
 ### The ATT&CK Matrix Structure
@@ -87,7 +87,7 @@ Visualizing threat data makes triage faster — patterns jump out of a dashboard
 
 ## Implementing Threat Actor Tracking
 
-[Research by Schlette et al. (2023)](https://doi.org/10.1145/3607199.3607240) shows tracking threat actor TTPs improves detection of targeted attacks by 82%. Let's add actor profiling:
+Tracking a threat actor's TTPs is what turns a pile of disconnected indicators into a recognizable adversary you can actually anticipate. Let's add actor profiling:
 
 📎 **Complete implementation:**
 [Full ThreatActorProfiler with MITRE groups database](https://gist.github.com/williamzujkowski/f840bcab11952a1aa1bf56fe87749b17)
@@ -155,7 +155,7 @@ Threat intelligence is only valuable if it drives action.
 
 ## Sources
 
-1. **[MITRE ATT&CK Framework](https://doi.org/10.1109/cyber-rci59474.2023.10671555)** (2024)
+1. **[MITRE ATT&CK Framework](https://attack.mitre.org/)** (2024)
    - MITRE Corporation
    - *Adversarial Tactics, Techniques, and Common Knowledge*
 
@@ -163,10 +163,3 @@ Threat intelligence is only valuable if it drives action.
    - Cyber Threat Alliance
    - *Industry Threat Sharing Guidelines*
 
-3. **[A Comprehensive Study of the MITRE ATT&CK Framework](https://doi.org/10.1016/j.cose.2023.103097)** (2023)
-   - Georgiadou, Anna, et al.
-   - *Computers & Security*
-
-4. **[Threat Actor Attribution Using TTP Analysis](https://doi.org/10.1145/3607199.3607240)** (2023)
-   - Schlette, Daniel, et al.
-   - *ACM Transactions on Privacy and Security*

--- a/src/posts/2025-09-20-iot-security-homelab-owasp.md
+++ b/src/posts/2025-09-20-iot-security-homelab-owasp.md
@@ -19,7 +19,7 @@ What I found led me down a rabbit hole of firmware analysis, MQTT exploitation, 
 
 [OWASP IoT Top 10 (2018)](https://owasp.org/www-project-internet-of-things/) identifies the most critical security risks, but theoretical knowledge only goes so far. I'm still figuring out which risks are actually exploitable in my homelab versus which are edge cases.
 
-[OWASP IoTGoat](https://doi.org/10.1201/9781003054115-11) deliberately vulnerable IoT firmware designed for learning. Think of it as the IoT equivalent of WebGoat or DVWA, **but** with the added complexity of embedded systems.
+[OWASP IoTGoat](https://github.com/OWASP/IoTGoat) is deliberately vulnerable IoT firmware designed for learning. Think of it as the IoT equivalent of WebGoat or DVWA, **but** with the added complexity of embedded systems.
 
 
 ## Building Your IoT Security Lab
@@ -45,7 +45,7 @@ flowchart TD
 
 ### Essential Tools Setup
 
-Based on [security research by Allodi & Campobasso (2023)](https://doi.org/10.1007/978-3-031-25460-4_14) these tools catch 90% of common IoT vulnerabilities. For additional automation approaches, check out my post on [automating home network security with Python](/posts/2025-02-10-automating-home-network-security). The complete lab setup script includes tool installation, IoTGoat deployment, and firmware analysis commands:
+These tools catch the common IoT vulnerability classes well. For additional automation approaches, check out my post on [automating home network security with Python](/posts/2025-02-10-automating-home-network-security). The complete lab setup script includes tool installation, IoTGoat deployment, and firmware analysis commands:
 
 <script src="https://gist.github.com/williamzujkowski/680213bdd6d4a52ef369d1f2801cb9b4.js"></script>
 
@@ -205,8 +205,4 @@ Remember: in IoT security, paranoia is just good planning. Or maybe it's overkil
 2. **[IoT Security Foundation Best Practice Guidelines](https://www.iotsecurityfoundation.org/best-practice-guidelines/)** (2024)
    - IoT Security Foundation
    - *Industry Security Standards*
-
-3. **[Security Analysis of IoT Devices Using Testbeds](https://doi.org/10.1007/978-3-031-25460-4_14)** (2023)
-   - Luca Allodi, Michele Campobasso
-   - *Springer Lecture Notes*
 


### PR DESCRIPTION
The #368 fidelity audit found the citation problem runs far deeper than the 8 fabricated (404) DOIs #257 removed: **9 of 12 remaining academic citations in the 5-post cluster are REAL, resolvable DOIs/arXiv IDs bolted onto completely unrelated papers** — a 200/valid-ID check never catches this.

Examples: an **audio-adversarial-attack paper** cited as a MITRE ATT&CK TTP study (backing '82%'); a **federated-learning IDS paper** cited as an ATT&CK Pareto study (backing '89%'); a **TLS-ecosystems paper** cited for the DAO hack; a **robotics model-predictive-control paper** cited as a 'Quantum-AI Integration Roadmap'.

Fixes: removed the misattributed citations + the invented stats they backed; repointed the MITRE framework and OWASP IoTGoat links to their real homes (attack.mitre.org, github.com/OWASP/IoTGoat); corrected one wrong arXiv ID (LEVER → the actual Security-Hardening paper, verified); dropped a wrong 'Stanford' attribution.

**This is systemic, not isolated** — a full-corpus audit of the other 34 academic-citation posts (2 agents) is running now. Verified: 0 misattributed IDs remain, build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)