### PR TITLE
docs: canonical content-visuals guide + accuracy fixes (#414)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,8 @@
 # Agent Instructions
 
 **Status:** Authoritative
-**Last Updated:** 2026-04-22
-**Project:** Personal website and technical blog (Astro 6 + Svelte 5 + hand-written CSS / Remarque design tokens)
+**Last Updated:** 2026-07-29
+**Project:** Personal website and technical blog (Astro 7 + Svelte 5 + hand-written CSS / Remarque design tokens)
 
 This file is the canonical guidance for AI coding agents working in this repo (Claude Code, Codex, Cursor, Aider, etc.). Harness-specific entry points (e.g. `CLAUDE.md`) import this file — edit here, not there.
 
@@ -29,12 +29,11 @@ pnpm check           # Astro type checking
 
 ```
 ├── src/                       # Content collections (loaded by astro-site)
-│   ├── posts/                 # Blog posts (Markdown) — astro-site/src/content.config.ts globs ../src/posts
-│   └── projects/              # Project entries (Markdown)
-├── astro-site/                # Website source (Astro 6 + Svelte 5)
+│   └── posts/                 # Blog posts (Markdown) — astro-site/src/content.config.ts globs ../src/posts
+├── astro-site/                # Website source (Astro 7 + Svelte 5)
 │   ├── src/
 │   │   ├── components/        # Svelte & Astro components
-│   │   ├── content.config.ts  # Content collection schemas (points at ../src/posts, ../src/projects)
+│   │   ├── content.config.ts  # Content collection schemas (points at ../src/posts)
 │   │   ├── layouts/           # Page layouts (BaseLayout.astro)
 │   │   ├── pages/             # Route pages
 │   │   └── styles/            # Global CSS (hand-written; Remarque design tokens)
@@ -147,6 +146,7 @@ The old rule was right about precision and wrong to strip out the personality. K
 - Blog posts require frontmatter: title, date, description, tags
 - Citations required for technical claims (target 90%+ coverage)
 - Social images are generated per post at build time (`/og/<slug>.png`) — no hero-image frontmatter
+- **Visuals:** follow `docs/content-visuals.md` — `.flow` for processes, `.arch` for layers/zones, Markdown tables for matrices, split dense diagrams; Mermaid is legacy for genuine node graphs. Zine doodles must carry the idea visually (a specific metaphor), never a stamped label. All authored visuals use `var(--color-*)` tokens (never hardcoded colors), stay ≥0.8125rem, and reflow on mobile.
 - SEO: canonical URLs, Open Graph, Twitter Cards, structured data
 
 ---

--- a/README.md
+++ b/README.md
@@ -51,12 +51,11 @@ pnpm audit          # Remarque design audits (contrast, typography, colors, APCA
 
 ```
 ├── src/                    # Content collections (loaded by astro-site)
-│   ├── posts/              # Blog posts (Markdown)
-│   └── projects/           # Project entries (Markdown)
-├── astro-site/             # Website source (Astro 6 + Svelte 5)
+│   └── posts/              # Blog posts (Markdown)
+├── astro-site/             # Website source (Astro 7 + Svelte 5)
 │   ├── src/
 │   │   ├── components/     # Svelte & Astro components
-│   │   ├── content.config.ts  # Collection schemas (point at ../src/posts, ../src/projects)
+│   │   ├── content.config.ts  # Collection schemas (point at ../src/posts)
 │   │   ├── layouts/        # Page layouts
 │   │   ├── pages/          # Route pages
 │   │   └── styles/         # Hand-written CSS (Remarque design tokens)
@@ -70,7 +69,7 @@ pnpm audit          # Remarque design audits (contrast, typography, colors, APCA
 
 ## Technologies
 
-- **Static Site Generator**: [Astro 6](https://astro.build/) with Svelte 5 islands
+- **Static Site Generator**: [Astro 7](https://astro.build/) with Svelte 5 islands
 - **Styling**: Hand-written CSS, Remarque design tokens (OKLCH), no framework
 - **Search**: [Pagefind](https://pagefind.app/) (static search index)
 - **Python Tooling**: Link validation CI scripts managed with UV
@@ -82,6 +81,7 @@ pnpm audit          # Remarque design audits (contrast, typography, colors, APCA
 ### Creating a New Post
 
 1. Create a Markdown file in `src/posts/` (repo root) named `YYYY-MM-DD-slug.md`
+   - For diagrams, tables, and images, follow [`docs/content-visuals.md`](docs/content-visuals.md) (no hero-image frontmatter — OG cards are auto-generated)
 2. Add front matter:
 
 ```yaml

--- a/docs/content-visuals.md
+++ b/docs/content-visuals.md
@@ -1,0 +1,185 @@
+# Content Visuals
+
+Use native HTML patterns first. They inherit Remarque tokens, survive the theme deck,
+and stay readable on phones. Mermaid still renders, but it is legacy for new posts.
+
+## Decision Rule
+
+| Reader question | Pattern |
+|---|---|
+| What happens next? A process, pipeline, or recovery path. | `.flow` |
+| What's in this layer, tier, or zone? | `.arch` |
+| What talks to what under failure or security policy? | Split into 2-3 focused `.flow` / `.arch` views, then add a caption. |
+| Which option is better? A matrix or trade-off grid. | Markdown table |
+| A genuine node graph that resists all of the above. | Leave as a fenced `mermaid` block for now. Legacy; being phased down. Consider a future vertical-D2 render. |
+
+## `.flow`
+
+Use `.flow` for ordered work: pipelines, backup paths, gates, fan-out/fan-in, and
+pass/fail branches. Connectors are drawn by CSS between direct children. Do not add
+arrow characters or connector markup.
+
+Class contract:
+
+```html
+<div class="flow" aria-label="Short diagram purpose">
+  <div class="flow-node">Step</div>
+  <div class="flow-node is-gate">Decision / gate</div>
+  <div class="flow-parallel">
+    <div class="flow-node">Parallel step</div>
+  </div>
+  <div class="flow-branch">
+    <div class="flow-leg" data-branch="Pass">
+      <div class="flow-node is-good">Good result</div>
+    </div>
+    <div class="flow-leg" data-branch="Fail">
+      <div class="flow-node is-bad">Bad result</div>
+    </div>
+  </div>
+</div>
+```
+
+Allowed node variants: `.is-gate`, `.is-good`, `.is-bad`.
+
+Raw HTML rules:
+
+- Put the opening tag at column 0.
+- Use no blank lines inside the block.
+- Use 2-space indentation.
+- Escape HTML-sensitive characters: `&` -> `&amp;`, `<` -> `&lt;`, `>` -> `&gt;`.
+- Use `<b>` for the main label and `<i>` for the second line when needed.
+
+Copy-paste example:
+
+```html
+<div class="flow" aria-label="Security scanning pipeline">
+  <div class="flow-node">Git Push / PR</div>
+  <div class="flow-node is-gate">Trigger Pipeline</div>
+  <div class="flow-parallel">
+    <div class="flow-node"><b>OSV</b><i>dependency scan</i></div>
+    <div class="flow-node"><b>Grype</b><i>container scan</i></div>
+    <div class="flow-node"><b>Trivy</b><i>filesystem scan</i></div>
+  </div>
+  <div class="flow-node">Upload SARIF</div>
+  <div class="flow-node is-gate">Security Gate</div>
+  <div class="flow-branch">
+    <div class="flow-leg" data-branch="Pass"><div class="flow-node is-good">Deploy</div></div>
+    <div class="flow-leg" data-branch="Critical"><div class="flow-node is-bad">Block &amp; Alert</div></div>
+  </div>
+</div>
+```
+
+## `.arch`
+
+Use `.arch` for layered systems, trust zones, service tiers, and component
+inventory by tier. It is not a dense topology graph. If the story depends on many
+cross-links, split the view.
+
+Class contract:
+
+```html
+<figure class="arch-fig">
+<div class="arch is-stack" aria-label="Short diagram purpose">
+  <section class="arch-tier" data-label="Tier label">
+    <span class="arch-chip is-primary"><b>Main component</b><i>second line</i></span>
+    <span class="arch-chip is-guard">Guardrail</span>
+    <span class="arch-chip is-warn">Warning</span>
+    <span class="arch-chip is-bad">Failure</span>
+  </section>
+</div>
+<figcaption>One sentence explaining how to read the view.</figcaption>
+</figure>
+```
+
+Allowed chip variants: `.is-primary`, `.is-guard`, `.is-warn`, `.is-bad`.
+Chips may use `<b>` and `<i>` for a two-line label. `<figcaption>` is optional,
+but use it when the interpretation is not obvious.
+
+Use `.arch.is-stack` when tiers are ordered dependencies; it shows a down-cue
+between tiers. Omit `.is-stack` for peer zones.
+
+Raw HTML rules:
+
+- Put the opening `<figure>` or `<div class="arch...">` tag at column 0.
+- Use no blank lines inside the block.
+- Use 2-space indentation.
+- Escape HTML-sensitive characters: `&` -> `&amp;`, `<` -> `&lt;`, `>` -> `&gt;`.
+- Set `aria-label` on the `.arch` when the diagram needs a text purpose.
+
+Copy-paste example:
+
+```html
+<figure class="arch-fig">
+<div class="arch is-stack" aria-label="Self-hosted vault architecture">
+  <section class="arch-tier" data-label="Client Access"><span class="arch-chip">Web Vault</span><span class="arch-chip">Mobile Apps</span><span class="arch-chip">Browser Extensions</span></section>
+  <section class="arch-tier" data-label="Ingress Protection"><span class="arch-chip is-guard">Firewall Rules</span><span class="arch-chip is-guard">TLS 1.3</span><span class="arch-chip is-guard">Fail2ban</span></section>
+  <section class="arch-tier" data-label="Application Edge"><span class="arch-chip">Nginx Reverse Proxy</span></section>
+  <section class="arch-tier" data-label="Vault Service"><span class="arch-chip is-primary">Vaultwarden</span></section>
+  <section class="arch-tier" data-label="Data Store"><span class="arch-chip"><b>SQLite / PostgreSQL</b><i>encrypted at rest</i></span></section>
+</div>
+<figcaption>Clients enter through the protected edge; the vault service writes to a private database.</figcaption>
+</figure>
+```
+
+## Splitting Dense Diagrams
+
+Each view should answer one question and stay under about 8 items. If a zero-trust
+VLAN diagram wants to show zones, flows, policy, exceptions, and failure behavior,
+split it:
+
+- Trust zones: one `.arch` without `.is-stack`.
+- Allowed path or failure path: one `.flow`.
+- Policy matrix: one Markdown table.
+
+Tie the set together with a one-sentence caption. Do not make one heroic graph
+that requires horizontal scrolling and a generous reader.
+
+## Tables
+
+Use plain Markdown tables for matrices, comparisons, scanner/tool choices, policy
+rules, and measured results. The prose stylesheet handles table wrapping and
+theme-token styling.
+
+```markdown
+| Option | Strength | Weakness | Use when |
+|---|---|---|---|
+| Grype | Fast container scans | Narrower coverage | Image risk is the question |
+| Trivy | Broad scanner | Slower | One tool needs to cover several surfaces |
+```
+
+## Images
+
+### Zine Doodles
+
+Use zine doodles as hand-drawn spot illustrations for posts that would otherwise
+open as pure text. Place them after the intro and before the next heading.
+
+Placement pattern:
+
+```html
+<div class="zine-doodle" aria-hidden="true" style="--doodle: url('/assets/doodles/example.png'); width: min(240px, 62%); aspect-ratio: 340/328; margin: 2rem auto 0.5rem;"></div>
+<p class="hand-note" style="text-align: center; display: block;">short caption</p>
+```
+
+The drawing must carry the post's idea on its own: a specific visual metaphor,
+not a stamped text label. The caption can add voice; it cannot rescue a vague
+drawing.
+
+Assets are alpha-masked pure-black PNGs, under 60 KB, recolored per theme by CSS
+masking. Set `--doodle`, `width`, `aspect-ratio`, and margin per use. Keep the
+doodle `aria-hidden="true"` because the adjacent prose carries the meaning.
+
+### OG Social Cards
+
+Do nothing. Per-post OG cards are generated at build time at `/og/<slug>.png`
+from the post metadata. Do not add hero-image frontmatter.
+
+## Shared Rules
+
+- Use existing classes only. Do not invent one-off diagram classes in a post.
+- Use `var(--color-*)` design tokens for authored visuals. Never hardcode
+  `fill:#hex`, inline SVG colors, or theme-specific CSS.
+- Keep all visual text at `0.8125rem` or larger. That is the USWDS 13px floor.
+- Diagrams must reflow on mobile without horizontal scroll.
+- Set an `aria-label` on diagrams when the purpose is not obvious.
+- Add a `<figcaption>` when interpretation helps.


### PR DESCRIPTION
Establishes the durable standard for how future posts present diagrams, tables, and images — so the `.flow` / `.arch` / split / table patterns get reused instead of re-derived.

## Adds
- **`docs/content-visuals.md`** — decision rule, `.flow` + `.arch` class contracts with copy-paste examples, splitting dense diagrams, tables for matrices, images (zine-doodle idea-legibility principle + auto OG cards), shared token/13px/reflow/a11y rules. Drafted by codex from the real components, reviewed.
- Wired into **AGENTS.md** (Content Standards) and **README** (new-post steps).
- An author-local **`blog-visuals` skill** surfaces the decision rule interactively (not committed; lives in `~/.claude/skills/`).

## Fixes (from the doc-accuracy audit)
- **Astro 6 → 7** across AGENTS.md + README (matches `astro-site/package.json` `^7.1.0`).
- Removed the **defunct `src/projects`** collection references (projects are hand-authored in `pages/projects.astro`).

## Follow-up (not in this PR)
The audit also flagged stale script names/counts in `docs/link-validation/README.md` and legacy "use Mermaid / hero image" guidance in several dated `docs/research/*` reports — queued for a separate delegated cleanup so this PR stays focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)