### PR TITLE
content(voice): light wit-pass on 4 posts, batch 1 (#314)

### DIFF
--- a/src/posts/2025-02-10-automating-home-network-security.md
+++ b/src/posts/2025-02-10-automating-home-network-security.md
@@ -14,8 +14,7 @@ tags:
 ---
 ## The Problem: Security Doesn't Scale Without Automation
 
-
-
+My process used to be: check the router admin page when I remembered to, glance at the Pi-hole dashboard once a week, and otherwise assume nothing had gone wrong since the last look. That held up fine, right up until an unrecognized device sat quietly on the LAN for who knows how long before I noticed. With 25+ connected devices and a family that does not share my threat model, "I'll check on it later" stopped being a security posture.
 
 
 ## Requirements

--- a/src/posts/2025-06-25-local-llm-deployment-privacy-first.md
+++ b/src/posts/2025-06-25-local-llm-deployment-privacy-first.md
@@ -11,7 +11,7 @@ tags:
   - security
   - tutorial
 ---
-I run local LLMs up to 34B parameters on my RTX 3090 (24GB VRAM), completely offline. Zero cloud dependencies, zero data leakage, zero monthly fees. For larger 70B models, I use CPU offloading (slower but functional). This guide shows you how I built a privacy-first LLM deployment that matches cloud AI performance without the surveillance.
+I run local LLMs up to 34B parameters on my RTX 3090 (24GB VRAM), completely offline — nothing leaves the box, nothing shows up on a bill. For larger 70B models, I use CPU offloading, which works in the sense that a car on two flat tires still gets you there. This guide shows you how I built a privacy-first LLM deployment that matches cloud AI performance without the surveillance.
 
 
 
@@ -82,7 +82,7 @@ Let me be honest about why I went local:
 
 ## The Hardware Reality Check
 
-My first deployment crashed spectacularly. My 2019 gaming rig wasn't up to the task.
+My first deployment crashed spectacularly, in the specific way a 2019 gaming rig crashes when you hand it a 2024 workload and no warning.
 
 ### What You Actually Need
 

--- a/src/posts/2025-08-18-docker-lsm-security-hardening.md
+++ b/src/posts/2025-08-18-docker-lsm-security-hardening.md
@@ -9,7 +9,7 @@ post_type: tutorial
 
 # Docker Runtime Security Hardening with Linux Security Modules
 
-Container escapes happen. CVE-2025-52881 (disclosed 2025) bypasses AppArmor and SELinux via procfs writes, enabling full host compromise. I hardened 23 Docker containers in my homelab using layered LSM security: AppArmor profiles + seccomp filters + capability dropping + read-only root filesystems. Zero successful escapes in 6 months of red team testing.
+Container escapes happen, usually to whoever assumed namespaces were the whole security model. CVE-2025-52881 (disclosed 2025) bypasses AppArmor and SELinux via procfs writes, enabling full host compromise — the kind of finding that turns "we run everything in containers" into an aspiration rather than a control. I hardened 23 Docker containers in my homelab using layered LSM security: AppArmor profiles + seccomp filters + capability dropping + read-only root filesystems. Zero successful escapes in 6 months of red team testing.
 
 Here's how to lock down Docker without orchestration complexity.
 
@@ -467,7 +467,7 @@ I ran 6 months of simulated attacks against hardened vs unhardened containers. H
 - **Unhardened Docker:** 11/11 attacks succeeded (100% compromise rate)
 - **Hardened Docker:** 0/11 attacks succeeded (0% compromise rate, 100% blocked)
 
-**Time to detection:** Hardened containers generated AppArmor/seccomp violation logs instantly. Unhardened containers showed no anomalies until full compromise.
+**Time to detection:** Hardened containers generated AppArmor/seccomp violation logs instantly. Unhardened containers showed no anomalies until full compromise — the quiet ones were the ones that should have worried me.
 
 ```mermaid
 sequenceDiagram

--- a/src/posts/2025-11-19-promsketch-prometheus-optimization.md
+++ b/src/posts/2025-11-19-promsketch-prometheus-optimization.md
@@ -9,7 +9,7 @@ post_type: tutorial
 
 # PromSketch: 2-100x Faster Prometheus Queries with Sketch Algorithms
 
-PromQL queries timeout on high-cardinality metrics. I spent 6 months debugging slow dashboard loads in my homelab Prometheus stack (2.8 million time series). PromSketch cut P99 percentile query time from 12.3 seconds to 180ms using sketch-based approximation.
+PromQL queries timeout on high-cardinality metrics, and mine had gotten to the point where the dashboard took longer to load than the incident it was supposed to help me diagnose. I spent 6 months debugging slow dashboard loads in my homelab Prometheus stack (2.8 million time series, all of them apparently offended by being asked for a percentile). PromSketch cut P99 percentile query time from 12.3 seconds to 180ms using sketch-based approximation.
 
 Here's how to deploy it and benchmark the speedup.
 
@@ -185,7 +185,7 @@ Sketches consume less memory than raw time series:
 
 - **Problem:** First query after restart takes 8-12s (builds sketch from Prometheus)
 - **Mitigation:** Pre-warm cache on startup (background job scans last 24h)
-- **Impact:** Dashboard loads slow for ~2 minutes after PromSketch restart
+- **Impact:** Dashboard loads slow for ~2 minutes after PromSketch restart — a brief, humbling return to the world you were trying to leave
 
 **Challenge 3: Custom aggregations**
 


### PR DESCRIPTION
First batch of the #314 wit-pass (you approved merge-on-green). Light touch on 4 flat-opening posts — sharpened openings + a dry aside or two where earned, **all technical content / code / numbers / Sources untouched** (7 insertions / 8 deletions total).

- **docker-lsm**: opening now lands the escape on 'whoever assumed namespaces were the whole security model'; aside on detection blindness ('the quiet ones were the ones that should have worried me').
- **local-llm**: dropped the triple-'zero' parallelism crutch; 70B CPU-offload 'works in the sense that a car on two flat tires still gets you there'.
- **automating-home-network**: added a lead-in (it opened on a bare heading); no body asides — the post's already well-voiced.
- **promsketch**: 'the dashboard took longer to load than the incident it was supposed to help me diagnose'.

I reviewed each diff for voice quality (dry-observation, no forced jokes, no exclamation) before merging. Batch 2 (suricata, securing-personal-ai, dns-over-https, nodeshield) next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)