### PR TITLE
feat(diagrams): native .arch tiered component for architecture diagrams (#414)

### DIFF
--- a/astro-site/src/styles/global.css
+++ b/astro-site/src/styles/global.css
@@ -954,6 +954,56 @@ article .prose > p:first-of-type::first-letter {
 .prose .flow-leg[data-branch]:has(.is-bad)::before  { color: var(--color-error); }
 @media (prefers-reduced-motion: reduce) { .prose .flow * { transition: none; } }
 
+/* ===== Native architecture diagrams (issue #414) — sibling to .flow, for
+ * multi-tier / layered systems that aren't a linear pipeline. Stacked labelled
+ * tiers whose component chips wrap on mobile; understated border-accent chips
+ * (no fills) to match the zine aesthetic. Dense zone/topology graphs get SPLIT
+ * into 2-3 of these instead of forcing one; matrices become Markdown tables.
+ * All text >= 0.8125rem (USWDS 13px floor). */
+.prose .arch-fig { margin-block: var(--space-6); }
+.prose .arch {
+  display: flex; flex-direction: column; gap: 1.6rem;
+  font-family: var(--font-body); color: var(--color-fg);
+}
+.prose .arch-tier {
+  position: relative; display: flex; flex-wrap: wrap;
+  align-items: stretch; justify-content: center; gap: 0.45rem;
+  padding: 1.7rem 0.6rem 0.65rem;
+  background: var(--color-surface); border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+.prose .arch-tier::before {
+  content: attr(data-label); position: absolute; top: 0.5rem; left: 0.7rem;
+  font-family: var(--font-mono); font-size: 0.8125rem; letter-spacing: 0.04em;
+  text-transform: uppercase; color: var(--color-muted);
+}
+/* ordered dependency stack shows a down-cue between tiers; peer "zones" don't */
+.prose .arch.is-stack .arch-tier + .arch-tier::after {
+  content: "\2193"; position: absolute; top: -1.2rem; left: 50%;
+  transform: translateX(-50%); color: var(--color-border-bold);
+  font-size: 1rem; line-height: 1;
+}
+.prose .arch-chip {
+  display: flex; flex-direction: column; align-items: center;
+  justify-content: center; text-align: center;
+  flex: 1 1 6.5rem; min-width: 5.5rem; padding: 0.4rem 0.6rem;
+  background: var(--color-bg); border: 1.5px solid var(--color-border-bold);
+  border-radius: var(--radius-sm); font-size: 0.875rem; font-weight: 600;
+  line-height: 1.25; overflow-wrap: anywhere;
+}
+.prose .arch-chip i {
+  font-style: normal; font-weight: 400; font-family: var(--font-mono);
+  font-size: 0.8125rem; color: var(--color-fg-muted); margin-top: 0.1rem;
+}
+.prose .arch-chip.is-primary { border-color: var(--color-accent); color: var(--color-accent); }
+.prose .arch-chip.is-guard { border-style: dashed; border-color: var(--color-accent); }
+.prose .arch-chip.is-warn { border-color: var(--color-warning); color: var(--color-warning); }
+.prose .arch-chip.is-bad { border-color: var(--color-error); color: var(--color-error); }
+.prose .arch-fig figcaption {
+  color: var(--color-fg-muted); font-size: 0.8125rem; font-style: italic;
+  text-align: center; margin-top: 0.6rem;
+}
+
 /* ===== Footer ===== */
 .site-footer {
   margin-block-start: var(--space-8);

--- a/src/posts/2025-09-01-self-hosted-bitwarden-migration-guide.md
+++ b/src/posts/2025-09-01-self-hosted-bitwarden-migration-guide.md
@@ -21,57 +21,24 @@ tags:
 
 ## Self-Hosted Password Management Architecture
 
-```mermaid
-flowchart TB
-    subgraph clientaccess["Client Access"]
-        Web[Web Vault]
-        Mobile[Mobile Apps]
-        Desktop[Desktop Apps]
-        Browser[Browser Extensions]
-    end
-    subgraph bitwardenserver["Bitwarden Server"]
-        Nginx[Nginx Reverse Proxy]
-        Vaultwarden[Vaultwarden Service]
-        DB[(SQLite/PostgreSQL)]
-    end
-    subgraph securitylayer["Security Layer"]
-        Firewall[Firewall Rules]
-        WAF[ModSecurity WAF]
-        Fail2ban[Fail2ban]
-        TLS[TLS 1.3]
-    end
-    subgraph backuprecovery["Backup & Recovery"]
-        Local[Local Backups]
-        Offsite[Offsite Backups]
-        Encrypted[Encrypted Storage]
-        Versioned[Version Control]
-    end
+<figure class="arch-fig">
+<div class="arch is-stack" aria-label="Self-hosted Bitwarden serving architecture">
+  <section class="arch-tier" data-label="Client Access"><span class="arch-chip">Web Vault</span><span class="arch-chip">Mobile Apps</span><span class="arch-chip">Desktop Apps</span><span class="arch-chip">Browser Extensions</span></section>
+  <section class="arch-tier" data-label="Ingress Protection"><span class="arch-chip is-guard">Firewall Rules</span><span class="arch-chip is-guard">TLS 1.3</span><span class="arch-chip is-guard">Fail2ban</span><span class="arch-chip is-guard">ModSecurity WAF</span></section>
+  <section class="arch-tier" data-label="Application Edge"><span class="arch-chip">Nginx Reverse Proxy</span></section>
+  <section class="arch-tier" data-label="Vault Service"><span class="arch-chip is-primary">Vaultwarden</span></section>
+  <section class="arch-tier" data-label="Data Store"><span class="arch-chip"><b>SQLite / PostgreSQL</b><i>encrypted at rest</i></span></section>
+</div>
+<figcaption>Clients enter through the protected edge; Vaultwarden sits behind Nginx and writes to a private database. Backups (below) run downstream of the data store.</figcaption>
+</figure>
 
-    Web --> Nginx
-    Mobile --> Nginx
-    Desktop --> Nginx
-    Browser --> Nginx
-
-    Nginx --> WAF
-    WAF --> Vaultwarden
-    Vaultwarden --> DB
-
-    Firewall --> Nginx
-    Fail2ban --> Nginx
-    TLS --> Nginx
-
-    DB --> Local
-    Local --> Encrypted
-    Encrypted --> Offsite
-    Offsite --> Versioned
-
-    classDef successStyle fill:#4caf50,color:#fff
-    classDef warningStyle fill:#ff9800,color:#fff
-    classDef criticalStyle fill:#f44336,color:#fff
-    class Vaultwarden successStyle
-    class WAF warningStyle
-    class Encrypted criticalStyle
-```
+<div class="flow" aria-label="Bitwarden backup and recovery path">
+  <div class="flow-node">Database</div>
+  <div class="flow-node">Local Backups</div>
+  <div class="flow-node is-gate">Encrypted Storage</div>
+  <div class="flow-node">Offsite Backups</div>
+  <div class="flow-node">Versioned Copies</div>
+</div>
 
 ## Why Self-Host?
 


### PR DESCRIPTION
Sibling to `.flow` — a native tiered component for the ~46 **multi-subgraph architecture** diagrams that aren't linear pipelines and are unreadable on a phone.

## Design
Synthesized from independent **codex + agy** research on the real diagrams (they converged on the same answer):
- **`.arch`** — stacked labelled tiers, component chips that **wrap** on mobile, understated border-accent variants (`is-primary`/`is-guard`/`is-warn`/`is-bad`, no fills), a subtle `↓` between tiers on `.is-stack`. Token-based → light/dark + 12 decks; all text ≥ 0.8125rem.
- **Split** dense zone/topology maps into 2–3 focused `.arch`/`.flow` views + a caption.
- **Tables** for matrices.

Decision rule: *what should the reader learn first?* → "what's in this layer?" = `.arch`; "what talks to what under policy?" = split; "which is better?" = table.

## This PR
- The `.arch` component (global.css)
- First conversion: self-hosted Bitwarden (4-subgraph graph → `.arch` serving stack + a small backup `.flow`; hardcoded fill colors dropped)

Verified in-site at 390px, light + dark (high contrast both). Bulk conversion of the rest follows in delegated batches. Class contract + authoring guidance will be documented in the repo (follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)