### PR TITLE
feat: remarque-tokens 0.24.0 — state/viz token conformance

### DIFF
--- a/astro-site/DESIGN-DEVIATIONS.md
+++ b/astro-site/DESIGN-DEVIATIONS.md
@@ -285,6 +285,85 @@ follow-up, not a regression: `remarque-audit`'s CONTRAST check only ever ran
 against the `--palette` file (`global.css`), not `theme-deck.css`, before this
 change either.
 
+## 9. State + dataviz token conformance (remarque-tokens 0.24.0)
+
+Bumped `remarque-tokens` from 0.15.0 → 0.24.0 (consumer-refresh, npm's caret
+range had frozen this site at 0.15.0 while the package moved through
+0.16.0–0.24.0). Two token families were added upstream in that span and
+are both required by `remarque-audit`'s CONTRAST check; both are now
+declared in all three of `global.css`'s palette blocks (`:root`,
+`:root.dark`, the `@media (prefers-color-scheme: dark) :root:not(.light)`
+block), same keep-if-passing-else-solve pattern as §8's syntax slots.
+
+**State colors** (0.17.0, REMARQUE.md "State Colors") — 7 slots:
+`--color-error`/`-subtle`, `--color-success`/`-subtle`,
+`--color-warning`/`-subtle`, and `--color-disabled`. Every state text color
+is required ≥ 4.5:1 against **both** `--color-bg` and `--color-surface`
+(not just one); every `-subtle` banner background is required to hold
+`--color-fg` ≥ 4.5:1 on top of it. `--color-disabled` aliases
+`--color-muted` per spec — not a new hue, so nothing to solve there (it
+inherits whatever `--color-muted` already audits to).
+
+Only one of the 6 hue-bearing slots needed solving:
+
+| Slot | Upstream default | This site | Rationale |
+|---|---|---|---|
+| `--color-success` (light) | `oklch(0.51 0.12 145)` — 4.71:1 bg / **4.43:1 surface** (fails 4.5:1) | `oklch(0.50 0.12 145)` — 4.92:1 bg / 4.63:1 surface | Darkened to clear 4.5:1 against this site's `--color-surface` (`oklch(0.93 0.015 75)`), which sits closer to `--color-bg` than upstream's default surface/bg spread |
+
+All other slots — `--color-error`, `--color-warning` (both themes), and
+`--color-success` (dark) — match the upstream default byte-for-byte and
+clear 4.5:1 against both `--color-bg` and `--color-surface` unmodified. All
+3 `-subtle` backgrounds (both themes) hold `--color-fg` well past 4.5:1
+(13.7–16.5:1) unmodified — the near-bg lightness these are designed at
+gives enormous headroom regardless of a site's own bg/surface tuning.
+
+**Dataviz categorical** (0.22.0, REMARQUE.md "Dataviz Tokens") — 6 slots,
+`--color-viz-1` through `--color-viz-6`, each required ≥ 3:1 against
+`--color-bg` only (Carbon's mark-on-background line, not text's 4.5:1; see
+REMARQUE.md for why marks get the non-text WCAG 1.4.11 threshold instead).
+All 6 pass unmodified in both themes (4.39–4.97:1 light, 7.70–7.75:1 dark)
+— no solving needed. Per REMARQUE.md's mandatory non-color-redundancy
+rule, any future chart on this site must pair `--color-viz-*` with a
+second channel (marker shape, dash pattern, or a direct label) rather than
+relying on hue alone — noted here for whoever adds the first chart, not
+enforced by any script today (no chart component exists on this site yet).
+Not extended to `theme-deck.css`'s 12 terminal palettes, same rationale as
+§8's syntax slots (each deck would need its own solve; tracked as the same
+kind of follow-up, not a regression, since `remarque-audit` only ever
+checks the `--palette` file).
+
+`node node_modules/remarque-tokens/scripts/drift-check.mjs --css-file
+src/styles/global.css --package-dir .` correctly classifies the one solved
+`--color-success` value as palette-tier INFO (sanctioned personalization),
+never FAIL — 0 FAIL / 1 WARN (the pre-existing, already-documented
+`--text-display` core deviation from §1) / 19 INFO overall.
+
+**Forced-colors / `prefers-contrast` coverage gap (0.21.0, not fixed in
+this bump).** 0.21.0 added `@media (forced-colors: active)` rules to
+`forms.css` (validation-state geometry) and `broadsheet.css` (title-link
+hover underline, decorative rule conversion) — this site imports neither
+module (only `remarque-tokens/core`), so those specific fixes do not flow
+through. `tokens-core.css`'s `:focus-visible` forced-colors rule *does*
+apply here (core is always imported), so keyboard focus rings are covered.
+Auditing this site's own local CSS the same way REMARQUE.md's "Forced
+Colors & Contrast Preferences" section audited the package: `.lead-title
+a`/`.entry-title a` in `global.css` implements the exact same
+gradient-underline hover/focus affordance that `broadsheet.css`'s
+`.remarque-lead-title a`/`.remarque-entry-title a` was fixed for in
+0.21.0 — a `background-image: linear-gradient(...)` grown via
+`background-size` on hover, which `forced-colors: active` unconditionally
+forces to `none`, silently dropping the entire hover/focus affordance for
+mouse users under Windows High Contrast Mode (keyboard focus still gets
+the global `:focus-visible` outline from core). This site's own CSS was
+never audited against `forced-colors: active` before this bump either, so
+this is a **pre-existing gap being surfaced, not a regression introduced
+here** — no site-local forced-colors rule is added in this PR (out of
+scope: this bump is token-only). Flagged here as a real, concrete
+follow-up candidate — the same `text-decoration: underline` fallback
+`broadsheet.css` uses would fix it, scoped to `.lead-title a:hover,
+.entry-title a:hover, .lead-title a:focus-visible, .entry-title
+a:focus-visible` inside `@media (forced-colors: active)`.
+
 ## References
 
 - Issue #324 (this migration)
@@ -294,3 +373,7 @@ change either.
 - remarque-tokens 0.5.0 `CHANGELOG.md` — "Theme-convention unification"
   (remarque#47 item 4, ratified 3-0), the release that unblocked §6
 - Issue #283 (accent-font lint, `--font-accent` allowlist)
+- remarque-tokens 0.24.0 (consumer-refresh: state colors 0.17.0, dataviz
+  categorical 0.22.0, forced-colors/prefers-contrast 0.21.0, light-dark()
+  palette migration 0.24.0 — backward compatible for consumers, this
+  site's palette stays in the conventional `:root`/`:root.dark` form)

--- a/astro-site/package.json
+++ b/astro-site/package.json
@@ -36,7 +36,7 @@
     "cookie": "^2.0.1",
     "markdown-it": "^14.3.0",
     "rehype-mermaid": "^3.0.0",
-    "remarque-tokens": "^0.15.0",
+    "remarque-tokens": "^0.24.0",
     "sanitize-html": "^2.17.6",
     "satori": "^0.28.2",
     "svelte": "^5.56.7",

--- a/astro-site/pnpm-lock.yaml
+++ b/astro-site/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0(playwright@1.61.1)
       remarque-tokens:
-        specifier: ^0.15.0
-        version: 0.15.0
+        specifier: ^0.24.0
+        version: 0.24.0
       sanitize-html:
         specifier: ^2.17.6
         version: 2.17.6
@@ -2795,12 +2795,12 @@ packages:
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
-  remarque-tokens@0.15.0:
-    resolution: {integrity: sha512-W+9Zp8UwcoEl373N2ulpFhkmTdEhipXMCQomH36eR2eoRDGtVH/SDno0PTZhWrIxzWIJQaV6AhIqskUK/s2v6w==}
+  remarque-tokens@0.24.0:
+    resolution: {integrity: sha512-4a8ngs04qcSQQLzRH09hrqS98QWUcOqPfiVqQIgG3EbYxaoi4OQbivV/2csR2EKxFLlHRSY26ZsUPKVk1P8HSg==}
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
-      '@williamzujkowski/oklch-terminal-themes': '>=0.1.0 <0.3.0'
+      '@williamzujkowski/oklch-terminal-themes': '>=0.1.0 <1.0.0'
     peerDependenciesMeta:
       '@williamzujkowski/oklch-terminal-themes':
         optional: true
@@ -6230,7 +6230,7 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
-  remarque-tokens@0.15.0: {}
+  remarque-tokens@0.24.0: {}
 
   request-light@0.5.8: {}
 

--- a/astro-site/src/styles/global.css
+++ b/astro-site/src/styles/global.css
@@ -5,7 +5,7 @@
  * See: https://github.com/williamzujkowski/remarque
  */
 
-/* consumes remarque-tokens v0.15.0 (core tier) + local palette layer.
+/* consumes remarque-tokens v0.24.0 (core tier) + local palette layer.
  * Core tier (type scale, rhythm, spacing, content-standard/wide, radius,
  * motion, base resets, prose/typography machinery) is imported below;
  * this file keeps only the PALETTE tier (fonts, colors, --content-reading)
@@ -97,6 +97,36 @@
   --color-syntax-variable: oklch(0.26 0.01 80);
   --color-syntax-link: var(--color-accent);
 
+  /* ─── Palette tier: state colors (remarque-tokens 0.17.0, REMARQUE.md
+   * "State Colors") ─── feedback moments only (validation, banners,
+   * disabled controls), never decoration — see REMARQUE.md. Same
+   * keep-if-passing-else-solve pattern as the syntax slots above: each
+   * upstream ANSI-derived default is checked against THIS site's own
+   * --color-bg/--color-surface (both required ≥ 4.5:1) before accepting
+   * it unmodified. --color-disabled deliberately aliases --color-muted
+   * (already audited, not re-derived) rather than getting its own hue,
+   * per REMARQUE.md's "a disabled state is a muted register, not a hue". */
+  --color-error: oklch(0.52 0.12 25);            /* upstream default — 5.05:1 bg / 4.76:1 surface, unmodified */
+  --color-error-subtle: oklch(0.95 0.02 25);      /* fg on this: 16.27:1, unmodified */
+  --color-success: oklch(0.50 0.12 145);          /* solved: upstream default (L 0.51) is 4.71:1 bg / 4.43:1 surface here — darkened to 0.50 for 4.92:1 bg / 4.63:1 surface */
+  --color-success-subtle: oklch(0.95 0.02 145);   /* fg on this: 16.49:1, unmodified */
+  --color-warning: oklch(0.52 0.105 85);          /* upstream default — 4.80:1 bg / 4.52:1 surface, unmodified */
+  --color-warning-subtle: oklch(0.95 0.02 85);    /* fg on this: 16.38:1, unmodified */
+  --color-disabled: var(--color-muted);           /* alias, not a new hue — see comment above */
+
+  /* ─── Palette tier: dataviz categorical (remarque-tokens 0.22.0, REMARQUE.md
+   * "Dataviz Tokens") ─── 6 slots, each ≥ 3:1 against --color-bg (Carbon's
+   * mark-on-background line, not text's 4.5:1). All 6 pass unmodified
+   * against this site's --color-bg in both themes — no solving needed.
+   * Never the sole distinguisher between chart series: pair with shape,
+   * dash pattern, or a direct label (non-color redundancy, mandatory). */
+  --color-viz-1: oklch(0.538 0.121 250.5);  /* 4.40:1 vs this site's bg */
+  --color-viz-2: oklch(0.541 0.111 85.5);   /* 4.39:1 */
+  --color-viz-3: oklch(0.524 0.12 24.6);    /* 4.97:1 */
+  --color-viz-4: oklch(0.499 0.12 144.8);   /* 4.94:1 */
+  --color-viz-5: oklch(0.524 0.121 309.6);  /* 4.95:1 */
+  --color-viz-6: oklch(0.528 0.09 195.8);   /* 4.40:1 */
+
   /* Semantic vars core's machinery (`.remarque-prose a`, `:focus-visible`,
    * `::selection`) consumes that this site didn't previously need, since
    * its own rules set these directly (`a { color: var(--color-accent); }`,
@@ -146,6 +176,26 @@
   --color-syntax-variable: oklch(0.82 0.005 80);
   --color-syntax-link: var(--color-accent);
 
+  /* State colors (remarque-tokens 0.17.0) — default dark palette, all pass
+   * unmodified against this site's --color-bg/--color-surface. See the
+   * :root block's comment above for the derivation/solving methodology. */
+  --color-error: oklch(0.62 0.11 26);
+  --color-error-subtle: oklch(0.22 0.04 25);
+  --color-success: oklch(0.61 0.11 145);
+  --color-success-subtle: oklch(0.22 0.04 145);
+  --color-warning: oklch(0.62 0.11 85);
+  --color-warning-subtle: oklch(0.22 0.04 85);
+  --color-disabled: var(--color-muted);
+
+  /* Dataviz categorical (remarque-tokens 0.22.0) — default dark palette,
+   * all pass ≥ 3:1 against this site's --color-bg unmodified. */
+  --color-viz-1: oklch(0.708 0.129 249.5);
+  --color-viz-2: oklch(0.712 0.13 85.3);
+  --color-viz-3: oklch(0.724 0.129 310.2);
+  --color-viz-4: oklch(0.725 0.129 25.4);
+  --color-viz-5: oklch(0.696 0.129 144.9);
+  --color-viz-6: oklch(0.697 0.119 194.8);
+
   /* Core-consumed semantic vars (see the base :root block's comment) */
   --color-link: var(--color-accent);
   --color-link-hover: var(--color-accent-hover);
@@ -181,6 +231,23 @@
     --color-syntax-punctuation: oklch(0.60 0.005 80);
     --color-syntax-variable: oklch(0.82 0.005 80);
     --color-syntax-link: var(--color-accent);
+
+    /* State colors — keep in sync with :root.dark above */
+    --color-error: oklch(0.62 0.11 26);
+    --color-error-subtle: oklch(0.22 0.04 25);
+    --color-success: oklch(0.61 0.11 145);
+    --color-success-subtle: oklch(0.22 0.04 145);
+    --color-warning: oklch(0.62 0.11 85);
+    --color-warning-subtle: oklch(0.22 0.04 85);
+    --color-disabled: var(--color-muted);
+
+    /* Dataviz categorical — keep in sync with :root.dark above */
+    --color-viz-1: oklch(0.708 0.129 249.5);
+    --color-viz-2: oklch(0.712 0.13 85.3);
+    --color-viz-3: oklch(0.724 0.129 310.2);
+    --color-viz-4: oklch(0.725 0.129 25.4);
+    --color-viz-5: oklch(0.696 0.129 144.9);
+    --color-viz-6: oklch(0.697 0.119 194.8);
 
     /* Core-consumed semantic vars (see the base :root block's comment) */
     --color-link: var(--color-accent);


### PR DESCRIPTION
## What changed

Bumps `remarque-tokens` from `^0.15.0` to `^0.24.0`. npm's caret range had
frozen this site at 0.15.0 while the package moved through 0.16.0-0.24.0;
this is the consumer-refresh to close that gap and adopt the two new
palette-tier token families that shipped in between, both required by
`remarque-audit`'s CONTRAST check:

- **7 state tokens** (0.17.0, REMARQUE.md "State Colors"): `--color-error`
  / `-success` / `-warning` (each with a `-subtle` banner-background
  companion) and `--color-disabled` (aliases `--color-muted` — not a new
  hue, per spec).
- **6 dataviz categorical tokens** (0.22.0, REMARQUE.md "Dataviz Tokens"):
  `--color-viz-1` through `--color-viz-6`, each required ≥ 3:1 against
  `--color-bg` (Carbon's mark-on-background line, not text's 4.5:1).

All 13 are declared in all three of `global.css`'s palette blocks
(`:root`, `:root.dark`, the `@media (prefers-color-scheme: dark)` block),
following the same keep-if-passing-else-solve pattern §8 of
`DESIGN-DEVIATIONS.md` established for the syntax-highlighting palette.
The 9 syntax tokens from 0.15.0 were already present and needed no
changes.

The forced-colors/`prefers-contrast` work (0.21.0) and the `light-dark()`
palette migration (0.24.0, backward-compatible for consumers —
`remarque-audit`/`remarque-drift` parse both forms) required no code
changes here. This site's local palette intentionally stays in the
conventional `:root`/`:root.dark` form rather than adopting `light-dark()`
itself — out of scope for a token-conformance bump.

## Token decisions / drift summary

Only **one** of the 13 new values needed solving; the other 12 pass
unmodified against this site's own bg/surface:

| Slot | Upstream default | This site | Why |
|---|---|---|---|
| `--color-success` (light) | `oklch(0.51 0.12 145)` — 4.71:1 bg / **4.43:1 surface** (fails 4.5:1) | `oklch(0.50 0.12 145)` — 4.92:1 bg / 4.63:1 surface | This site's `--color-surface` (`oklch(0.93 0.015 75)`) sits closer to `--color-bg` than upstream's default surface/bg spread, so the default value clears bg but not surface |

`node node_modules/remarque-tokens/scripts/drift-check.mjs --css-file
src/styles/global.css --package-dir .` output:

```
Summary: 0 FAIL, 1 WARN, 19 INFO
```

- **0 FAIL** — no undocumented core-tier override.
- **1 WARN** — the pre-existing, already-ratified `--text-display`
  core-tier deviation (issue #274), unrelated to this PR.
- **19 INFO** — palette-tier personalization, all pre-existing except the
  one new line: `--color-success (light): package default "oklch(0.51
  0.12  145)", consumer defines "oklch(0.50 0.12 145)"`, correctly
  classified INFO (sanctioned), never FAIL.

Full writeup, including the exact contrast ratios for all 13 new tokens in
both themes, is in `DESIGN-DEVIATIONS.md` §9.

## Gate results (run locally, matches this repo's CI jobs)

- `pnpm run audit` (remarque/typography/colors/accent-font/apca) — all
  pass. `remarque-audit` reports every new pairing (state text vs
  bg **and** surface, fg vs each `-subtle`, viz-\* vs bg) passing in both
  themes, 0 known false positives, 0 real failures.
- `node node_modules/remarque-tokens/scripts/drift-check.mjs` — 0 FAIL, 1
  WARN (pre-existing), 19 INFO (see above).
- `pnpm build` — clean; verified the built CSS still contains core-tier
  selectors (`.text-display`, `.content-standard`, `.text-meta`) after the
  bump.
- `pnpm check` — 0 errors, 17 pre-existing hints (unchanged).
- `pnpm lint` — 0 errors, 1 pre-existing `set:html` warning (unchanged).
- `pnpm test:unit` — 7/7 pass, unchanged.
- `CI=true npx playwright test tests/e2e/` (matches `a11y.yml`) — **44
  passed, 24 skipped, 6 failed.** The 6 failures are all in
  `tests/e2e/sidenotes.spec.ts` and are **pre-existing on unmodified
  `origin/main`** — verified by stashing this PR's changes, reinstalling
  `remarque-tokens@0.15.0`, and re-running just that spec file: identical
  6 failures, 3 passed. Not introduced by this diff, which only touches
  `global.css` colors, `package.json`/`pnpm-lock.yaml`, and
  `DESIGN-DEVIATIONS.md`.

## Forced-colors gap (noted, not fixed here)

remarque-tokens 0.21.0 added `@media (forced-colors: active)` rules to
`forms.css` and `broadsheet.css` — this site imports neither module (only
`remarque-tokens/core`), so those specific fixes don't flow through.
`tokens-core.css`'s `:focus-visible` forced-colors rule *does* apply
(core is always imported), so keyboard focus rings are covered.

Auditing this site's own local CSS the same way: `.lead-title
a`/`.entry-title a` in `global.css` implements the same
gradient-underline hover/focus affordance that `broadsheet.css`'s
`.remarque-lead-title a` was fixed for in 0.21.0 — under `forced-colors:
active`, the `linear-gradient()` background is forced to `none`, silently
dropping the entire hover/focus affordance for mouse users (keyboard
focus still gets the global `:focus-visible` outline). This is a
**pre-existing gap being surfaced, not a regression** — this site's own
CSS was never audited against `forced-colors: active` before this bump
either. No site-local forced-colors rule is added here (out of scope: this
bump is token-only) — full writeup and the suggested fix (a
`text-decoration: underline` fallback, mirroring `broadsheet.css`'s own
fix) are in `DESIGN-DEVIATIONS.md` §9. A follow-up issue would be welcome.

## PR #380 rebase note

#380 ("feat: migrate sidenotes/TOC to remarque-tokens/essay") also touches
`global.css` and is awaiting human design sign-off before merge. **This
PR does not touch any sidenote/TOC code** (by design — out of scope), but
since both PRs edit `global.css`, **#380 will need a rebase against `main`
once this merges** to pick up the new state/viz token blocks cleanly.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
