### PR TITLE
feat: remarque-tokens 0.15.0 — syntax palette adoption (+ essay module if swapped)

### DIFF
--- a/astro-site/DESIGN-DEVIATIONS.md
+++ b/astro-site/DESIGN-DEVIATIONS.md
@@ -241,6 +241,50 @@ explicit `background-color: transparent;` — background-color's own
 initial value — to restore exactly the pre-migration appearance. See the
 inline comment in `global.css` for the full reasoning.
 
+## 8. Syntax-highlighting palette (remarque-tokens 0.15.0)
+
+Bumped `remarque-tokens` from 0.8.0 → 0.15.0 (issue: this migration) and
+adopted the "Syntax Highlighting" section of `REMARQUE.md`: `astro.config.mjs`
+now passes Shiki's `createCssVariablesTheme({ variablePrefix:
+'--color-syntax-' })` as a single theme object (replacing the previous
+`themes: { light: 'github-light', dark: 'github-dark' }` dual-theme vendor
+config), and `global.css` adds the required `.astro-code` CSS bridge plus
+the 9 `--color-syntax-*` palette-tier slots to all three palette blocks
+(`:root`, `:root.dark`, the `@media (prefers-color-scheme: dark) :root:not(.light)`
+block).
+
+The 9 slots are copied from remarque-tokens' own default palette (ANSI-derived,
+targeted at `--color-code-bg`, not this site's accent hue) rather than
+re-derived from Palette B's green/ferric-red accent — per REMARQUE.md, a quiet
+hue-spread syntax ramp is the intended look regardless of a site's own accent.
+All 9 are audit-verified (`pnpm audit:remarque`) ≥ 4.5:1 against this site's
+own `--color-code-bg` in both themes, not just trusted from upstream.
+
+Three light-theme slots needed solving (upstream defaults are tuned against
+remarque's own lighter `--color-code-bg`, `oklch(0.945 0.005 80)`; this site's
+is `oklch(0.92 0.015 75)`, slightly darker):
+
+| Slot | Upstream default | This site | Rationale |
+|---|---|---|---|
+| `--color-syntax-string` | `oklch(0.50 0.12 145)` (4.49:1 here) | `oklch(0.49 0.12 145)` (4.69:1) | Darkened to clear 4.5:1 against this site's code-bg |
+| `--color-syntax-comment` | `oklch(0.52 0.01 80)` (4.35:1 here) | `oklch(0.505 0.01 80)` (4.63:1) | Same fix |
+| `--color-syntax-punctuation` | `oklch(0.52 0.01 80)` (4.35:1 here) | `oklch(0.505 0.01 80)` (4.63:1) | Same source triple as comment, same fix |
+
+All other 6 slots (`keyword`, `constant`, `function`, `type`, `variable`,
+`link`) match the upstream default byte-for-byte in both themes and clear
+4.5:1 unmodified. `node node_modules/remarque-tokens/scripts/drift-check.mjs`
+correctly classifies all 3 solved values as palette-tier INFO (sanctioned
+personalization), never FAIL.
+
+Not extended to `theme-deck.css`'s 12 terminal palettes in this migration —
+each deck defines its own `--color-code-bg`/`--color-code-fg` but none
+currently overrides `--color-syntax-*`, so highlighted code under an active
+theme-deck renders with this section's base-palette syntax colors (verified
+non-broken, just not deck-tuned/contrast-audited per-deck). Tracked as a
+follow-up, not a regression: `remarque-audit`'s CONTRAST check only ever ran
+against the `--palette` file (`global.css`), not `theme-deck.css`, before this
+change either.
+
 ## References
 
 - Issue #324 (this migration)

--- a/astro-site/astro.config.mjs
+++ b/astro-site/astro.config.mjs
@@ -4,7 +4,25 @@ import sitemap from '@astrojs/sitemap';
 import rehypeMermaid from 'rehype-mermaid';
 import remarkSmartypants from 'remark-smartypants';
 import { visit } from 'unist-util-visit';
+import { createCssVariablesTheme } from 'shiki';
 import rehypeSidenotes from './src/lib/rehype-sidenotes.mjs';
+
+/**
+ * Remarque syntax-highlighting theme (remarque-tokens 0.15.0, REMARQUE.md
+ * "Syntax Highlighting" / "Astro / Shiki wiring"). Passed as an OBJECT, not
+ * the `'css-variables'` string — Astro's markdown pipeline renames the
+ * string form's variable prefix to `--astro-code-*`, which would silently
+ * break the mapping to this package's `--color-syntax-*` tokens. Because
+ * this is a single CSS-variables theme (not a light/dark pair), the actual
+ * light vs. dark color swap happens in global.css's palette blocks (the
+ * `--color-syntax-*` custom properties themselves are themed there) plus
+ * the `.astro-code` CSS bridge below — not here.
+ */
+const remarqueSyntaxTheme = createCssVariablesTheme({
+  name: 'remarque',
+  variablePrefix: '--color-syntax-',
+  fontStyle: true,
+});
 
 /**
  * Shiki transformer: extract title="filename" from code fence meta
@@ -200,10 +218,7 @@ export default defineConfig({
       excludeLangs: ['mermaid'],
     },
     shikiConfig: {
-      themes: {
-        light: 'github-light',
-        dark: 'github-dark',
-      },
+      theme: remarqueSyntaxTheme,
       transformers: [transformerCodeTitle()],
     },
     remarkPlugins: [

--- a/astro-site/package.json
+++ b/astro-site/package.json
@@ -36,7 +36,7 @@
     "cookie": "^2.0.1",
     "markdown-it": "^14.3.0",
     "rehype-mermaid": "^3.0.0",
-    "remarque-tokens": "^0.8.0",
+    "remarque-tokens": "^0.15.0",
     "sanitize-html": "^2.17.6",
     "satori": "^0.28.2",
     "svelte": "^5.56.7",
@@ -58,7 +58,8 @@
     "prettier": "^3.9.6",
     "prettier-plugin-astro": "^0.14.1",
     "prettier-plugin-svelte": "^4.1.1",
-    "remark-smartypants": "^3.0.2"
+    "remark-smartypants": "^3.0.2",
+    "shiki": "^4.1.0"
   },
   "overrides": {
     "fast-xml-parser": ">=5.5.8",

--- a/astro-site/pnpm-lock.yaml
+++ b/astro-site/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0(playwright@1.61.1)
       remarque-tokens:
-        specifier: ^0.8.0
-        version: 0.8.0
+        specifier: ^0.15.0
+        version: 0.15.0
       sanitize-html:
         specifier: ^2.17.6
         version: 2.17.6
@@ -109,6 +109,9 @@ importers:
       remark-smartypants:
         specifier: ^3.0.2
         version: 3.0.2
+      shiki:
+        specifier: ^4.1.0
+        version: 4.1.0
 
 packages:
 
@@ -2792,10 +2795,15 @@ packages:
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
-  remarque-tokens@0.8.0:
-    resolution: {integrity: sha512-R5u8smwTTg8anDR0vxu5jLhWeH25SWq019LlXNh802MD92a56C7UkqCNYNH69mm4Tg5DLmCgbxWvIMIriIpQVA==}
+  remarque-tokens@0.15.0:
+    resolution: {integrity: sha512-W+9Zp8UwcoEl373N2ulpFhkmTdEhipXMCQomH36eR2eoRDGtVH/SDno0PTZhWrIxzWIJQaV6AhIqskUK/s2v6w==}
     engines: {node: '>=18'}
     hasBin: true
+    peerDependencies:
+      '@williamzujkowski/oklch-terminal-themes': '>=0.1.0 <0.3.0'
+    peerDependenciesMeta:
+      '@williamzujkowski/oklch-terminal-themes':
+        optional: true
 
   request-light@0.5.8:
     resolution: {integrity: sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg==}
@@ -6222,7 +6230,7 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
-  remarque-tokens@0.8.0: {}
+  remarque-tokens@0.15.0: {}
 
   request-light@0.5.8: {}
 

--- a/astro-site/src/styles/global.css
+++ b/astro-site/src/styles/global.css
@@ -5,7 +5,7 @@
  * See: https://github.com/williamzujkowski/remarque
  */
 
-/* consumes remarque-tokens v0.3.0 (core tier) + local palette layer.
+/* consumes remarque-tokens v0.15.0 (core tier) + local palette layer.
  * Core tier (type scale, rhythm, spacing, content-standard/wide, radius,
  * motion, base resets, prose/typography machinery) is imported below;
  * this file keeps only the PALETTE tier (fonts, colors, --content-reading)
@@ -78,6 +78,25 @@
   --color-overlay: oklch(0 0 0 / 0.5);        /* modal backdrop scrim */
   --color-shadow: oklch(0 0 0 / 0.5);         /* drop-shadow color */
 
+  /* ─── Palette tier: syntax highlighting (remarque-tokens 0.15.0, REMARQUE.md
+   * "Syntax Highlighting") ─── these 9 slots are copied verbatim from
+   * remarque-tokens' own default light palette (tokens-palette.css) rather
+   * than re-derived from this site's accent hue: they're ANSI-derived and
+   * targeted at --color-code-bg specifically (not the accent), so a quiet,
+   * hue-spread syntax ramp is the intended look regardless of a site's own
+   * accent color. Each slot is verified ≥ 4.5:1 against THIS site's own
+   * --color-code-bg by `pnpm audit:remarque` (remarque-audit@0.15.0 added a
+   * CONTRAST check for all 9 slots) — not just trusted from upstream. */
+  --color-syntax-keyword: oklch(0.51 0.12 250);
+  --color-syntax-string: oklch(0.49 0.12 145);    /* solved: upstream default (L 0.50) is 4.49:1 against THIS site's code-bg (0.92 vs upstream's 0.945) — darkened to 0.49 for 4.69:1 */
+  --color-syntax-constant: oklch(0.51 0.105 85);
+  --color-syntax-comment: oklch(0.505 0.01 80);   /* solved: upstream default (L 0.52) is 4.35:1 here — darkened to 0.505 for 4.63:1 */
+  --color-syntax-function: oklch(0.52 0.12 310);
+  --color-syntax-type: oklch(0.50 0.085 196);
+  --color-syntax-punctuation: oklch(0.505 0.01 80); /* same fix as comment (same source oklch triple) */
+  --color-syntax-variable: oklch(0.26 0.01 80);
+  --color-syntax-link: var(--color-accent);
+
   /* Semantic vars core's machinery (`.remarque-prose a`, `:focus-visible`,
    * `::selection`) consumes that this site didn't previously need, since
    * its own rules set these directly (`a { color: var(--color-accent); }`,
@@ -115,6 +134,18 @@
   --color-code-fg: oklch(0.88 0.03 140);
   --color-selection-bg: oklch(0.30 0.08 140);  /* was C 0.10 — remarque-audit flagged it out-of-sRGB-gamut (blue channel clips to -0.0007 at L 0.30/H 140/C 0.10); 0.08 is back in gamut with margin (blue +0.0036) and keeps the same hue/lightness "tinted green" look. selection-fg/selection-bg still 10.58:1, well above the 4.5:1 floor. */
 
+  /* Syntax highlighting (remarque-tokens 0.15.0) — default dark palette,
+   * see the :root block's comment above for rationale. */
+  --color-syntax-keyword: oklch(0.61 0.11 250);
+  --color-syntax-string: oklch(0.60 0.11 145);
+  --color-syntax-constant: oklch(0.61 0.11 84);
+  --color-syntax-comment: oklch(0.60 0.005 80);
+  --color-syntax-function: oklch(0.62 0.11 310);
+  --color-syntax-type: oklch(0.60 0.10 195);
+  --color-syntax-punctuation: oklch(0.60 0.005 80);
+  --color-syntax-variable: oklch(0.82 0.005 80);
+  --color-syntax-link: var(--color-accent);
+
   /* Core-consumed semantic vars (see the base :root block's comment) */
   --color-link: var(--color-accent);
   --color-link-hover: var(--color-accent-hover);
@@ -139,6 +170,17 @@
     --color-code-bg: oklch(0.17 0.015 140);
     --color-code-fg: oklch(0.88 0.03 140);
     --color-selection-bg: oklch(0.30 0.08 140);  /* keep in sync with :root.dark above — gamut fix, see its comment */
+
+    /* Syntax highlighting — keep in sync with :root.dark above */
+    --color-syntax-keyword: oklch(0.61 0.11 250);
+    --color-syntax-string: oklch(0.60 0.11 145);
+    --color-syntax-constant: oklch(0.61 0.11 84);
+    --color-syntax-comment: oklch(0.60 0.005 80);
+    --color-syntax-function: oklch(0.62 0.11 310);
+    --color-syntax-type: oklch(0.60 0.10 195);
+    --color-syntax-punctuation: oklch(0.60 0.005 80);
+    --color-syntax-variable: oklch(0.82 0.005 80);
+    --color-syntax-link: var(--color-accent);
 
     /* Core-consumed semantic vars (see the base :root block's comment) */
     --color-link: var(--color-accent);
@@ -723,16 +765,41 @@ article .prose > p:first-of-type::first-letter {
   font-feature-settings: "liga" 1, "calt" 1, "dlig" 1;
 }
 
-/* Shiki dual-theme dark mode swap */
-@media (prefers-color-scheme: dark) {
-  .astro-code, .astro-code span {
-    color: var(--shiki-dark) !important;
-    background-color: var(--shiki-dark-bg) !important;
-  }
-}
-:root.dark .astro-code, :root.dark .astro-code span {
-  color: var(--shiki-dark) !important;
-  background-color: var(--shiki-dark-bg) !important;
+/* Shiki syntax highlighting — Remarque CSS-variables bridge
+ * (remarque-tokens 0.15.0, REMARQUE.md "Syntax Highlighting" / "Astro /
+ * Shiki wiring"). astro.config.mjs passes `createCssVariablesTheme({
+ * variablePrefix: '--color-syntax-' })` as a single theme object, so Shiki
+ * bakes `color: var(--color-syntax-token-keyword)` etc. into every span —
+ * NOT `var(--color-syntax-keyword)` (variablePrefix is a plain string
+ * prepend, not a rename: Shiki's own internal slot names already start
+ * with `token-`). Left unbridged, every span would resolve to nothing and
+ * silently inherit its parent color — highlighting would look missing, not
+ * broken, with no build error. This block is REQUIRED, not optional; it
+ * replaces the previous Shiki dual-theme (`themes: {light, dark}` +
+ * `--shiki-dark`/`--shiki-dark-bg` !important overrides) approach, which
+ * baked vendor `github-light`/`github-dark` colors per span instead of
+ * this site's own token palette and couldn't repaint under the .dark
+ * class without !important fights. Scoped to `.astro-code` (the class
+ * Astro's Shiki integration puts on the <pre>) so these Shiki-internal
+ * variable names don't leak into the page's global custom-property
+ * namespace. No light/dark branching needed here: --color-syntax-* is
+ * already themed per :root / :root.dark / the system-preference media
+ * block above, so this bridge is identical in both themes — the swap
+ * happens upstream of it. */
+.astro-code {
+  --color-syntax-foreground: var(--color-code-fg);
+  --color-syntax-background: var(--color-code-bg);
+  --color-syntax-token-keyword: var(--color-syntax-keyword);
+  --color-syntax-token-string: var(--color-syntax-string);
+  --color-syntax-token-string-expression: var(--color-syntax-string);
+  --color-syntax-token-constant: var(--color-syntax-constant);
+  --color-syntax-token-comment: var(--color-syntax-comment);
+  --color-syntax-token-function: var(--color-syntax-function);
+  --color-syntax-token-parameter: var(--color-syntax-variable);
+  --color-syntax-token-punctuation: var(--color-syntax-punctuation);
+  --color-syntax-token-link: var(--color-syntax-link);
+  /* token-inserted/-deleted/-changed intentionally left undefined — diff
+     markers, out of scope; they fall back to inherited foreground. */
 }
 
 /* Mermaid Diagrams */


### PR DESCRIPTION
## Summary

- Bumps `remarque-tokens` `^0.8.0` → `^0.15.0` (core-tier consumption unchanged; `@import "remarque-tokens/core"` + local palette layer, per `DESIGN-DEVIATIONS.md`).
- Adopts REMARQUE.md's "Syntax Highlighting" section: `astro.config.mjs` now passes Shiki's `createCssVariablesTheme({ variablePrefix: '--color-syntax-' })` as a theme **object** (not the `'css-variables'` string, which Astro renames to `--astro-code-*`), replacing the previous vendor `themes: { light: 'github-light', dark: 'github-dark' }` dual-theme config. `global.css` adds the required `.astro-code` CSS bridge and the 9 `--color-syntax-*` palette-tier tokens to all three palette blocks (`:root`, `:root.dark`, the system-preference dark media block).
- Assessed the Essay Module (`remarque-tokens/essay`) swap for this site's sidenote/TOC implementation — **deferred**, not done. See "Swap decision" below and issue #378.

## Drift-report changes (`node node_modules/remarque-tokens/scripts/drift-check.mjs --css-file src/styles/global.css --package-dir .`)

Exit code 0 (0 FAIL) before and after this PR. What's new:

- The 9 `--color-syntax-*` slots are now tracked by drift for the first time (they didn't exist in 0.8.0). 6 of 9 match the upstream default byte-for-byte in both themes (`keyword`, `constant`, `function`, `type`, `variable`, `link`) — no drift entry.
- 3 light-theme slots (`string`, `comment`, `punctuation`) needed a small solved adjustment (documented in `DESIGN-DEVIATIONS.md` §8): upstream's defaults are tuned against remarque's own `--color-code-bg` (`oklch(0.945 0.005 80)`); this site's is slightly darker (`oklch(0.92 0.015 75)`), so `string`/`comment`/`punctuation` cleared only 4.49:1/4.35:1/4.35:1 against the 4.5:1 floor — darkened `L` by 0.01-0.015 to clear it (4.69:1/4.63:1/4.63:1). All 3 correctly classify as palette-tier **INFO** (sanctioned personalization), never FAIL.
- No new core-tier WARN beyond the pre-existing, already-documented `--text-display` deviation (issue #274).

`pnpm audit:remarque` (remarque-audit@0.15.0, which added a CONTRAST check for all 9 syntax slots) failed immediately after the version bump alone (18 undefined-token errors) until the syntax palette was wired in this same PR — items 1 and 2 are coupled at the CI level for this bump, not independently optional.

## Syntax-palette wiring — verified

- Built the site (`pnpm build`) and confirmed a code-bearing post's HTML emits `<span style="color:var(--color-syntax-token-keyword)">` etc. (Shiki's raw `variablePrefix`-prepended names, exactly the shape REMARQUE.md warns is NOT a rename).
- Confirmed the built CSS (`dist/_astro/BaseLayout.*.css`) contains the `.astro-code { --color-syntax-token-keyword: var(--color-syntax-keyword); ... }` bridge, and that `--color-syntax-keyword` etc. resolve to different oklch values under `:root` vs `:root.dark` — the full chain (span -> bridge -> themed token) resolves correctly in both themes.
- `pnpm audit:remarque`, `pnpm audit:typography`, `pnpm audit:colors`, `pnpm audit:accent-font`, `pnpm audit:apca` (the full `pnpm run audit` composite) all pass clean.
- Not extended to `theme-deck.css`'s 12 terminal palettes (each has its own `--color-code-bg` but none override `--color-syntax-*` yet) — documented as a known, non-regressing gap in `DESIGN-DEVIATIONS.md` §8 (pre-existing: `remarque-audit`'s CONTRAST check never covered `theme-deck.css` either, only the `--palette` file).

## Swap decision: sidenote/TOC module — **deferred**

Compared this site's `src/lib/rehype-sidenotes.mjs` + `global.css` sidenote/TOC CSS against `remarque-tokens/essay` (`essay.css`, graduated FROM this site per remarque issue #52). The two are close in shape (same `>=80rem` breakpoint, same left-gutter/right-rail split, same "only first reference gets a note" rule) but **not close enough to swap with confidently identical visual output** in this PR:

- Sidenote column width: this site 11.5rem (hand-measured) vs. the module's token-derived 8rem — a real ~30% narrower margin column.
- TOC rail width: this site `minmax(12rem, 14rem)` vs. the module's `minmax(10rem, 12rem)`.
- TOC marker: SVG chevron (this site) vs. a unicode `▸` (the module).
- TOC label voice: `text-transform: uppercase` (this site) vs. true `font-variant-caps: all-small-caps` (the module) — upstream's own changelog calls this an intentional correction, not a re-expression.
- Open/close mechanics: this site force-opens the TOC `<details>` via a small inline script on every breakpoint crossing; the module is deliberately no-JS (`<details open>` by default, stays collapsed if a reader manually closes it and resizes).
- Numbering: this site's rehype plugin injects a literal number span (from GFM's own numbering) at `--text-micro`; the module numbers via CSS counters at `--text-meta` (a full floor size larger) scoped to `.remarque-prose` — swapping cleanly needs a rehype-plugin rewrite (strip the injected number/GFM digit to avoid double-numbering) plus a `.prose` -> `.remarque-prose` class change.

None of these are individually alarming, but stacked together they don't clear the "visually essentially identical" bar without a real VR diff pass and a design-review sign-off — the standard this site already holds every `DESIGN-DEVIATIONS.md` entry to. Filed **#378** ("migrate local sidenotes/TOC to remarque-tokens/essay") with the full diff list and two suggested paths forward (a VR-backed follow-up PR, or requesting upstream expose the width tokens as overrides).

## Test plan

- [x] `pnpm install` — `remarque-tokens@0.15.0` resolved, `shiki@4.1.0` added as an explicit devDependency (needs to be directly importable for `createCssVariablesTheme` under pnpm's strict `node_modules`)
- [x] `pnpm run audit` (remarque + typography + colors + accent-font + apca) — all clean
- [x] `node node_modules/remarque-tokens/scripts/drift-check.mjs --css-file src/styles/global.css --package-dir .` — exit 0, 0 FAIL (see drift section above)
- [x] `pnpm build` — 201 pages, clean; verified syntax-token wiring in built HTML/CSS by hand
- [x] `pnpm check` (astro check) — 0 errors, 0 warnings (pre-existing hints only)
- [x] `pnpm lint` (eslint) — 0 errors (pre-existing 1 warning, unrelated)
- [x] `pnpm test:unit` — 7/7 pass (sidenotes rehype plugin untouched by this PR)
- [x] `npx playwright test tests/e2e/` (smoke + a11y + sidenotes + theme-deck) — run locally, matching the `a11y.yml` CI command
- [x] Filed follow-up issue #378 for the deferred sidenote/TOC swap

🤖 Generated with [Claude Code](https://claude.com/claude-code)
