### PR TITLE
fix(citations): corpus-wide misattribution cleanup — 23 fixes across 16 posts (#368)

### DIFF
--- a/src/posts/2024-09-09-embodied-ai-teaching-agents.md
+++ b/src/posts/2024-09-09-embodied-ai-teaching-agents.md
@@ -146,21 +146,13 @@ The future of human-robot interaction looks increasingly conversational, collabo
 
 ### Embodied AI Research
 
-1. **[Embodied AI: From Research to Applications](https://arxiv.org/abs/2304.02195)** (2023)
-   - Survey of embodied artificial intelligence
-   - *arXiv preprint*
-
-2. **[Learning to Navigate in Complex Environments](https://arxiv.org/abs/1611.03673)** (2017)
+1. **[Learning to Navigate in Complex Environments](https://arxiv.org/abs/1611.03673)** (2017)
    - Mirowski et al. - DeepMind navigation research
    - *ICLR 2017*
 
 ### Robotics & Simulation
 
-1. **[Sim-to-Real Transfer in Deep Reinforcement Learning](https://arxiv.org/abs/1812.11103)** (2018)
-   - Zhao et al. - Bridging simulation and reality
-   - *arXiv preprint*
-
-2. **[RoboNet: Large-Scale Multi-Robot Learning](https://arxiv.org/abs/1910.11215)** (2019)
+1. **[RoboNet: Large-Scale Multi-Robot Learning](https://arxiv.org/abs/1910.11215)** (2019)
    - Dasari et al. - Multi-robot learning framework
    - *CoRL 2019*
 

--- a/src/posts/2024-09-19-biomimetic-robotics.md
+++ b/src/posts/2024-09-19-biomimetic-robotics.md
@@ -11,7 +11,7 @@ tags:
 ---
 ## Bottom Line Up Front
 
-Engineers spend billions on advanced robotics while nature already solved locomotion, sensing, and adaptation through millions of years of testing. [MIT's Cheetah robot](https://ieeexplore.ieee.org/document/8593885/) matches a human sprinter at 6.4 m/s by copying quadruped biomechanics. [Harvard's RoboBee](https://arxiv.org/abs/2411.06382) achieves autonomous flight at 90 milligrams (lighter than a paperclip) using insect wing mechanics. Soft robotics researchers discovered octopus arms compute grasping without brain involvement, fundamentally changing how we design manipulators.
+Engineers spend billions on advanced robotics while nature already solved locomotion, sensing, and adaptation through millions of years of testing. [MIT's Cheetah robot](https://ieeexplore.ieee.org/document/8593885/) matches a human sprinter at 6.4 m/s by copying quadruped biomechanics. Harvard's RoboBee is an insect-scale flying robot, roughly the weight of a paperclip, built around insect wing mechanics. Soft robotics researchers discovered octopus arms compute grasping without brain involvement, fundamentally changing how we design manipulators.
 
 **Why it matters:** Traditional rigid robots require complex control systems for basic tasks nature performs passively through material properties and morphology. Biomimetic approaches achieve 10-30% better energy efficiency, operate in confined spaces impossible for conventional designs, and reduce computational overhead by embedding intelligence in physical structure instead of software. This shift from centralized control to distributed mechanical intelligence enables robots to work in disaster zones, surgical environments, and extraterrestrial exploration where traditional designs fail.
 
@@ -57,7 +57,7 @@ This computational approach extends beyond robotics: distributing computation ac
 **Real examples:**
 - Toucan beak: Shape distributes mechanical forces without calculation
 - Robotic grippers: Handle delicate objects through material compliance, not force sensors
-- [RoboBee](https://arxiv.org/abs/2411.06382): Wing structures auto-generate aerodynamic forces for stable flight
+- RoboBee: Wing structures auto-generate aerodynamic forces for stable flight
 - Octopus arms: Compute grasping decisions locally, bypassing central brain
 
 The elegance: physics does the work, software complexity drops dramatically. In my own testing with compliant grippers (using silicone durometer Shore 00-30), I found they could adapt to irregular objects without any feedback sensors at all, purely through material deformation.
@@ -86,13 +86,12 @@ Modern biomimetic approaches create robots that move with animal-like grace. The
 
 Bird and insect flight inspired breakthrough micro aerial vehicles. Engineers discovered that biological wing mechanics scale down to remarkably small platforms, enabling autonomous flight at weights lighter than a paperclip.
 
-**[Harvard RoboBee X-Wing](https://arxiv.org/abs/2411.06382) specifications (2024 prototype):**
-- Mass: 90 milligrams (lighter than a paperclip)
-- Power: Solar cells (untethered autonomous flight)
+**Harvard RoboBee X-Wing (insect-scale flying robot):**
+- Mass: on the order of tens of milligrams, roughly the weight of a paperclip
+- Power: designed around miniature solar cells
 - Wing design: Biomimetic insect mechanics
-- Control: Distributed processing mimics insect nervous system
-- Achievement: Sustained flight without external motion capture
-- Limitation: Flight duration remains limited (battery constraints)
+- Control: Distributed processing inspired by insect nervous systems
+- Limitation: Flight duration remains constrained by power and battery limits
 
 **University of Pennsylvania DALER:**
 - Adaptive wings inspired by bats
@@ -371,7 +370,6 @@ Biomimetic robotics represents a fundamental shift toward working with natural p
 
 - [MIT Cheetah 3: Design and Control of a Robust, Dynamic Quadruped Robot](https://journals.sagepub.com/doi/10.1177/0278364917694244) — legged robot mechanics and control
 - [MIT Cheetah robot documentation](https://ieeexplore.ieee.org/document/8593885/) — IEEE
-- [Harvard RoboBee X-Wing](https://arxiv.org/abs/2411.06382) — untethered flight, arXiv
 - [Morphological intelligence: how a robot's body shapes its cognition](https://www.nature.com/articles/s41467-021-25874-z) — Nature Communications
 - [Neuromorphic computing and vision sensors](https://www.nature.com/articles/s44172-025-00492-5) — Nature
 - [Harvard Kilobot swarm research](https://dash.harvard.edu/entities/publication/73120378-a434-6bd4-e053-0100007fdf3b) — Harvard DASH repository

--- a/src/posts/2024-10-03-quantum-computing-defense.md
+++ b/src/posts/2024-10-03-quantum-computing-defense.md
@@ -216,4 +216,3 @@ The quantum era of defense has already begun. Understanding both its promises an
 - [NSA Quantum Computing FAQ](https://www.nsa.gov/Cybersecurity/Quantum-Key-Distribution-QKD-and-Quantum-Cryptography-QC/)
 - [ETSI Quantum Safe Cryptography](https://www.etsi.org/technologies/quantum-safe-cryptography)
 - [Shor's Algorithm](https://arxiv.org/abs/quant-ph/9508027) — Peter Shor's polynomial-time factoring algorithm (1995)
-- [Post-Quantum Cryptography: Current state and quantum mitigation](https://arxiv.org/abs/2105.12707) — arXiv preprint (2021)

--- a/src/posts/2024-10-22-ai-edge-computing.md
+++ b/src/posts/2024-10-22-ai-edge-computing.md
@@ -240,9 +240,9 @@ Edge AI is making responsive, private, local intelligence possible. But it's not
 ## Sources
 
 ### Academic Papers
-- [Edge AI: A Survey](https://arxiv.org/abs/2003.12488) - Comprehensive survey of AI at the edge
-- [TinyML: Machine Learning with TensorFlow Lite](https://arxiv.org/abs/2010.11267) - Ultra-low-power ML systems
-- [Federated Learning at the Network Edge](https://arxiv.org/abs/1902.01046) - Distributed learning approaches
+- [AI on the Edge: Rethinking AI-based IoT Applications Using Specialized Edge Architectures](https://arxiv.org/abs/2003.12488) - Comprehensive survey of AI at the edge
+- [MicroNets: Neural Network Architectures for Deploying TinyML Applications on Commodity Microcontrollers](https://arxiv.org/abs/2010.11267) - Ultra-low-power ML systems
+- [Towards Federated Learning at Scale: System Design](https://arxiv.org/abs/1902.01046) - Distributed learning approaches
 
 ### Industry Standards & Frameworks
 - [NVIDIA Edge Computing Resources](https://www.nvidia.com/en-us/edge-computing/) - GPU-accelerated edge AI

--- a/src/posts/2024-11-15-gpu-power-monitoring-homelab-ml.md
+++ b/src/posts/2024-11-15-gpu-power-monitoring-homelab-ml.md
@@ -17,7 +17,7 @@ The 312W average power draw during LLM inference wasn't shocking. I knew the RTX
 
 I've been running a homelab for years, but 2024 changed everything. Large language model democratization meant I could run GPT-3-class models on my hardware. Ollama made it trivially easy: `ollama pull llama3.1:8b` and I had a capable LLM in under 90 seconds. Ease of deployment masked an inconvenient truth: running AI at home isn't cheap.
 
-A [2023 University of Massachusetts Amherst study](https://arxiv.org/abs/2311.16863) found training a single large language model can emit as much carbon as five cars over their lifetimes. I wasn't training from scratch, but inference isn't free. A [2024 Joule analysis](https://www.cell.com/joule/fulltext/S2542-4351(24)00094-7) estimated ChatGPT's energy consumption could reach 1 TWh annually, roughly equivalent to 100,000 U.S. homes' yearly electricity. Scaling to homelab levels still means real environmental and financial impact.
+A [2023 University of Massachusetts Amherst study](https://arxiv.org/abs/1906.02243) found training a single large language model can emit as much carbon as five cars over their lifetimes. I wasn't training from scratch, but inference isn't free. A [2024 Joule analysis](https://www.cell.com/joule/fulltext/S2542-4351(24)00094-7) estimated ChatGPT's energy consumption could reach 1 TWh annually, roughly equivalent to 100,000 U.S. homes' yearly electricity. Scaling to homelab levels still means real environmental and financial impact.
 
 I needed data. Not vendor claims or theoretical calculations, but actual measurements from my hardware running my workloads.
 

--- a/src/posts/2025-01-22-llm-security-alert-triage-local.md
+++ b/src/posts/2025-01-22-llm-security-alert-triage-local.md
@@ -331,7 +331,7 @@ Academic research validates LLM effectiveness for security operations. Multiple 
 
 **Key findings:**
 
-1. **Survey on LLM SOC Applications** (arXiv:2509.10858, September 2024)
+1. **Survey on LLM SOC Applications** (arXiv:2509.10858, September 2025)
    - LLMs show strong potential in log summarization, alert triage, threat intelligence, incident response
    - Average alert triage time reduction: **160-250 minutes per incident**
    - Challenges: prompt injection, excessive agency, hallucination risks

--- a/src/posts/2025-06-25-local-llm-deployment-privacy-first.md
+++ b/src/posts/2025-06-25-local-llm-deployment-privacy-first.md
@@ -337,11 +337,7 @@ Drop me a line – I'd love to hear about your setup or help troubleshoot if you
 
 ### Privacy-Preserving ML Research
 
-1. **[Privacy Risks of General-Purpose Language Models](https://arxiv.org/abs/2011.05068)** (2021)
-   - Brown et al. analyze privacy implications of large language models
-   - *IEEE Symposium on Security and Privacy*
-
-2. **[Extracting Training Data from Large Language Models](https://arxiv.org/abs/2012.07805)** (2021)
+1. **[Extracting Training Data from Large Language Models](https://arxiv.org/abs/2012.07805)** (2021)
    - Carlini et al. demonstrate memorization risks in LLMs
    - *USENIX Security Symposium*
 

--- a/src/posts/2025-08-07-supercharging-development-claude-flow.md
+++ b/src/posts/2025-08-07-supercharging-development-claude-flow.md
@@ -234,11 +234,7 @@ Since adopting Claude-Flow:
 
 ### AI Agent Systems Research
 
-1. **[AutoGPT: An Autonomous GPT-4 Experiment](https://arxiv.org/abs/2303.08774) (2023)
-   - Research on autonomous AI agent architectures
-   - *arXiv preprint*
-
-2. **[Swarm Intelligence: From Natural to Artificial Systems](https://academic.oup.com/book/8358)** (1999)
+1. **[Swarm Intelligence: From Natural to Artificial Systems](https://academic.oup.com/book/8358)** (1999)
    - Bonabeau, Dorigo, and Theraulaz - Foundational swarm intelligence principles
    - *Oxford University Press*
 

--- a/src/posts/2025-09-20-vulnerability-prioritization-epss-kev.md
+++ b/src/posts/2025-09-20-vulnerability-prioritization-epss-kev.md
@@ -49,7 +49,7 @@ The model outputs a probability score from 0 to 1, representing the likelihood o
 
 ## CISA KEV: Ground Truth for Active Exploitation
 
-[Known Exploited Vulnerabilities (KEV) catalog](https://doi.org/10.5194/egusphere-egu22-4316) provides ground truth about what's being exploited right now. Federal agencies must patch KEV vulnerabilities within strict deadlines: usually 21 days.
+[Known Exploited Vulnerabilities (KEV) catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog) provides ground truth about what's being exploited right now. Federal agencies must patch KEV vulnerabilities within strict deadlines: usually 21 days.
 
 I cross-referenced my CVE list against CISA's KEV catalog. Two of my vulnerabilities were in KEV: CVE-2023-38545 (curl SOCKS5 heap overflow, CVSS 7.5) and CVE-2023-4863 (libwebp buffer overflow, CVSS 7.8). I patched these immediately, even though their CVSS scores weren't extreme. This was the right call **because** KEV means active exploitation in the wild, not theoretical risk.
 
@@ -621,7 +621,7 @@ Remember, the goal isn't perfection. It's making better decisions with the data 
    - FIRST.org
    - *Official EPSS Documentation and API*
 
-6. **[CISA Known Exploited Vulnerabilities Catalog](https://doi.org/10.5194/egusphere-egu22-4316)**
+6. **[CISA Known Exploited Vulnerabilities Catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog)**
 
    - Cybersecurity and Infrastructure Security Agency
    - *Official KEV Catalog*

--- a/src/posts/2025-10-13-embodied-ai-robots-physical-world.md
+++ b/src/posts/2025-10-13-embodied-ai-robots-physical-world.md
@@ -132,7 +132,7 @@ VLA models are powerful but immature, and I'm frankly concerned about how quickl
 - **Adversarial robustness unknown**: a carefully placed object could trigger dangerous behavior
 - **Emergency protocols underdeveloped** compared to traditional automation
 
-[Robot Safety: A Survey](https://arxiv.org/abs/2106.15684) outlines comprehensive safety frameworks, but most VLA deployments lack rigorous implementation.
+Formal safety frameworks for robotics exist, but most VLA deployments lack rigorous implementation of them.
 
 ### Defense in Depth
 
@@ -275,8 +275,8 @@ The embodied AI revolution isn't coming, it's here. The question is whether you'
 
 ### Primary Research
 
-1. **[Gemini Robotics: Foundation Models for Robotic Manipulation](https://arxiv.org/abs/2503.20020)** (2025)
-   - Huang, Zigang et al.
+1. **[Gemini Robotics: Bringing AI into the Physical World](https://arxiv.org/abs/2503.20020)** (2025)
+   - Gemini Robotics Team
    - *arXiv preprint* - State-of-the-art VLA model architecture and results
 
 2. **[Open X-Embodiment: Robotic Learning Datasets and RT-X Models](https://arxiv.org/abs/2310.08864)** (2023)
@@ -292,10 +292,6 @@ The embodied AI revolution isn't coming, it's here. The question is whether you'
 4. **[π0: A Vision-Language-Action Flow Model for General Robot Control](https://arxiv.org/abs/2410.24164)** (2024)
    - Physical Intelligence Team
    - *arXiv preprint* - Alternative VLA architecture approach
-
-5. **[Robot Safety: A Survey](https://arxiv.org/abs/2106.15684)** (2021)
-   - Vicentini, Federico
-   - *arXiv preprint* - Comprehensive safety frameworks for physical AI
 
 ### Industry Standards & Resources
 

--- a/src/posts/2025-10-29-privacy-first-ai-lab-local-llms.md
+++ b/src/posts/2025-10-29-privacy-first-ai-lab-local-llms.md
@@ -68,13 +68,13 @@ After digging into recent security research, I found that "local" AI faces way m
 
 ### Model Extraction and Prompt Injection
 
-The most concerning finding came from academic research on [prompt injection attacks achieving 89.6% success rates](https://arxiv.org/abs/2408.03561) using roleplay-based techniques. These aren't theoretical attacks, they work on production models. An attacker can craft prompts that extract information about the model's training data, reveal system prompts, or even exfiltrate sensitive context you've provided.
+The most concerning finding came from academic research on prompt injection attacks using roleplay-based techniques, which can reliably subvert a model's guardrails. These aren't theoretical attacks, they work on production models. An attacker can craft prompts that extract information about the model's training data, reveal system prompts, or even exfiltrate sensitive context you've provided.
 
 I tested this on my own Ollama instance with a basic "jailbreak" prompt. It worked. The model happily explained how to bypass its own safety guidelines. If an adversary got access to my LLM API (which was listening on all network interfaces by default, including my IoT VLAN), they could extract far more than I was comfortable with. This experience reinforced a hard lesson – never assume "local" automatically means "secure."
 
 ### Membership Inference and PII Leakage
 
-Research on membership inference attacks shows that [sophisticated attacks increase PII leakage by 5× compared to naive approaches](https://arxiv.org/abs/2409.04040). This means an attacker can determine if specific data was used in training, potentially revealing whether private documents were included in fine-tuning datasets.
+Research on membership inference attacks shows that sophisticated attacks can meaningfully increase PII leakage compared to naive approaches. This means an attacker can determine if specific data was used in training, potentially revealing whether private documents were included in fine-tuning datasets.
 
 For my homelab use cases, personal notes, research documents, technical documentation, this is a dealbreaker. I don't want anyone inferring what data I've been feeding into my models.
 
@@ -86,7 +86,7 @@ My RTX 3090 stores all those attention mechanism states in VRAM. Without proper 
 
 ### Model Poisoning: Easier Than I Thought
 
-Research shows that [just 250 poisoned documents can backdoor a 13B parameter model](https://arxiv.org/abs/2410.02486). That's an alarmingly low threshold. If I'm downloading models from HuggingFace without verification, I have no guarantee they haven't been tampered with.
+Research shows that backdooring a large language model can require a surprisingly small number of poisoned training documents relative to the size of the dataset. That's an alarmingly low threshold. If I'm downloading models from HuggingFace without verification, I have no guarantee they haven't been tampered with.
 
 I started verifying model checksums obsessively after reading this.
 
@@ -211,7 +211,7 @@ Protecting GPU memory from KV cache leakage attacks requires [selective encrypti
 
 ### Homomorphic Encryption: Not Practical Yet
 
-I experimented with homomorphic encryption for completely encrypted inference. The overhead is brutal: [100-1000× slowdown compared to plaintext inference](https://arxiv.org/abs/2109.00984). Recent optimizations bring this down to 10-100×, but that's still too much for interactive use.
+I experimented with homomorphic encryption for completely encrypted inference. The overhead is brutal, homomorphic schemes add significant computational cost compared to plaintext inference, and even with recent optimizations, it's still too much for interactive use.
 
 **My Test Results:**
 - Plaintext inference: 2.49 seconds
@@ -540,7 +540,6 @@ If you're not willing to properly secure your deployment, use a reputable cloud 
 - [MPC-Minimized Secure LLM Inference](https://arxiv.org/abs/2408.03561) - Secure multi-party computation techniques
 - [A First Look At Efficient And Secure On-Device LLM Inference Against KV Leakage](https://arxiv.org/abs/2409.04040) - GPU memory protection
 - [CMIF Framework: Differential Privacy in LLM Inference](https://arxiv.org/html/2509.09091) - Performance overhead measurements
-- [CrypTen: Secure Multi-Party Computation Meets Machine Learning](https://arxiv.org/abs/2109.00984) - MPC benchmarks
 
 **AI Safety Frameworks:**
 - [Constitutional AI: Harmlessness from AI Feedback](https://www.anthropic.com/research/constitutional-ai-harmlessness-from-ai-feedback) - Anthropic's alignment approach

--- a/src/posts/2025-11-19-promsketch-prometheus-optimization.md
+++ b/src/posts/2025-11-19-promsketch-prometheus-optimization.md
@@ -208,7 +208,7 @@ Sketches consume less memory than raw time series:
 
 ## Further Reading
 
-**Research paper:** [PromSketch: Generating PromQL Queries from Sketches](https://arxiv.org/abs/2505.10560) (arXiv:2505.10560, VLDB 2025)
+**Research paper:** [Approximation-First Timeseries Monitoring Query At Scale](https://arxiv.org/abs/2505.10560) (arXiv:2505.10560, VLDB 2025)
 
 **Algorithm foundations:**
 - [Count-Min Sketch](https://doi.org/10.1016/j.jalgor.2003.12.001) (Cormode & Muthukrishnan, 2005)

--- a/src/posts/2025-11-23-nodeshield-runtime-sbom-enforcement.md
+++ b/src/posts/2025-11-23-nodeshield-runtime-sbom-enforcement.md
@@ -419,7 +419,7 @@ NodeShield blocked 1,025 of 1,043 supply chain attacks in my homelab testing. Ad
 
 ## Sources
 
-1. **NodeShield: Capability-Based Runtime Enforcement for Supply Chain Security** (arXiv:2508.13750) - Primary research paper with reproducible dataset and methodology. https://arxiv.org/abs/2508.13750
+1. **NodeShield: Runtime Enforcement of Security-Enhanced SBOMs for Node.js** (arXiv:2508.13750) - Primary research paper with reproducible dataset and methodology. https://arxiv.org/abs/2508.13750
 
 2. **SolarWinds Supply Chain Attack Analysis** - CISA official report documenting SUNBURST malware spread across 18,000 organizations through malicious dependency update. https://www.cisa.gov/news-events/cybersecurity-advisories/aa20-352a
 

--- a/src/posts/2026-01-15-routellm-contextual-bandits-model-router-research.md
+++ b/src/posts/2026-01-15-routellm-contextual-bandits-model-router-research.md
@@ -12,7 +12,7 @@ readingTime: "10 min read"
 
 I spent three months building model routers that didn't work before I started reading the papers. Round-robin was unfair. Random selection was wasteful. Static scoring was brittle. Every approach I tried had a failure mode that became obvious only after I deployed it against real tasks in my homelab.
 
-This post walks through the research that fixed each problem, from [RouteLLM's](https://arxiv.org/abs/2406.18510) cost-quality tradeoff to [LinUCB's](https://arxiv.org/abs/2508.21141) adaptive learning. If you're building any kind of multi-model system, these papers probably save you the same months of trial and error.
+This post walks through the research that fixed each problem, from [RouteLLM's](https://arxiv.org/abs/2406.18665) cost-quality tradeoff to [LinUCB's](https://arxiv.org/abs/2508.21141) adaptive learning. If you're building any kind of multi-model system, these papers probably save you the same months of trial and error.
 
 ## The Naive Phase: Why Simple Approaches Fail
 
@@ -40,7 +40,7 @@ I probably spent 40 hours tuning those weights manually before I realized I was 
 
 ## The RouteLLM Wake-Up Call
 
-The [RouteLLM paper](https://arxiv.org/abs/2406.18510) (Ong et al.) changed my thinking completely. Their key finding: you can route between a strong model and a weak model using a learned classifier, cutting costs by 85% while maintaining 95% of the quality. They trained on preference data from Chatbot Arena to predict which model would give a better response for a given query.
+The [RouteLLM paper](https://arxiv.org/abs/2406.18665) (Ong et al.) changed my thinking completely. Their key finding: you can route between a strong model and a weak model using a learned classifier, cutting costs by 85% while maintaining 95% of the quality. They trained on preference data from Chatbot Arena to predict which model would give a better response for a given query.
 
 I couldn't use their exact approach. They optimized for a two-model strong/weak pair, and I had three models with overlapping capabilities. But the insight was transferable: **model selection is a classification problem with learnable features, not a static lookup table.**
 
@@ -133,7 +133,7 @@ If I were starting over, I'd probably skip the Preference Router and fold its lo
 
 ## Sources
 
-- [RouteLLM: Learning to Route LLMs](https://arxiv.org/abs/2406.18510) (Ong et al.) - Cost-quality routing with preference-trained classifiers
+- [RouteLLM: Learning to Route LLMs](https://arxiv.org/abs/2406.18665) (Ong et al.) - Cost-quality routing with preference-trained classifiers
 - [MoMA: Multi-objective Model Selection](https://arxiv.org/abs/2509.07571) - TOPSIS for LLM routing
 - [PILOT: Practical LLM Routing](https://arxiv.org/abs/2508.21141) - LinUCB contextual bandits for model selection
 - [SATER: Confidence-Aware Routing](https://arxiv.org/abs/2510.05164) - Difficulty estimation for routing decisions

--- a/src/posts/2026-01-28-consensus-voting-ai-models-multi-agent.md
+++ b/src/posts/2026-01-28-consensus-voting-ai-models-multi-agent.md
@@ -138,7 +138,7 @@ I use voting selectively:
 
 In practice, maybe 15-20% of decisions go through consensus. The rest use single-model routing through the [model router](/posts/2026-01-15-routellm-contextual-bandits-model-router-research/). The 80/20 split works well. Consensus adds value where decisions are high-stakes and reversibility is low.
 
-The [multi-agent committee research](https://arxiv.org/abs/2512.21352) on code review confirms this pattern: multi-agent review provides the most value on complex, ambiguous tasks, and the least value on routine, well-defined tasks. Don't consensus-vote your variable names.
+The [multi-agent committee research](https://arxiv.org/abs/2512.21352) on autonomous software beta testing confirms this pattern: multi-agent review provides the most value on complex, ambiguous tasks, and the least value on routine, well-defined tasks. Don't consensus-vote your variable names.
 
 ## Failure Modes
 
@@ -172,4 +172,4 @@ The [nexus-agents repository](https://github.com/nexus-substrate/nexus-agents) i
 - [Voting vs. Consensus Protocols](https://arxiv.org/abs/2502.19130) - Aggregation strategy comparison
 - [Free-MAD: Anti-Conformity in Multi-Agent Systems](https://arxiv.org/abs/2509.11035) - Adversarial agent design
 - [Higher-Order Voting](https://arxiv.org/abs/2510.01499) - Bayesian-optimal vote aggregation
-- [Multi-Agent Committee Code Review](https://arxiv.org/abs/2512.21352) - Task complexity and multi-agent review value
+- [Multi-Agent LLM Committees for Autonomous Software Beta Testing](https://arxiv.org/abs/2512.21352) - Task complexity and multi-agent review value

--- a/src/posts/2026-02-09-building-nexus-agents-multi-model-orchestration.md
+++ b/src/posts/2026-02-09-building-nexus-agents-multi-model-orchestration.md
@@ -20,7 +20,7 @@ Most AI-assisted development workflows look like this: you pick one model, send 
 
 I was spending time not writing software but context-switching between tools. Open Claude for architecture planning. Switch to Gemini for broad research. Use Codex for rapid code generation. Copy context between them. Lose track of which model said what. Frustrating.
 
-**The core insight:** Model selection is a routing problem, not a loyalty problem. Research on [LLM routing](https://arxiv.org/abs/2406.18510) confirms that different tasks have measurably different performance across models. A system that routes intelligently should outperform any single model used for everything. The [RouteLLM paper](https://arxiv.org/abs/2406.18510) showed this could cut costs 85% while maintaining quality, which convinced me the approach was worth pursuing.
+**The core insight:** Model selection is a routing problem, not a loyalty problem. Research on [LLM routing](https://arxiv.org/abs/2406.18665) confirms that different tasks have measurably different performance across models. A system that routes intelligently should outperform any single model used for everything. The [RouteLLM paper](https://arxiv.org/abs/2406.18665) showed this could cut costs 85% while maintaining quality, which convinced me the approach was worth pursuing.
 
 ## Architecture: Research-Backed, Not Ad Hoc
 
@@ -293,7 +293,7 @@ Building this taught me that the future of AI-assisted development isn't about p
 ## Sources
 
 - [nexus-agents](https://github.com/nexus-substrate/nexus-agents) — the project this post is about
-- [RouteLLM: Learning to Route LLMs with Preference Data](https://arxiv.org/abs/2406.18510) — arXiv
+- [RouteLLM: Learning to Route LLMs with Preference Data](https://arxiv.org/abs/2406.18665) — arXiv
 - [Model Context Protocol (MCP)](https://modelcontextprotocol.io/)
 - [STPA safety analysis of MCP](https://arxiv.org/abs/2601.08012) — arXiv
 - [MoMA framework](https://arxiv.org/abs/2509.07571) — arXiv


### PR DESCRIPTION
Completes the citation-integrity work that began as #257. A full-corpus fidelity audit (2 agents, 34 posts, every doi.org/arxiv.org citation verified against Crossref/arXiv) confirmed the fabricated-DOI problem is **systemic**: real, resolvable identifiers bolted onto unrelated papers — invisible to any HTTP/200 link check.

**Full tally across the whole effort:** 8 fabricated DOIs (#369) + 9 cluster misattributions (#372) + **23 more here** = ~40 bad citations across ~18 posts. ~85% of all citations audited were clean, so it clusters in specific posts.

**This PR (16 posts):**
- **Corrections** — RouteLLM `2406.18510`→`2406.18665` (2 posts, anchored the cost-savings thesis); Strubell carbon paper; CISA KEV → real URL; several fabricated/paraphrased titles/authors/dates fixed to the real papers.
- **Removals** — the `privacy-first-ai-lab` fabricated security stats (89.6%/5×/250-doc/100-1000×), a physics-paper-as-crypto, the RoboBee test-rig (flight stats softened), debugging/Alzheimer papers miscited as robotics/embodied-AI, a GPT-4-report-as-AutoGPT.

Correct uses of the same IDs elsewhere were verified and left intact. Build green, 201 pages.

Closes #368.

🤖 Generated with [Claude Code](https://claude.com/claude-code)