### PR TITLE
feat(diagrams): convert 16 pipeline flowcharts to native flow (#414)

### DIFF
--- a/src/posts/2024-01-30-python-vulnerability-scanner-automation.md
+++ b/src/posts/2024-01-30-python-vulnerability-scanner-automation.md
@@ -61,22 +61,18 @@ My scanner uses three components: package inventory, NVD query engine, and alert
 
 **System design:**
 
-```mermaid
-flowchart LR
-    Inventory[Package Inventory] -->|List installed| Scanner[Vulnerability Scanner]
-    Scanner -->|Query CVEs| NVD[NVD API 2.0]
-    NVD -->|CVE details| Matcher[Version Matcher]
-    Matcher -->|Vulnerable?| Filter[Severity Filter]
-    Filter -->|Critical/High| Alerts[Alert Dispatcher]
-    Alerts -->|Notify| Slack[Slack/Email]
-    Alerts -->|Metrics| Prom[Prometheus]
-
-    classDef core fill:#3498db,color:#fff
-    classDef external fill:#e74c3c,color:#fff
-
-    class Scanner,Matcher,Filter core
-    class NVD,Alerts external
-```
+<div class="flow">
+  <div class="flow-node"><b>Package Inventory</b><i>list installed</i></div>
+  <div class="flow-node"><b>Vulnerability Scanner</b><i>query CVEs</i></div>
+  <div class="flow-node"><b>NVD API 2.0</b><i>CVE details</i></div>
+  <div class="flow-node"><b>Version Matcher</b><i>vulnerable?</i></div>
+  <div class="flow-node"><b>Severity Filter</b><i>Critical / High</i></div>
+  <div class="flow-node">Alert Dispatcher</div>
+  <div class="flow-parallel">
+    <div class="flow-node"><b>Slack / Email</b><i>notify</i></div>
+    <div class="flow-node"><b>Prometheus</b><i>metrics</i></div>
+  </div>
+</div>
 
 **How it works:**
 

--- a/src/posts/2024-06-11-zero-knowledge-authentication-homelab.md
+++ b/src/posts/2024-06-11-zero-knowledge-authentication-homelab.md
@@ -54,26 +54,16 @@ My homelab SSO replaces password transmission with ZK-SNARK proof generation and
 
 **System design:**
 
-```mermaid
-flowchart LR
-    User[User Browser] -->|Username| Client[ZK Client\nJavaScript]
-    Client -->|Password\nlocal only| ProofGen[Proof Generator\nzk-SNARK]
-    ProofGen -->|Proof π| Server[Auth Server]
-    Server -->|Verify π| Verifier[ZK Verifier]
-    Verifier -->|Valid?| TokenIssue[JWT Issuer]
-    TokenIssue -->|Session Token| User
-
-    DB[(User DB\nPublic Keys Only)]
-    Server -.->|Lookup public key| DB
-
-    classDef client fill:#3498db,color:#fff
-    classDef server fill:#e74c3c,color:#fff
-    classDef crypto fill:#9b59b6,color:#fff
-
-    class User,Client,ProofGen client
-    class Server,Verifier,TokenIssue server
-    class DB crypto
-```
+<div class="flow">
+  <div class="flow-node">User Browser</div>
+  <div class="flow-node"><b>ZK Client</b><i>JavaScript; username, password local only</i></div>
+  <div class="flow-node"><b>Proof Generator</b><i>zk-SNARK proof π</i></div>
+  <div class="flow-node">Auth Server</div>
+  <div class="flow-node"><b>User DB</b><i>public keys only</i></div>
+  <div class="flow-node is-gate"><b>ZK Verifier</b><i>verify π</i></div>
+  <div class="flow-node is-good">JWT Issuer</div>
+  <div class="flow-node">Session Token</div>
+</div>
 
 **How it works:**
 

--- a/src/posts/2024-06-25-designing-resilient-systems.md
+++ b/src/posts/2024-06-25-designing-resilient-systems.md
@@ -22,19 +22,16 @@ On paper, the system had everything — load balancers, database replicas, circu
 5. Circuit breakers open, but fallback services are also overwhelmed
 6. Total platform outage
 
-```mermaid
-flowchart TD
-    A["DB Timeout"] --> B["Connection Pools Fill Up"]
-    B --> C["Health Checks Fail"]
-    C --> D["Auto-Scaling Triggers"]
-    D --> E["New Instances Overwhelm DB"]
-    E --> F["Circuit Breakers Open"]
-    F --> G["Fallback Services Overwhelmed"]
-    G --> H["Total Platform Outage"]
-
-    style A fill:#e74c3c,color:#fff
-    style H fill:#c0392b,color:#fff
-```
+<div class="flow">
+  <div class="flow-node is-bad">DB Timeout</div>
+  <div class="flow-node">Connection Pools Fill Up</div>
+  <div class="flow-node">Health Checks Fail</div>
+  <div class="flow-node">Auto-Scaling Triggers</div>
+  <div class="flow-node">New Instances Overwhelm DB</div>
+  <div class="flow-node">Circuit Breakers Open</div>
+  <div class="flow-node">Fallback Services Overwhelmed</div>
+  <div class="flow-node is-bad">Total Platform Outage</div>
+</div>
 
 The postmortem revealed something uncomfortable: every safety mechanism *amplified* the original failure. Auto-scaling made it worse by piling more connections onto a dying database. Circuit breakers triggered, but their fallback services shared the same overwhelmed infrastructure. The "resilient" architecture had created a tightly-coupled system wearing a distributed costume.
 

--- a/src/posts/2024-09-15-running-llama-raspberry-pi-pipeload.md
+++ b/src/posts/2024-09-15-running-llama-raspberry-pi-pipeload.md
@@ -99,26 +99,19 @@ Combined with layer unloading, peak memory usage drops by 90.3% for GPT-style mo
 
 ⚠️ **Warning:** This diagram demonstrates layer-wise loading architecture for educational purposes. Implementation requires proper memory management and hardware configuration.
 
-```mermaid
-flowchart TD
-    A[Input Tokens] --> B[Layer 0]
-    B --> C[Unload Layer 0]
-    C --> D[Load Layer 1 in parallel]
-    D --> E[Layer 1]
-    E --> F[Unload Layer 1]
-    F --> G[Load Layer 2 in parallel]
-    G --> H[Layer 2]
-    H --> I[...]
-    I --> J[Layer 31]
-    J --> K[Output Tokens]
-
-    classDef layerStyle fill:#10b981,color:#fff
-    classDef unloadStyle fill:#ef4444,color:#fff
-    classDef loadStyle fill:#3b82f6,color:#fff
-    class B,E,H,J layerStyle
-    class C,F unloadStyle
-    class D,G loadStyle
-```
+<div class="flow">
+  <div class="flow-node">Input Tokens</div>
+  <div class="flow-node">Layer 0</div>
+  <div class="flow-node">Unload Layer 0</div>
+  <div class="flow-node">Load Layer 1 in parallel</div>
+  <div class="flow-node">Layer 1</div>
+  <div class="flow-node">Unload Layer 1</div>
+  <div class="flow-node">Load Layer 2 in parallel</div>
+  <div class="flow-node">Layer 2</div>
+  <div class="flow-node">...</div>
+  <div class="flow-node">Layer 31</div>
+  <div class="flow-node">Output Tokens</div>
+</div>
 
 **Key insight:** By the time layer N completes execution, layer N+1 is already loaded and ready. No idle CPU cycles waiting for I/O.
 

--- a/src/posts/2025-01-22-llm-security-alert-triage-local.md
+++ b/src/posts/2025-01-22-llm-security-alert-triage-local.md
@@ -48,25 +48,16 @@ names, internal network topology. Local LLM inference keeps all data in homelab.
 
 **Ollama architecture:**
 
-```mermaid
-flowchart LR
-    Alerts[Security Alerts\nWazuh/Suricata] -->|JSON| Processor[Alert Processor\nPython]
-    Processor -->|Prompt| Ollama[Ollama Server\nLocal LLM]
-    Ollama -->|Classification| DB[(SQLite\nAlert DB)]
-    DB -->|High Priority| Slack[Slack Notification]
-    DB -->|All Alerts| Dashboard[Grafana Dashboard]
-
-    GPU[NVIDIA GPU\n8GB VRAM]
-    Ollama -.->|Inference| GPU
-
-    classDef local fill:#3498db,color:#fff
-    classDef alert fill:#e74c3c,color:#fff
-    classDef output fill:#2ecc71,color:#000
-
-    class Processor,Ollama,GPU local
-    class Alerts,DB alert
-    class Slack,Dashboard output
-```
+<div class="flow">
+  <div class="flow-node"><b>Security Alerts</b><i>Wazuh / Suricata JSON</i></div>
+  <div class="flow-node"><b>Alert Processor</b><i>Python prompt</i></div>
+  <div class="flow-node"><b>Ollama Server</b><i>local LLM; NVIDIA GPU inference, 8GB VRAM</i></div>
+  <div class="flow-node"><b>SQLite</b><i>alert DB classification</i></div>
+  <div class="flow-parallel">
+    <div class="flow-node is-bad"><b>Slack Notification</b><i>high priority</i></div>
+    <div class="flow-node"><b>Grafana Dashboard</b><i>all alerts</i></div>
+  </div>
+</div>
 
 **How it works:**
 
@@ -231,22 +222,13 @@ Large Language Models benefit from context. Retrieval-Augmented Generation (RAG)
 
 **RAG architecture:**
 
-```mermaid
-flowchart LR
-    Alert[New Alert] -->|Query| Retriever[Vector DB\nChroma]
-    Retriever -->|Similar Alerts| Context[Context Builder]
-    Context -->|Enriched Prompt| LLM[Ollama LLM]
-    LLM -->|Classification| Output[Triage Decision]
-
-    HistoricalDB[(Historical Alerts\n30 days)]
-    ThreatIntel[(Threat Intel\nMISP/OTX)]
-
-    HistoricalDB -.->|Embeddings| Retriever
-    ThreatIntel -.->|IOCs| Context
-
-    classDef rag fill:#9b59b6,color:#fff
-    class Retriever,Context rag
-```
+<div class="flow">
+  <div class="flow-node">New Alert</div>
+  <div class="flow-node"><b>Vector DB</b><i>Chroma query; 30 days historical alert embeddings</i></div>
+  <div class="flow-node"><b>Context Builder</b><i>similar alerts + MISP / OTX IOCs</i></div>
+  <div class="flow-node"><b>Ollama LLM</b><i>enriched prompt</i></div>
+  <div class="flow-node"><b>Triage Decision</b><i>classification</i></div>
+</div>
 
 **How RAG improves triage:**
 

--- a/src/posts/2025-07-22-supercharging-claude-cli-with-standards.md
+++ b/src/posts/2025-07-22-supercharging-claude-cli-with-standards.md
@@ -122,25 +122,20 @@ git commit -m "Add user auth"
 
 The standards system works through a context-aware loading pipeline that detects what you are working on and serves relevant standards:
 
-```mermaid
-flowchart TD
-    INPUT["Developer Input<br/>'I'm building a secure API'"] --> DETECT["Context Detection"]
-    DETECT --> PARSE["Parse Project Signals<br/>(files, imports, config)"]
-    PARSE --> MATCH["Standard Matching Engine"]
-    MATCH --> CS["CS:python<br/>CS:api"]
-    MATCH --> SEC["SEC:auth<br/>SEC:payments"]
-    MATCH --> TS["TS:integration"]
-    MATCH --> COMP["COMPLIANCE:pci"]
-
-    CS --> COMPRESS["Token Compression<br/>5000 → 500 tokens"]
-    SEC --> COMPRESS
-    TS --> COMPRESS
-    COMP --> COMPRESS
-    COMPRESS --> CLI["Claude CLI<br/>Context Window"]
-
-    style COMPRESS fill:#27ae60,color:#fff
-    style CLI fill:#3498db,color:#fff
-```
+<div class="flow">
+  <div class="flow-node"><b>Developer Input</b><i>'I'm building a secure API'</i></div>
+  <div class="flow-node">Context Detection</div>
+  <div class="flow-node"><b>Parse Project Signals</b><i>files, imports, config</i></div>
+  <div class="flow-node is-gate">Standard Matching Engine</div>
+  <div class="flow-parallel">
+    <div class="flow-node"><b>CS:python</b><i>CS:api</i></div>
+    <div class="flow-node"><b>SEC:auth</b><i>SEC:payments</i></div>
+    <div class="flow-node">TS:integration</div>
+    <div class="flow-node">COMPLIANCE:pci</div>
+  </div>
+  <div class="flow-node is-good"><b>Token Compression</b><i>5000 → 500 tokens</i></div>
+  <div class="flow-node"><b>Claude CLI</b><i>Context Window</i></div>
+</div>
 
 ## My Favorite Features
 
@@ -339,19 +334,11 @@ curl -O [https://raw.githubusercontent.com/williamzujkowski/standards/master/doc
 
 The following diagram shows the evolution of CLAUDE.md and the standards system over six months:
 
-```mermaid
-flowchart LR
-    V1["v1.0<br/>120 lines<br/>Python only"] --> V2["v2.0<br/>~800 lines<br/>Multi-language"]
-    V2 --> V3["v3.0<br/>2,847 lines<br/>Full enforcement"]
-
-    V1 --- N1["87 violations found<br/>4.5 hrs to fix"]
-    V2 --- N2["312 flagged<br/>88% false positives"]
-    V3 --- N3["FP rate: 4%<br/>12s validation"]
-
-    style V1 fill:#e74c3c,color:#fff
-    style V2 fill:#f39c12,color:#fff
-    style V3 fill:#27ae60,color:#fff
-```
+<div class="flow">
+  <div class="flow-node is-bad"><b>v1.0</b><i>120 lines, Python only; 87 violations found, 4.5 hrs to fix</i></div>
+  <div class="flow-node"><b>v2.0</b><i>~800 lines, multi-language; 312 flagged, 88% false positives</i></div>
+  <div class="flow-node is-good"><b>v3.0</b><i>2,847 lines, full enforcement; FP rate: 4%, 12s validation</i></div>
+</div>
 
 ## Real-World Impact: The Numbers
 

--- a/src/posts/2025-08-07-supercharging-development-claude-flow.md
+++ b/src/posts/2025-08-07-supercharging-development-claude-flow.md
@@ -139,30 +139,13 @@ Memory persistence adds overhead, and token costs scale with context size.
 
 ## SPARC Development Methodology
 
-```mermaid
-flowchart LR
-    S[📋 Specification] --> P[🔢 Pseudocode]
-    P --> A[🏛️ Architecture]
-    A --> R[🔧 Refinement]
-    R --> C[✅ Completion]
-
-    S -.-> M1[Define Requirements]
-    P -.-> M2[Design Algorithms]
-    A -.-> M3[System Structure]
-    R -.-> M4[TDD & Iteration]
-    C -.-> M5[Integration & Deploy]
-
-    classDef blueNode fill:#e3f2fd,color:#000,stroke:#1976d2,stroke-width:2px
-    classDef purpleNode fill:#f3e5f5,color:#000,stroke:#7b1fa2,stroke-width:2px
-    classDef orangeNode fill:#fff3e0,color:#000,stroke:#f57c00,stroke-width:2px
-    classDef greenNode fill:#e8f5e9,color:#000,stroke:#388e3c,stroke-width:2px
-    classDef redNode fill:#ffebee,color:#000,stroke:#d32f2f,stroke-width:2px
-    class S blueNode
-    class P purpleNode
-    class A orangeNode
-    class R greenNode
-    class C redNode
-```
+<div class="flow">
+  <div class="flow-node"><b>📋 Specification</b><i>Define Requirements</i></div>
+  <div class="flow-node"><b>🔢 Pseudocode</b><i>Design Algorithms</i></div>
+  <div class="flow-node"><b>🏛️ Architecture</b><i>System Structure</i></div>
+  <div class="flow-node"><b>🔧 Refinement</b><i>TDD &amp; Iteration</i></div>
+  <div class="flow-node is-good"><b>✅ Completion</b><i>Integration &amp; Deploy</i></div>
+</div>
 
 ## Practical Use Cases
 

--- a/src/posts/2025-08-18-docker-lsm-security-hardening.md
+++ b/src/posts/2025-08-18-docker-lsm-security-hardening.md
@@ -126,32 +126,16 @@ I combine multiple isolation mechanisms for defense-in-depth. If attacker bypass
 
 **Security layers:**
 
-```mermaid
-flowchart TB
-    Container[Docker Container]
-
-    Container --> Layer1[Layer 1: AppArmor Profile\nFile system access control]
-    Layer1 --> Layer2[Layer 2: Seccomp Filter\nSyscall restrictions]
-    Layer2 --> Layer3[Layer 3: Capabilities\nRemove dangerous privileges]
-    Layer3 --> Layer4[Layer 4: User Namespaces\nNon-root UID mapping]
-    Layer4 --> Layer5[Layer 5: Read-Only Root FS\nImmutable container]
-
-    Attacker[Attacker with RCE]
-    Attacker -.->|Try to escape| Layer1
-    Layer1 -.->|Bypass AppArmor?| Layer2
-    Layer2 -.->|Bypass seccomp?| Layer3
-    Layer3 -.->|Bypass caps?| Layer4
-    Layer4 -.->|Bypass user NS?| Layer5
-    Layer5 -.->|Blocked| Host[Host Protected]
-
-    classDef layer fill:#3498db,color:#fff
-    classDef attack fill:#e74c3c,color:#fff
-    classDef safe fill:#2ecc71,color:#000
-
-    class Layer1,Layer2,Layer3,Layer4,Layer5 layer
-    class Attacker attack
-    class Host safe
-```
+<div class="flow">
+  <div class="flow-node">Docker Container</div>
+  <div class="flow-node is-bad"><b>Attacker with RCE</b><i>try to escape</i></div>
+  <div class="flow-node"><b>Layer 1: AppArmor Profile</b><i>file system access control</i></div>
+  <div class="flow-node"><b>Layer 2: Seccomp Filter</b><i>syscall restrictions</i></div>
+  <div class="flow-node"><b>Layer 3: Capabilities</b><i>remove dangerous privileges</i></div>
+  <div class="flow-node"><b>Layer 4: User Namespaces</b><i>non-root UID mapping</i></div>
+  <div class="flow-node"><b>Layer 5: Read-Only Root FS</b><i>immutable container</i></div>
+  <div class="flow-node is-good">Host Protected</div>
+</div>
 
 **How defense-in-depth works:**
 

--- a/src/posts/2025-10-29-privacy-first-ai-lab-local-llms.md
+++ b/src/posts/2025-10-29-privacy-first-ai-lab-local-llms.md
@@ -95,25 +95,16 @@ I started verifying model checksums obsessively after reading this.
 
 ## Local LLM Tools: The Privacy Reality Check
 
-```mermaid
-flowchart LR
-    User([User Prompt]) --> LocalInference
-
-    subgraph LocalInference["Local Inference Pipeline"]
-        direction TB
-        A[System Prompt + Filters] --> B[Tokenizer]
-        B --> C[GPU VRAM — Model Weights]
-        C --> D[KV Cache — Attention States]
-        D --> E[Token Sampling]
-        E --> F[Detokenizer]
-    end
-
-    LocalInference --> Response([Response])
-
-    style LocalInference fill:#1a1a2e,color:#e0e0e0
-    style C fill:#e74c3c,color:#fff
-    style D fill:#f39c12,color:#fff
-```
+<div class="flow">
+  <div class="flow-node">User Prompt</div>
+  <div class="flow-node">System Prompt + Filters</div>
+  <div class="flow-node">Tokenizer</div>
+  <div class="flow-node">GPU VRAM — Model Weights</div>
+  <div class="flow-node">KV Cache — Attention States</div>
+  <div class="flow-node">Token Sampling</div>
+  <div class="flow-node">Detokenizer</div>
+  <div class="flow-node is-good">Response</div>
+</div>
 
 Not all "local" LLM tools are created equal. I tested seven popular options and found massive differences in their actual privacy practices.
 

--- a/src/posts/2025-11-12-quantum-error-correction-willow-breakthrough.md
+++ b/src/posts/2025-11-12-quantum-error-correction-willow-breakthrough.md
@@ -59,24 +59,11 @@ Google's Willow chip finally cracked the code. They built logical qubits using s
 
 **The breakthrough:** As they increased from 3x3 to 5x5 to 7x7, the logical error rate decreased exponentially. Adding more physical qubits made the logical qubit more reliable, not less.
 
-```mermaid
-flowchart LR
-    subgraph A["3x3 Array"]
-        A1["9 Physical Qubits<br/>Higher Error Rate"]
-    end
-    subgraph B["5x5 Array"]
-        B1["25 Physical Qubits<br/>Lower Error Rate"]
-    end
-    subgraph C["7x7 Array"]
-        C1["49 Physical Qubits<br/>Lowest Error Rate"]
-    end
-
-    A -->|"Error rate<br/>decreases"| B -->|"Exponential<br/>suppression"| C
-
-    style A fill:#e74c3c,color:#fff
-    style B fill:#f39c12,color:#fff
-    style C fill:#2ecc71,color:#fff
-```
+<div class="flow">
+  <div class="flow-node is-bad"><b>3x3 Array</b><i>9 Physical Qubits; Higher Error Rate</i></div>
+  <div class="flow-node"><b>5x5 Array</b><i>25 Physical Qubits; Lower Error Rate</i></div>
+  <div class="flow-node is-good"><b>7x7 Array</b><i>49 Physical Qubits; Lowest Error Rate</i></div>
+</div>
 
 This is the "below threshold" operation that quantum error correction theory predicted. Willow's physical qubit error rates (0.1-0.2%) are well below the surface code threshold (~1%), enabling exponential error suppression.
 
@@ -90,24 +77,14 @@ The paper (["Quantum error correction below the surface code threshold"](https:/
 
 ## Why This Changes Everything
 
-```mermaid
-graph TB
-    subgraph Stack["Quantum Computing Stack"]
-        direction TB
-        Apps["Applications<br/>Drug Discovery, Crypto, AI, Climate"]
-        Algo["Quantum Algorithms<br/>Shor's, Grover's, VQE"]
-        Logic["Logical Qubits<br/>Error-Corrected Computation"]
-        QEC["Quantum Error Correction<br/>Surface Codes — Willow Breakthrough"]
-        Phys["Physical Qubits<br/>Superconducting Transmons"]
-        HW["Hardware<br/>Dilution Refrigerator at 15 mK"]
-    end
-
-    Apps --> Algo --> Logic --> QEC --> Phys --> HW
-
-    style QEC fill:#e74c3c,color:#fff,stroke:#c0392b,stroke-width:3px
-    style Logic fill:#f39c12,color:#fff
-    style Apps fill:#3498db,color:#fff
-```
+<div class="flow">
+  <div class="flow-node"><b>Applications</b><i>Drug Discovery, Crypto, AI, Climate</i></div>
+  <div class="flow-node"><b>Quantum Algorithms</b><i>Shor's, Grover's, VQE</i></div>
+  <div class="flow-node"><b>Logical Qubits</b><i>Error-Corrected Computation</i></div>
+  <div class="flow-node"><b>Quantum Error Correction</b><i>Surface Codes — Willow Breakthrough</i></div>
+  <div class="flow-node"><b>Physical Qubits</b><i>Superconducting Transmons</i></div>
+  <div class="flow-node"><b>Hardware</b><i>Dilution Refrigerator at 15 mK</i></div>
+</div>
 
 Think of this like the moment transistors became reliable enough for integrated circuits. We've proven the fundamental scaling law that makes quantum computing work.
 

--- a/src/posts/2025-12-17-docker-container-hardening-homelab.md
+++ b/src/posts/2025-12-17-docker-container-hardening-homelab.md
@@ -28,32 +28,18 @@ Container security isn't binary. You can't just "enable security" and assume you
 - **Network segmentation** contains lateral movement
 - **Resource limits** stop resource exhaustion attacks
 
-```mermaid
-graph TB
-    Attacker([Attacker]) --> L1
-    subgraph Layers["Eight Defense Layers"]
-        direction TB
-        L1["Layer 1: Minimal Base Images<br/>Reduced attack surface"]
-        L2["Layer 2: User Namespaces<br/>No real root privileges"]
-        L3["Layer 3: Seccomp Profiles<br/>Blocked dangerous syscalls"]
-        L4["Layer 4: AppArmor / SELinux<br/>Mandatory access control"]
-        L5["Layer 5: Capability Dropping<br/>Fine-grained privilege removal"]
-        L6["Layer 6: Read-Only Filesystem<br/>No persistence possible"]
-        L7["Layer 7: Network Segmentation<br/>No lateral movement"]
-        L8["Layer 8: Resource Limits<br/>No resource exhaustion"]
-    end
-    L1 --> L2 --> L3 --> L4 --> L5 --> L6 --> L7 --> L8
-    L8 --> App([Protected Application])
-
-    style L1 fill:#e74c3c,color:#fff
-    style L2 fill:#e67e22,color:#fff
-    style L3 fill:#f39c12,color:#fff
-    style L4 fill:#f1c40f,color:#000
-    style L5 fill:#2ecc71,color:#fff
-    style L6 fill:#1abc9c,color:#fff
-    style L7 fill:#3498db,color:#fff
-    style L8 fill:#9b59b6,color:#fff
-```
+<div class="flow">
+  <div class="flow-node is-bad">Attacker</div>
+  <div class="flow-node"><b>Layer 1: Minimal Base Images</b><i>reduced attack surface</i></div>
+  <div class="flow-node"><b>Layer 2: User Namespaces</b><i>no real root privileges</i></div>
+  <div class="flow-node"><b>Layer 3: Seccomp Profiles</b><i>blocked dangerous syscalls</i></div>
+  <div class="flow-node"><b>Layer 4: AppArmor / SELinux</b><i>mandatory access control</i></div>
+  <div class="flow-node"><b>Layer 5: Capability Dropping</b><i>fine-grained privilege removal</i></div>
+  <div class="flow-node"><b>Layer 6: Read-Only Filesystem</b><i>no persistence possible</i></div>
+  <div class="flow-node"><b>Layer 7: Network Segmentation</b><i>no lateral movement</i></div>
+  <div class="flow-node"><b>Layer 8: Resource Limits</b><i>no resource exhaustion</i></div>
+  <div class="flow-node is-good">Protected Application</div>
+</div>
 
 **Why it matters:** Single-layer security is brittle. Attackers bypass one control and own your system. Multiple independent layers mean they need to break through all defenses.
 
@@ -392,23 +378,13 @@ docker run \
 
 ## Implementation Strategy
 
-```mermaid
-flowchart LR
-    W1["Week 1<br/>Base Images +<br/>Resource Limits"] --> W2["Week 2<br/>User<br/>Namespaces"]
-    W2 --> W3["Week 3<br/>Cap Drop +<br/>Read-Only FS"]
-    W3 --> W4["Week 4<br/>Seccomp +<br/>AppArmor"]
-    W4 --> W5["Week 5<br/>Network<br/>Segmentation"]
-
-    W1 -.- T1["Low disruption"]
-    W3 -.- T2["Medium disruption"]
-    W5 -.- T3["Full defense-in-depth"]
-
-    style W1 fill:#2ecc71,color:#fff
-    style W2 fill:#27ae60,color:#fff
-    style W3 fill:#f39c12,color:#fff
-    style W4 fill:#e67e22,color:#fff
-    style W5 fill:#e74c3c,color:#fff
-```
+<div class="flow">
+  <div class="flow-node"><b>Week 1</b><i>Base Images + Resource Limits; Low disruption</i></div>
+  <div class="flow-node"><b>Week 2</b><i>User Namespaces</i></div>
+  <div class="flow-node"><b>Week 3</b><i>Cap Drop + Read-Only FS; Medium disruption</i></div>
+  <div class="flow-node"><b>Week 4</b><i>Seccomp + AppArmor</i></div>
+  <div class="flow-node"><b>Week 5</b><i>Network Segmentation; Full defense-in-depth</i></div>
+</div>
 
 Don't enable all layers simultaneously. Incremental hardening prevents breaking production workloads.
 

--- a/src/posts/2026-07-19-oklch-terminal-themes.md
+++ b/src/posts/2026-07-19-oklch-terminal-themes.md
@@ -67,17 +67,17 @@ The dataset also tags each theme with plain WCAG contrast ratios. `classify.ts` 
 
 For each curated theme, the script derives a dozen CSS tokens — muted text, borders, code background, accent, accent-hover — by mixing the theme's foreground and background in OKLCH space, with shortest-arc hue interpolation so a blend never takes the scenic route around the color wheel. Every derived token gets checked against the same floors as the source data. If a mixed color can't clear its floor, the script raises and the build fails. That's the actual payoff of all of this: not that OKLCH computes contrast for you (plain luminance math does that, color-space agnostic), but that colors nobody hand-picked stay predictable enough to gate a build on.
 
-```mermaid
-flowchart LR
-    U["12 upstream repos<br/>(sources.json, pinned SHAs)"] --> F["fetch-upstream.ts"]
-    F --> B["build.ts<br/>hex to OKLCH (culori)"]
-    B --> C["classify.ts<br/>WCAG tags, isDark, chroma"]
-    C --> V["validate.ts<br/>ΔE2000 < 1.0, Zod schema"]
-    V --> D[("themes.json<br/>545 records")]
-    D --> G["generate.py<br/>curate 12, contrast-validate"]
-    G --> T["theme-deck.json / theme-deck.css"]
-    T --> P["ThemeDeck.astro<br/>this site's header picker"]
-```
+<div class="flow">
+  <div class="flow-node"><b>12 upstream repos</b><i>sources.json, pinned SHAs</i></div>
+  <div class="flow-node">fetch-upstream.ts</div>
+  <div class="flow-node"><b>build.ts</b><i>hex to OKLCH (culori)</i></div>
+  <div class="flow-node"><b>classify.ts</b><i>WCAG tags, isDark, chroma</i></div>
+  <div class="flow-node"><b>validate.ts</b><i>ΔE2000 &lt; 1.0, Zod schema</i></div>
+  <div class="flow-node"><b>themes.json</b><i>545 records</i></div>
+  <div class="flow-node"><b>generate.py</b><i>curate 12, contrast-validate</i></div>
+  <div class="flow-node">theme-deck.json / theme-deck.css</div>
+  <div class="flow-node"><b>ThemeDeck.astro</b><i>this site's header picker</i></div>
+</div>
 
 Everything left of `themes.json` lives in the `oklch-terminal-themes` repo and runs weekly, unattended. Everything right of it lives in this repo and runs once per manual invocation — the part where 545 rows of somebody else's color choices turn into twelve you can actually click.
 


### PR DESCRIPTION
Second wave of #414 (builds on the `.flow` component from #415). Converts the **linear/pipeline** Mermaid flowcharts across 12 posts to the native responsive flow — full-size, high-contrast, theme-adaptive, phone-legible, no pan/zoom.

## Scope
- **16 diagrams / 12 posts** converted (delegated to codex against the conversion spec, verified here).
- **Conservative triage**: only process/pipeline/step shapes. Dense architecture graphs, cyclic flows, multi-subgraph comparisons, and `sequenceDiagram`/`pie`/`timeline`/`gantt`/`quadrantChart`/`block-beta` were **left as-is** — those are D2-vertical candidates for a later pass, per #414.
- Hardcoded `fill:#hex`/`classDef` colors dropped on converted blocks (they bypassed the theme).

## Verification
- Format gate (col-0 open, no interior blank lines, escaped entities, known classes only): 16/16 clean
- `pnpm build`: green · 13px type floor: clean
- Visual spot-checks at 390px (light+dark): the CI scanning pipeline, the OKLCH 9-step pipeline, and the 8-layer Docker hardening flow all render legibly with correct connectors + semantic pass/fail coloring

CI (axe / remarque / links) gates the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)