### PR TITLE
a11y: forced-colors fallbacks for site-local gradient-underline hovers (closes #382)

### DIFF
--- a/astro-site/DESIGN-DEVIATIONS.md
+++ b/astro-site/DESIGN-DEVIATIONS.md
@@ -364,6 +364,8 @@ follow-up candidate — the same `text-decoration: underline` fallback
 .entry-title a:hover, .lead-title a:focus-visible, .entry-title
 a:focus-visible` inside `@media (forced-colors: active)`.
 
+**Fixed** — closes [#382](https://github.com/williamzujkowski/williamzujkowski.github.io/issues/382): the exact `@media (forced-colors: active)` block described above now lives in `global.css` directly below the `.lead-title a:hover, .entry-title a:hover` rule.
+
 ## 10. Sidenotes/TOC migrated to `remarque-tokens/essay` (graduation, issue #378)
 
 **This section documents a graduation, not a new deviation.** This site's

--- a/astro-site/src/styles/global.css
+++ b/astro-site/src/styles/global.css
@@ -1194,6 +1194,26 @@ div:has(> .post-card) {
 }
 .lead-title a:hover,
 .entry-title a:hover { background-size: 100% 1px; }
+
+/* Forced-colors fallback (issue #382 — site-local instance of the same
+ * affordance-loss upstream fixed in remarque-tokens broadsheet.css 0.21.0:
+ * the underline-grow hover/focus signal above is painted entirely with
+ * `background-image: linear-gradient(...)`, which `forced-colors: active`
+ * forces to `none`. Without this, hovering/focusing a lead or entry title
+ * link produces no visible change at all under Windows High Contrast Mode.
+ * `text-decoration: underline` isn't a forced property, so it stands in as
+ * the same "this link is active" cue. Scoped to this media query only —
+ * the gradient underline-grow stays the only affordance outside
+ * forced-colors mode. */
+@media (forced-colors: active) {
+  .lead-title a:hover,
+  .lead-title a:focus-visible,
+  .entry-title a:hover,
+  .entry-title a:focus-visible {
+    text-decoration: underline;
+  }
+}
+
 .lead-lede {
   font-family: var(--font-display);
   font-size: 1.375rem;

--- a/astro-site/tests/e2e/forced-colors.spec.ts
+++ b/astro-site/tests/e2e/forced-colors.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from 'playwright/test';
+
+// Forced-colors (Windows High Contrast Mode) regression for the broadsheet
+// gradient-underline hover (issue #382). `.lead-title a` / `.entry-title a`
+// paint their hover/focus affordance entirely with `background-image:
+// linear-gradient(...)`, which forced-colors mode forces to `none` — without
+// the `text-decoration: underline` fallback in global.css's
+// `@media (forced-colors: active)` block, hovering/focusing one of these
+// links would produce no visible change at all under WHCM.
+
+test.describe('forced-colors: active', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.emulateMedia({ forcedColors: 'active' });
+  });
+
+  test('lead title link shows a text-decoration underline on hover', async ({ page }) => {
+    await page.goto('/');
+    const link = page.locator('.lead-title a').first();
+    await expect(link).toBeVisible();
+
+    await link.hover();
+    const decoration = await link.evaluate(
+      (el) => getComputedStyle(el).textDecorationLine
+    );
+    expect(decoration).not.toBe('none');
+    expect(decoration).toContain('underline');
+  });
+
+  test('entry title link shows a text-decoration underline on hover', async ({ page }) => {
+    await page.goto('/');
+    const link = page.locator('.entry-title a').first();
+    await expect(link).toBeVisible();
+
+    await link.hover();
+    const decoration = await link.evaluate(
+      (el) => getComputedStyle(el).textDecorationLine
+    );
+    expect(decoration).not.toBe('none');
+    expect(decoration).toContain('underline');
+  });
+
+  test('entry title link shows a text-decoration underline on keyboard focus', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    const link = page.locator('.entry-title a').first();
+    await link.focus();
+    const decoration = await link.evaluate(
+      (el) => getComputedStyle(el).textDecorationLine
+    );
+    expect(decoration).not.toBe('none');
+    expect(decoration).toContain('underline');
+  });
+});


### PR DESCRIPTION
## Summary
- `.lead-title a` / `.entry-title a` in `global.css` paint their hover/focus affordance entirely via `background-image: linear-gradient(...)`, grown on hover with `background-size` — the same pattern `remarque-tokens`' `broadsheet.css` was fixed for in 0.21.0.
- Under `forced-colors: active`, `background-image` is forced to `none`, silently dropping the hover/focus signal for mouse users under Windows High Contrast Mode (keyboard focus still gets the global `:focus-visible` outline). This site imports only `remarque-tokens/core`, so the upstream fix never reached it — flagged as a known gap in `DESIGN-DEVIATIONS.md` §9 during the 0.24.0 refresh (#381).
- Adds the exact same `text-decoration: underline` fallback inside a single `@media (forced-colors: active)` block in `global.css`, scoped to `.lead-title`/`.entry-title` hover and focus-visible states only — nothing changes outside forced-colors mode.
- Swept the rest of `astro-site/src/styles` (`global.css`, `zine.css`, `theme-deck.css`) plus every `.astro` component's scoped `<style>` block for other `background-image`/gradient hovers — this is the only occurrence in the codebase. Other hover-only state changes found (`.chip`/`.card` border-color, nav/footer link color, theme-deck option background) all retain a non-color affordance at rest (an existing border, a `✓` checkmark, or the base underlined `<a>`), so they don't share the same forced-to-`none` failure mode and are left alone.
- `DESIGN-DEVIATIONS.md` §9 updated to mark the gap fixed, with a reference back to this PR/issue.

## Test plan
- [x] New Playwright spec `astro-site/tests/e2e/forced-colors.spec.ts`: emulates `forcedColors: 'active'`, asserts a non-`none` `text-decoration-line` containing `underline` on `.lead-title a` hover, `.entry-title a` hover, and `.entry-title a` keyboard focus.
- [x] `pnpm run audit` (remarque contrast/gamut, typography floor, color-token, accent-font, APCA) — all pass.
- [x] `pnpm check` — 0 errors (pre-existing hints only).
- [x] `pnpm lint` — 0 errors (pre-existing warning only, unrelated file).
- [x] `pnpm test:unit` — 7/7 pass.
- [x] `pnpm build` — succeeds, 201 pages.
- [x] `npx playwright test` — new forced-colors spec (3/3), smoke (19/19), a11y (38/38), theme-deck, sidenotes all green. `visual-baselines.spec.ts` fails in this sandbox on unmodified `main` too (pixel-height drift from local font rendering vs. the CI-generated snapshots), confirmed unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)