### PR TITLE
feat(diagrams): native responsive flow component + first conversion (#414)

### DIFF
--- a/astro-site/src/styles/global.css
+++ b/astro-site/src/styles/global.css
@@ -887,6 +887,73 @@ article .prose > p:first-of-type::first-letter {
   border: 1px solid var(--color-border);
 }
 
+/* ===== Native flow diagrams (issue #414) — theme-token HTML flows that
+ * reshape wide Mermaid flowcharts into a vertical, phone-legible column.
+ * Authored as raw HTML in posts (like .zine-doodle); no build step, real
+ * site type so text is full-size & high-contrast, and it reflows: parallel
+ * rows and branches wrap/stack on narrow screens. All text >= 0.8125rem
+ * (USWDS 13px floor). Connectors are drawn by CSS between direct children. */
+.prose .flow {
+  display: flex; flex-direction: column; align-items: center; gap: 0;
+  margin-block: var(--space-6); font-family: var(--font-body);
+  color: var(--color-fg); text-align: center;
+}
+.prose .flow > * { position: relative; max-width: 100%; }
+/* vertical connector + arrowhead above every child after the first */
+.prose .flow > * + * { margin-top: 1.9rem; }
+.prose .flow > * + *::before {
+  content: ""; position: absolute; top: -1.75rem; left: 50%;
+  width: 2px; height: 1.25rem; transform: translateX(-50%);
+  background: var(--color-border-bold);
+}
+.prose .flow > * + *::after {
+  content: ""; position: absolute; top: -0.55rem; left: 50%;
+  transform: translateX(-50%);
+  border: 5px solid transparent; border-bottom: 0;
+  border-top-color: var(--color-border-bold);
+}
+.prose .flow-node {
+  background: var(--color-surface); border: 1.5px solid var(--color-border-bold);
+  border-radius: var(--radius-md); padding: 0.5rem 0.85rem;
+  line-height: 1.3; font-size: 0.95rem; font-weight: 600;
+}
+.prose .flow-node b { display: block; font-weight: 600; }
+.prose .flow-node i {
+  display: block; font-style: normal; font-weight: 400;
+  font-family: var(--font-mono); font-size: 0.8125rem;
+  color: var(--color-fg-muted); margin-top: 0.1rem;
+}
+/* decision / gate — dashed accent pill */
+.prose .flow-node.is-gate {
+  border-style: dashed; border-color: var(--color-accent);
+  border-radius: 999px; color: var(--color-accent);
+}
+.prose .flow-node.is-good { border-color: var(--color-success); color: var(--color-success); }
+.prose .flow-node.is-bad  { border-color: var(--color-error);   color: var(--color-error); }
+/* parallel steps — a row that wraps to a stack on narrow screens */
+.prose .flow-parallel {
+  display: flex; flex-wrap: wrap; gap: 0.5rem; justify-content: center; width: 100%;
+}
+.prose .flow-parallel .flow-node { flex: 1 1 7rem; min-width: 6rem; margin-top: 0; }
+.prose .flow-parallel .flow-node::before, .prose .flow-parallel .flow-node::after { content: none; }
+/* two-way branch — legs wrap/stack; each carries a labelled pill */
+.prose .flow-branch {
+  display: flex; flex-wrap: wrap; gap: 1rem; justify-content: center; width: 100%;
+}
+.prose .flow-leg {
+  display: flex; flex-direction: column; align-items: center; flex: 1 1 9rem;
+}
+.prose .flow-leg::before {
+  content: attr(data-branch); font-family: var(--font-mono);
+  font-size: 0.8125rem; letter-spacing: var(--tracking-meta);
+  text-transform: uppercase; color: var(--color-muted);
+  border: 1px solid currentColor; border-radius: 999px;
+  padding: 0.05rem 0.55rem; margin-bottom: 0.4rem;
+}
+.prose .flow-leg[data-branch]:has(.is-good)::before { color: var(--color-success); }
+.prose .flow-leg[data-branch]:has(.is-bad)::before  { color: var(--color-error); }
+@media (prefers-reduced-motion: reduce) { .prose .flow * { transition: none; } }
+
 /* ===== Footer ===== */
 .site-footer {
   margin-block-start: var(--space-8);

--- a/src/posts/2025-10-06-automated-security-scanning-pipeline.md
+++ b/src/posts/2025-10-06-automated-security-scanning-pipeline.md
@@ -117,19 +117,21 @@ I installed all three scanners on my Ubuntu 22.04 homelab server. The process to
 
 The pipeline orchestrates three scanners in parallel with a final quality gate:
 
-```mermaid
-flowchart LR
-    A[Git Push/PR] --> B{Trigger Pipeline}
-    B --> C[OSV: Dependency Scan]
-    B --> D[Grype: Container Scan]
-    B --> E[Trivy: Filesystem Scan]
-    C --> F[Upload SARIF]
-    D --> F
-    E --> F
-    F --> G{Security Gate}
-    G -->|Pass| H[Deploy]
-    G -->|Critical Found| I[Block & Alert]
-```
+<div class="flow">
+  <div class="flow-node">Git Push / PR</div>
+  <div class="flow-node is-gate">Trigger Pipeline</div>
+  <div class="flow-parallel">
+    <div class="flow-node"><b>OSV</b><i>dependency scan</i></div>
+    <div class="flow-node"><b>Grype</b><i>container scan</i></div>
+    <div class="flow-node"><b>Trivy</b><i>filesystem scan</i></div>
+  </div>
+  <div class="flow-node">Upload SARIF</div>
+  <div class="flow-node is-gate">Security Gate</div>
+  <div class="flow-branch">
+    <div class="flow-leg" data-branch="Pass"><div class="flow-node is-good">Deploy</div></div>
+    <div class="flow-leg" data-branch="Critical"><div class="flow-node is-bad">Block &amp; Alert</div></div>
+  </div>
+</div>
 
 **Key workflow features:** Triggers on push, pull requests, and daily at 2 AM UTC. Parallel scanner execution completes in 2-3 minutes total runtime. SARIF reports upload to GitHub Security tab automatically. Hard blocks occur on critical/high vulnerabilities. Slack notifications alert on failure.
 


### PR DESCRIPTION
Implements **Option B** from the mobile-legibility exploration (the one chosen after the pan/zoom viewer was shelved as a crutch).

## What
A `.flow` CSS component (in `global.css`) that reshapes wide Mermaid flowcharts into **vertical, phone-legible HTML flows** built from the site's own design tokens:
- Full-size, high-contrast text (real site fonts) — no pinch-zoom
- CSS-drawn connectors + arrowheads between steps
- **Reflows**: parallel rows and branches wrap/stack on narrow screens
- Adapts to light/dark + all 12 deck palettes automatically
- No headless-browser build cost; authored as raw HTML in posts (same mechanism as `.zine-doodle`)
- All text ≥ 0.8125rem (USWDS 13px floor — audit clean)

## Class contract
```
.flow
  .flow-node            (a step)      [.is-gate | .is-good | .is-bad]
  .flow-parallel        (wrapping row of .flow-node)
  .flow-branch
    .flow-leg[data-branch="Pass"]  (labelled leg)  > .flow-node
```
Connectors are drawn by CSS between direct `.flow` children.

## This PR
- The `.flow` system
- First conversion: the CI security-scanning pipeline (was `flowchart LR`)

Remaining ~95 flowchart conversions will follow in batches (delegated), per #414. Verified rendering at 390px in light + dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)