### PR TITLE
fix(content): remove 15 empty "## How It Works" stub headings (vestigial)

### DIFF
--- a/src/posts/2024-02-09-deepfake-dilemma-ai-deception.md
+++ b/src/posts/2024-02-09-deepfake-dilemma-ai-deception.md
@@ -19,9 +19,6 @@ Even more concerning, the false positive rate hit 18%. Nearly one in five real v
 <div class="zine-doodle" aria-hidden="true" style="--doodle: url('/assets/doodles/deepfake.png'); width: min(300px, 75%); aspect-ratio: 560/418; margin: 2rem auto 0.5rem;"></div>
 <p class="hand-note" style="text-align: center; display: block;">the tell is always on the right</p>
 
-## How It Works
-
-
 ## The Technology That Shattered Trust
 
 Deepfakes use generative adversarial networks (GANs) in a digital arms race. One neural network creates increasingly realistic fake content while another network tries to detect the forgeries. They push each other toward perfection in an endless cycle of improvement.

--- a/src/posts/2024-02-22-open-source-vs-proprietary-llms.md
+++ b/src/posts/2024-02-22-open-source-vs-proprietary-llms.md
@@ -13,9 +13,6 @@ After switching to a 4-bit quantized version and tweaking llama.cpp settings, I 
 
 This experience taught me that choosing between open-source and proprietary LLMs isn't about ideology. It's about understanding trade-offs, accepting real hardware constraints, and matching solutions to specific needs. Sometimes the "free" model costs you three days of debugging. Sometimes the API bill is cheaper than your time.
 
-## How It Works
-
-
 ## The Accessibility Question: Freedom vs. Convenience
 
 My first encounter with open-source LLMs came through Meta's LLaMA 2 release in July 2023. I was excited to finally peek under the hood, understand how these models work, and modify them for my specific needs.

--- a/src/posts/2024-04-04-retrieval-augmented-generation-rag.md
+++ b/src/posts/2024-04-04-retrieval-augmented-generation-rag.md
@@ -19,9 +19,6 @@ That's when I realized I needed RAG, not just a smarter model.
 <div class="zine-doodle" aria-hidden="true" style="--doodle: url('/assets/doodles/rag.png'); width: min(240px, 62%); aspect-ratio: 340/303; margin: 2rem auto 0.5rem;"></div>
 <p class="hand-note" style="text-align: center; display: block;">fetch first, answer second</p>
 
-## How It Works
-
-
 ## The Problem: When "Knowing Everything" Isn't Enough
 
 The limitations of standard LLMs became apparent pretty quickly when I tried to use them for my homelab:

--- a/src/posts/2024-04-11-ethics-large-language-models.md
+++ b/src/posts/2024-04-11-ethics-large-language-models.md
@@ -12,9 +12,6 @@ Whenever I interact with a Large Language Model, there's a moment of awe, like s
 
 Deploying a customer-facing LLM for the first time in March 2023 felt like releasing something powerful and unpredictable into the wild. The lessons that followed, about bias, fairness, and responsibility, changed how I think about AI development and deployment.
 
-## How It Works
-
-
 ## The Bias Mirror: Reflecting Humanity's Flaws
 
 My awakening to AI bias came during testing of a resume screening tool in August 2022. [The system consistently ranked male candidates higher for technical positions, even when qualifications were identical](https://www.brookings.edu/articles/gender-race-and-intersectional-bias-in-ai-resume-screening-via-language-model-retrieval/) (Wilson & Caliskan, 2024). After testing 500 identical resume pairs with only the names changed, I measured a 23% score differential favoring male-associated names. The model had learned from historical hiring data that reflected decades of workplace discrimination.

--- a/src/posts/2024-04-19-mastering-prompt-engineering-llms.md
+++ b/src/posts/2024-04-19-mastering-prompt-engineering-llms.md
@@ -29,9 +29,6 @@ Prompt engineering combines systematic optimization with practical techniques to
 
 **Critical warning:** LLMs are unreliable tools requiring constant verification. Hallucinations, bias, and inconsistency make them unsuitable for high-stakes decisions without human oversight.
 
-## How It Works
-
-
 ## Core Principle: Context Over Brevity
 
 **Bad prompt:**

--- a/src/posts/2024-05-14-ai-new-frontier-cybersecurity.md
+++ b/src/posts/2024-05-14-ai-new-frontier-cybersecurity.md
@@ -20,9 +20,6 @@ The pattern was subtle: five ports probed over 18 hours, each connection lasting
 
 That moment crystallized both the immense promise and the frustrating reality of AI in cybersecurity. When it works, it's remarkable. When it doesn't, you're drowning in false alarms wondering if you should just go back to grep and tcpdump.
 
-## How It Works
-
-
 ## The Double-Edged Nature of AI in Security
 
 Working with AI security tools since 2021 taught me that every defensive capability creates corresponding offensive possibilities. It's a frustrating arms race where your best defense inevitably becomes someone else's attack template.

--- a/src/posts/2024-05-30-ai-learning-resource-constrained.md
+++ b/src/posts/2024-05-30-ai-learning-resource-constrained.md
@@ -20,9 +20,6 @@ Staring at my electricity bill after running a large language model training job
 
 That moment of financial reality sparked my deep dive into AI learning in resource-constrained environments. This journey taught me more about efficiency, creativity, and the fundamentals of machine learning than years of unlimited cloud budgets ever could.
 
-## How It Works
-
-
 ## The Reality Check: When Resources Become Constraints
 
 My introduction to resource-constrained AI came from necessity, not choice. After burning through my AWS credits on a poorly optimized training run, I faced a choice: abandon AI experimentation or learn to do more with less.

--- a/src/posts/2024-07-09-zero-trust-architecture-implementation.md
+++ b/src/posts/2024-07-09-zero-trust-architecture-implementation.md
@@ -15,8 +15,6 @@ I spent three solid weekends implementing Zero Trust principles in my homelab us
 
 By June 2024, I had created distinct VLANs for management (192.168.1.0/24), servers (192.168.10.0/24), IoT devices (192.168.20.0/24), guest network (192.168.30.0/24), security tools (192.168.40.0/24), cameras (192.168.50.0/24), work devices (192.168.60.0/24), and storage (192.168.70.0/24). According to Wazuh 4.7.0 metrics from my SIEM, this segmentation reduced potential lateral movement paths by 94% compared to my previous flat network design. For detailed implementation guidance on [building a security-focused homelab with proper VLAN segmentation](/posts/2025-04-24-building-secure-homelab-adventure), I've shared my complete network architecture and lessons learned.
 
-## How It Works
-
 ## The Perimeter Security Illusion
 
 For decades, we'd built security around a simple premise: establish a secure perimeter, trust everything inside it, and scrutinize everything trying to get in. This model worked when employees sat at office desks connected to corporate networks, but it crumbled as work became distributed, cloud-first, and mobile.

--- a/src/posts/2024-07-24-multimodal-foundation-models.md
+++ b/src/posts/2024-07-24-multimodal-foundation-models.md
@@ -13,9 +13,6 @@ The first time I fed a UI mockup screenshot to GPT-4 Vision and watched it gener
 
 That moment marked my introduction to multimodal foundation models, systems that can reason across text, images, audio, and video with human-like fluency. The implications were staggering: AI that could truly see, hear, and understand the world as we do, though I'm cautious about overstating how close we really are to [human-level multimodal understanding](/posts/2024-03-20-transformer-architecture-deep-dive).
 
-## How It Works
-
-
 ## The Convergence: When AI Learns to See and Speak
 
 For years, AI capabilities were siloed. Computer vision models could classify images but couldn't explain them. Language models could write eloquently about concepts they'd never seen. Speech recognition systems could transcribe but not comprehend.

--- a/src/posts/2024-09-09-embodied-ai-teaching-agents.md
+++ b/src/posts/2024-09-09-embodied-ai-teaching-agents.md
@@ -20,9 +20,6 @@ That simulation experience crystallized something I'd been thinking about for ye
 
 The sim-to-real gap is probably the hardest unsolved problem in robotics, but maybe the human-robot communication gap is just as critical. Recent breakthrough research is finally addressing this, and after my Isaac Sim failures, the implications feel deeply personal.
 
-## How It Works
-
-
 ## The Problem with Assumption-Making Robots
 
 The challenge isn't just technical, it's deeply human. When instructions are ambiguous, traditional embodied AI agents typically handle it in one of three problematic ways. This intersection of AI capabilities and real-world interaction parallels challenges explored in multimodal foundation models, where systems must understand context across vision, language, and action.

--- a/src/posts/2024-10-03-quantum-computing-defense.md
+++ b/src/posts/2024-10-03-quantum-computing-defense.md
@@ -14,8 +14,6 @@ The convergence of quantum computing and defense technologies represents one of 
 
 Having followed this field closely since 2018, I've come to understand that quantum computing in defense isn't a distant future concern. It's a present reality that demands immediate attention and strategic planning.
 
-## How It Works
-
 ## The Quantum Advantage: Beyond Classical Limitations
 
 Quantum computing uses principles of quantum mechanics (superposition, entanglement, and quantum interference) to perform certain calculations exponentially faster than classical computers. While today's quantum computers are still noisy and limited, they're already capable enough to impact defense planning.

--- a/src/posts/2024-10-22-ai-edge-computing.md
+++ b/src/posts/2024-10-22-ai-edge-computing.md
@@ -15,9 +15,6 @@ That failure taught me something important about edge computing. After convertin
 
 The real win? Latency dropped from 200-500ms (cloud-based) to 15-50ms (local inference). And I'm not paying $0.001 per inference anymore. The convergence of artificial intelligence and edge computing represents one of the most significant shifts in how we think about data processing and decision-making. See my practical implementation of [running LLaMA on Raspberry Pi](/posts/2024-09-15-running-llama-raspberry-pi-pipeload) for hands-on edge deployment techniques. Instead of sending everything to distant cloud servers, we're bringing intelligence to where data originates, at the "edge" of the network. This transformation is creating systems that can respond in milliseconds rather than seconds, protect privacy by keeping sensitive data local, and maintain functionality even when network connections fail. It's fundamentally changing what's possible with AI applications. Though I should say, edge AI works great for simple tasks like object detection, but complex reasoning still needs cloud-scale compute.
 
-## How It Works
-
-
 ## Understanding Edge Computing: Proximity as Power
 
 Edge computing shifts processing from centralized data centers to locations physically closer to data sources. This proximity creates benefits that are particularly useful when combined with AI.

--- a/src/posts/2024-12-03-context-windows-llms.md
+++ b/src/posts/2024-12-03-context-windows-llms.md
@@ -20,9 +20,6 @@ It's a finite space where previous conversation, relevant information, and the c
 
 The length of conversations we can have. The complexity of documents we can analyze. The quality of code assistance we can expect. Understanding context windows isn't optional if you're working with large language models.
 
-## How It Works
-
-
 ## The Mechanics: How Context Windows Work
 
 At its core, a context window defines the maximum number of tokens (parts of words, whole words, or punctuation marks) that a language model can process simultaneously. This limitation stems from the fundamental architecture of [transformer models](/posts/2024-03-20-transformer-architecture-deep-dive), which rely on attention mechanisms that weigh relationships between all elements in a sequence.

--- a/src/posts/2025-04-10-securing-personal-ai-experiments.md
+++ b/src/posts/2025-04-10-securing-personal-ai-experiments.md
@@ -38,8 +38,6 @@ logging
 psutil
 torch
 ```
-## How It Works
-
 
 ## Why Security Matters for Personal AI Projects
 

--- a/src/posts/2025-05-10-llm-fine-tuning-homelab-guide.md
+++ b/src/posts/2025-05-10-llm-fine-tuning-homelab-guide.md
@@ -13,9 +13,6 @@ tags:
 
 After 47 hours of experimentation across two weeks, I finally got it working using QLoRA with 4-bit quantization. The successful training run took 14 hours at 340W average power consumption, which cost me roughly $8.40 in electricity. This guide shares everything I learned from that journey, including the five failures that taught me more than the eventual success.
 
-## How It Works
-
-
 ## Understanding Parameter-Efficient Fine-Tuning
 
 Traditional fine-tuning updates all model parameters during training. For large models with billions of parameters, this requires enormous computational resources. I discovered this the hard way when my first attempt to fine-tune the full Llama 3 8B model immediately maxed out my system's 64GB of RAM and triggered swap thrashing on my i9-9900K.


### PR DESCRIPTION
## What

A QA sweep of the post corpus found **15 older posts carrying an empty `## How It Works` heading** — a header with no body, immediately followed by the real first section. It's a leftover from the SEO-template era, and it added a dead entry to each post's table of contents that linked to an empty section.

Removed the stub from all 15 (each verified genuinely empty: the next non-blank line is another heading).

**Left untouched:** the 2 posts with a *real* "How It Works" section that owns a mermaid diagram — `transformer-architecture-deep-dive` and `quantum-computing-leap-forward`.

## How it was found

The doodle-placement QA agent (reviewing batch-6's 37 doodle insertions) flagged this as a **pre-existing, site-wide artifact unrelated to the doodles** — present identically in doodle-free posts. Confirmed with a corpus scan: 15 empty stubs, 2 legitimate sections.

## Safety
- No internal links reference the `#how-it-works` anchor (grepped `src/` + `astro-site/src/`)
- 15 files, 42 line deletions, pure heading removal — no design/CSS impact
- `pnpm build` — 202 pages, pre-commit hook green

🤖 Generated with [Claude Code](https://claude.com/claude-code)