### PR TITLE
feat(diagrams): convert architecture diagrams to native .arch/.flow (#414)

### DIFF
--- a/src/posts/2024-01-18-demystifying-cryptography-beginners-guide.md
+++ b/src/posts/2024-01-18-demystifying-cryptography-beginners-guide.md
@@ -38,25 +38,25 @@ I used to think of encryption like placing letters in sealed envelopes, but my r
 
 ### Symmetric Encryption: Speed vs. Key Distribution
 
-```mermaid
-flowchart LR
-    subgraph Symmetric["Symmetric Encryption (AES-256)"]
-        direction LR
-        A["🔑 Shared Secret Key"] --- E1["Encrypt"]
-        A --- D1["Decrypt"]
-        P1["Plaintext"] --> E1 --> C1["Ciphertext"] --> D1 --> P2["Plaintext"]
-    end
-
-    subgraph Asymmetric["Asymmetric Encryption (RSA/ECC)"]
-        direction LR
-        PubK["🔓 Public Key"] --- E2["Encrypt"]
-        PrivK["🔐 Private Key"] --- D2["Decrypt"]
-        P3["Plaintext"] --> E2 --> C2["Ciphertext"] --> D2 --> P4["Plaintext"]
-    end
-
-    style Symmetric fill:#e8f5e9,color:#000,stroke:#2e7d32
-    style Asymmetric fill:#e3f2fd,color:#000,stroke:#1565c0
-```
+<figure>
+<div class="flow" aria-label="Symmetric encryption path">
+  <div class="flow-node"><b>🔑 Shared Secret Key</b><i>used to encrypt and decrypt</i></div>
+  <div class="flow-node">Plaintext</div>
+  <div class="flow-node">Encrypt</div>
+  <div class="flow-node">Ciphertext</div>
+  <div class="flow-node">Decrypt</div>
+  <div class="flow-node">Plaintext</div>
+</div>
+<div class="flow" aria-label="Asymmetric encryption path">
+  <div class="flow-node"><b>🔓 Public Key</b><i>used to encrypt</i></div>
+  <div class="flow-node">Plaintext</div>
+  <div class="flow-node">Encrypt</div>
+  <div class="flow-node">Ciphertext</div>
+  <div class="flow-node"><b>Decrypt</b><i>with 🔐 Private Key</i></div>
+  <div class="flow-node">Plaintext</div>
+</div>
+<figcaption>Symmetric encryption shares one secret key; asymmetric encryption separates the public encryption key from the private decryption key.</figcaption>
+</figure>
 
 **How it works:** Same key locks and unlocks data (like two people sharing a secret handshake)
 
@@ -147,29 +147,11 @@ My introduction to hashing came through password storage, and I made every begin
 - **Fixed output size**: SHA-256 always produces 256 bits, regardless of input size
 - **Collision resistance**: Practically impossible to find two inputs with same hash
 
-```mermaid
-flowchart LR
-    subgraph Inputs
-        I1["'Hello World'"]
-        I2["'Hello World!'"]
-        I3["500 MB file"]
-    end
-
-    H["SHA-256<br/>Hash Function"]
-
-    subgraph Outputs["Fixed 256-bit Output"]
-        O1["a591a6d40bf4..."]
-        O2["7f83b1657ff1..."]
-        O3["e3b0c44298fc..."]
-    end
-
-    I1 --> H --> O1
-    I2 --> H --> O2
-    I3 --> H --> O3
-
-    style H fill:#fff3e0,color:#000,stroke:#e65100,stroke-width:2px
-    style Outputs fill:#f3e5f5,color:#000,stroke:#6a1b9a
-```
+| Input | Function | Fixed 256-bit output |
+|---|---|---|
+| `'Hello World'` | SHA-256 | `a591a6d40bf4...` |
+| `'Hello World!'` | SHA-256 | `7f83b1657ff1...` |
+| `500 MB file` | SHA-256 | `e3b0c44298fc...` |
 
 ### The Database Corruption Detective Story
 
@@ -243,37 +225,24 @@ If hashing creates fingerprints, digital signatures are like notarizing those fi
 
 ### How Digital Signatures Work
 
-```mermaid
-flowchart TB
-    subgraph Signing["Sender: Sign Document"]
-        direction TB
-        DOC1["📄 Original Document"] --> HASH1["SHA-256 Hash"]
-        HASH1 --> DIGEST1["Hash Digest<br/>a591a6d4..."]
-        DIGEST1 --> ENCRYPT["Encrypt with<br/>🔐 Private Key"]
-        ENCRYPT --> SIG["✍️ Digital Signature"]
-        DOC1 --> BUNDLE["📦 Document + Signature"]
-        SIG --> BUNDLE
-    end
-
-    BUNDLE -->|"Send"| VERIFY
-
-    subgraph VERIFY["Receiver: Verify Signature"]
-        direction TB
-        RECV["📦 Document + Signature"] --> SPLIT1["📄 Document"]
-        RECV --> SPLIT2["✍️ Signature"]
-        SPLIT1 --> HASH2["SHA-256 Hash"]
-        HASH2 --> DIGEST2["Hash Digest"]
-        SPLIT2 --> DECRYPT["Decrypt with<br/>🔓 Public Key"]
-        DECRYPT --> DIGEST3["Hash Digest"]
-        DIGEST2 --> COMPARE{"Match?"}
-        DIGEST3 --> COMPARE
-        COMPARE -->|"Yes"| VALID["✅ Authentic & Unaltered"]
-        COMPARE -->|"No"| INVALID["❌ Tampered or Forged"]
-    end
-
-    style Signing fill:#e8f5e9,color:#000,stroke:#2e7d32
-    style VERIFY fill:#e3f2fd,color:#000,stroke:#1565c0
-```
+<div class="flow" aria-label="Digital signature signing and verification path">
+  <div class="flow-node"><b>📄 Original Document</b><i>sender</i></div>
+  <div class="flow-node">SHA-256 Hash</div>
+  <div class="flow-node"><b>Hash Digest</b><i>a591a6d4...</i></div>
+  <div class="flow-node"><b>Encrypt</b><i>with 🔐 Private Key</i></div>
+  <div class="flow-node">✍️ Digital Signature</div>
+  <div class="flow-node">📦 Document + Signature</div>
+  <div class="flow-node"><b>Receiver</b><i>split document and signature</i></div>
+  <div class="flow-parallel">
+    <div class="flow-node"><b>📄 Document</b><i>SHA-256 Hash, then Hash Digest</i></div>
+    <div class="flow-node"><b>✍️ Signature</b><i>Decrypt with 🔓 Public Key, then Hash Digest</i></div>
+  </div>
+  <div class="flow-node is-gate">Match?</div>
+  <div class="flow-branch">
+    <div class="flow-leg" data-branch="Yes"><div class="flow-node is-good">✅ Authentic &amp; Unaltered</div></div>
+    <div class="flow-leg" data-branch="No"><div class="flow-node is-bad">❌ Tampered or Forged</div></div>
+  </div>
+</div>
 
 **The process is elegant in its simplicity:**
 - Hash the message first (creates fixed-size fingerprint)

--- a/src/posts/2024-03-20-transformer-architecture-deep-dive.md
+++ b/src/posts/2024-03-20-transformer-architecture-deep-dive.md
@@ -17,36 +17,14 @@ In late 2018, I implemented my first Transformer from scratch for a machine tran
 
 ## How It Works
 
-```mermaid
-flowchart TD
-    subgraph input["Input"]
-        Tokens[Token Embeddings]
-        Pos[Positional Encoding]
-    end
-    subgraph encoderstack["Encoder Stack"]
-        MHA1[Multi-Head Attention]
-        FFN1[Feed Forward]
-        Norm1[Layer Norm]
-    end
-    subgraph decoderstack["Decoder Stack"]
-        MHA2[Masked Attention]
-        Cross[Cross Attention]
-        FFN2[Feed Forward]
-    end
-
-    Tokens --> Pos
-    Pos --> MHA1
-    MHA1 --> FFN1
-    FFN1 --> Norm1
-    Norm1 --> Cross
-    MHA2 --> Cross
-    Cross --> FFN2
-
-    classDef orange fill:#ff9800,color:#000,stroke:#e65100,stroke-width:2px
-    classDef purple fill:#9c27b0,color:#fff,stroke:#6a1b9a,stroke-width:2px
-    class MHA1 orange
-    class Cross purple
-```
+<figure class="arch-fig">
+<div class="arch is-stack" aria-label="Transformer encoder and decoder architecture">
+  <section class="arch-tier" data-label="Input"><span class="arch-chip">Token Embeddings</span><span class="arch-chip">Positional Encoding</span></section>
+  <section class="arch-tier" data-label="Encoder Stack"><span class="arch-chip is-primary">Multi-Head Attention</span><span class="arch-chip">Feed Forward</span><span class="arch-chip">Layer Norm</span></section>
+  <section class="arch-tier" data-label="Decoder Stack"><span class="arch-chip">Masked Attention</span><span class="arch-chip is-primary">Cross Attention</span><span class="arch-chip">Feed Forward</span></section>
+</div>
+<figcaption>Token and position inputs move through the encoder stack before decoder attention combines masked and cross-attention paths.</figcaption>
+</figure>
 
 ## The Frustration That Led to Revolution
 

--- a/src/posts/2024-07-16-sustainable-computing-carbon-footprint.md
+++ b/src/posts/2024-07-16-sustainable-computing-carbon-footprint.md
@@ -41,30 +41,14 @@ Computational demands were growing faster than efficiency improvements, meaning 
 
 Before optimizing, I needed to understand where the emissions were coming from. The following diagram illustrates the three emission scopes and how they relate to an organization's computing infrastructure:
 
-```mermaid
-flowchart TD
-    ORG["Organization's Computing<br/>Carbon Footprint"]
-
-    ORG --> S1["Scope 1<br/>Direct Energy Use"]
-    ORG --> S2["Scope 2<br/>Indirect Energy Use"]
-    ORG --> S3["Scope 3<br/>Supply Chain Emissions"]
-
-    S1 --> S1A["Office Electricity"]
-    S1 --> S1B["Backup Generators"]
-    S1 --> S1C["Company Vehicles"]
-
-    S2 --> S2A["Cloud Computing"]
-    S2 --> S2B["Purchased Electricity"]
-    S2 --> S2C["Cooling & HVAC"]
-
-    S3 --> S3A["Device Manufacturing"]
-    S3 --> S3B["Employee Commuting"]
-    S3 --> S3C["Third-Party Services"]
-
-    style S1 fill:#e74c3c,color:#fff
-    style S2 fill:#f39c12,color:#fff
-    style S3 fill:#3498db,color:#fff
-```
+<figure class="arch-fig">
+<div class="arch" aria-label="Organization computing carbon footprint scopes">
+  <section class="arch-tier" data-label="Scope 1: Direct Energy Use"><span class="arch-chip">Office Electricity</span><span class="arch-chip">Backup Generators</span><span class="arch-chip">Company Vehicles</span></section>
+  <section class="arch-tier" data-label="Scope 2: Indirect Energy Use"><span class="arch-chip">Cloud Computing</span><span class="arch-chip">Purchased Electricity</span><span class="arch-chip">Cooling &amp; HVAC</span></section>
+  <section class="arch-tier" data-label="Scope 3: Supply Chain Emissions"><span class="arch-chip">Device Manufacturing</span><span class="arch-chip">Employee Commuting</span><span class="arch-chip">Third-Party Services</span></section>
+</div>
+<figcaption>An organization's computing carbon footprint spans direct energy, purchased energy, and supply-chain emissions.</figcaption>
+</figure>
 
 
 **Direct Energy Use (Scope 1):**
@@ -102,20 +86,13 @@ flowchart TD
 
 The overall flow from energy consumption through to carbon impact follows this pattern:
 
-```mermaid
-flowchart LR
-    A["Energy Source<br/>(Grid / Renewable)"] --> B["Data Center<br/>PUE Measurement"]
-    B --> C["Compute Workload<br/>(CPU, GPU, Storage)"]
-    C --> D["Carbon Intensity<br/>gCO2/kWh"]
-    D --> E["Total Carbon<br/>Footprint"]
-
-    F["Carbon Intensity API<br/>(WattTime, Electricity Maps)"] --> D
-    G["Cloud Provider<br/>Carbon Calculators"] --> E
-
-    style A fill:#27ae60,color:#fff
-    style D fill:#e67e22,color:#fff
-    style E fill:#c0392b,color:#fff
-```
+<div class="flow" aria-label="Carbon footprint measurement path">
+  <div class="flow-node"><b>Energy Source</b><i>Grid / Renewable</i></div>
+  <div class="flow-node"><b>Data Center</b><i>PUE Measurement</i></div>
+  <div class="flow-node"><b>Compute Workload</b><i>CPU, GPU, Storage</i></div>
+  <div class="flow-node"><b>Carbon Intensity</b><i>gCO2/kWh from WattTime or Electricity Maps</i></div>
+  <div class="flow-node"><b>Total Carbon Footprint</b><i>cloud provider calculators can feed estimates</i></div>
+</div>
 
 ## Strategies for Reducing Energy Consumption
 
@@ -187,39 +164,21 @@ Choosing data center locations based on carbon intensity:
 
 The following diagram shows how carbon-aware workload scheduling interacts with renewable energy availability:
 
-```mermaid
-flowchart TD
-    subgraph Scheduling["Carbon-Aware Scheduler"]
-        WL["Workload Queue"]
-        CI["Carbon Intensity<br/>API (WattTime)"]
-        DEC{"Carbon Intensity<br/>Below Threshold?"}
-    end
-
-    subgraph Energy["Energy Sources"]
-        SOLAR["Solar Generation<br/>Peak: 11AM-3PM"]
-        WIND["Wind Generation<br/>Peak: 2AM-6AM"]
-        GRID["Grid Electricity<br/>Variable Carbon"]
-    end
-
-    subgraph Actions["Scheduling Actions"]
-        RUN["Run Workload Now<br/>(Low Carbon)"]
-        DEFER["Defer to Low-Carbon<br/>Window"]
-        MIGRATE["Migrate to Green<br/>Region"]
-    end
-
-    SOLAR --> CI
-    WIND --> CI
-    GRID --> CI
-    WL --> DEC
-    CI --> DEC
-    DEC -- "Yes" --> RUN
-    DEC -- "No, deferrable" --> DEFER
-    DEC -- "No, urgent" --> MIGRATE
-
-    style RUN fill:#27ae60,color:#fff
-    style DEFER fill:#f39c12,color:#fff
-    style MIGRATE fill:#3498db,color:#fff
-```
+<div class="flow" aria-label="Carbon-aware scheduling decision path">
+  <div class="flow-parallel">
+    <div class="flow-node"><b>Solar Generation</b><i>Peak: 11AM-3PM</i></div>
+    <div class="flow-node"><b>Wind Generation</b><i>Peak: 2AM-6AM</i></div>
+    <div class="flow-node"><b>Grid Electricity</b><i>Variable Carbon</i></div>
+  </div>
+  <div class="flow-node"><b>Carbon Intensity API</b><i>WattTime</i></div>
+  <div class="flow-node">Workload Queue</div>
+  <div class="flow-node is-gate">Carbon Intensity Below Threshold?</div>
+  <div class="flow-branch">
+    <div class="flow-leg" data-branch="Yes"><div class="flow-node is-good"><b>Run Workload Now</b><i>Low Carbon</i></div></div>
+    <div class="flow-leg" data-branch="No, deferrable"><div class="flow-node is-gate">Defer to Low-Carbon Window</div></div>
+    <div class="flow-leg" data-branch="No, urgent"><div class="flow-node">Migrate to Green Region</div></div>
+  </div>
+</div>
 
 ### Carbon-Aware Computing
 

--- a/src/posts/2024-08-02-quantum-computing-leap-forward.md
+++ b/src/posts/2024-08-02-quantum-computing-leap-forward.md
@@ -18,36 +18,19 @@ That learning experience taught me something critical. Quantum computing isn't j
 
 ## How It Works
 
-```mermaid
-flowchart LR
-    subgraph initialization["Initialization"]
-        Q0[Qubit 0: Zero State]
-        Q1[Qubit 1: Zero State]
-    end
-    subgraph quantumgates["Quantum Gates"]
-        H[Hadamard Gate]
-        CNOT[CNOT Gate]
-        M[Measurement]
-    end
-    subgraph classicaloutput["Classical Output"]
-        C0[Classical Bit 0]
-        C1[Classical Bit 1]
-    end
-
-    Q0 --> H
-    H --> CNOT
-    Q1 --> CNOT
-    CNOT --> M
-    M --> C0
-    M --> C1
-
-    classDef hadamardStyle fill:#2196f3,color:#fff
-    classDef cnotStyle fill:#9c27b0,color:#fff
-    classDef measureStyle fill:#4caf50,color:#fff
-    class H hadamardStyle
-    class CNOT cnotStyle
-    class M measureStyle
-```
+<div class="flow" aria-label="Two-qubit quantum circuit path">
+  <div class="flow-parallel">
+    <div class="flow-node">Qubit 0: Zero State</div>
+    <div class="flow-node">Qubit 1: Zero State</div>
+  </div>
+  <div class="flow-node">Hadamard Gate</div>
+  <div class="flow-node">CNOT Gate</div>
+  <div class="flow-node is-gate">Measurement</div>
+  <div class="flow-parallel">
+    <div class="flow-node">Classical Bit 0</div>
+    <div class="flow-node">Classical Bit 1</div>
+  </div>
+</div>
 
 ## The Quantum Breakthrough: From Theory to Reality
 

--- a/src/posts/2024-08-13-high-performance-computing.md
+++ b/src/posts/2024-08-13-high-performance-computing.md
@@ -26,27 +26,16 @@ When the Department of Energy's Frontier system broke the exascale barrier in 20
 
 This convergence of power, efficiency, and accessibility is why I found myself standing in front of a supercomputer on a Tuesday afternoon, about to witness firsthand what happens when theoretical computational limits become engineering reality.
 
-```mermaid
-graph TB
-    subgraph Compute Cluster Architecture
-        direction TB
-        LB[Load Balancer / Job Scheduler]
-        LB --> N1[Compute Node 1<br/>CPU + GPU]
-        LB --> N2[Compute Node 2<br/>CPU + GPU]
-        LB --> N3[Compute Node N<br/>CPU + GPU]
-        N1 <-->|High-Speed Interconnect<br/>InfiniBand / Slingshot| N2
-        N2 <-->|High-Speed Interconnect| N3
-        N1 <-->|High-Speed Interconnect| N3
-        N1 --> PFS[(Parallel File System<br/>Lustre / GPFS)]
-        N2 --> PFS
-        N3 --> PFS
-        PFS --> ST[(Long-Term Storage<br/>Object / Tape)]
-    end
-    U[Users / Researchers] --> LB
-    style LB fill:#4a90d9,color:#fff
-    style PFS fill:#e8a838,color:#fff
-    style ST fill:#888,color:#fff
-```
+<figure class="arch-fig">
+<div class="arch is-stack" aria-label="Compute cluster architecture">
+  <section class="arch-tier" data-label="Access"><span class="arch-chip">Users / Researchers</span></section>
+  <section class="arch-tier" data-label="Scheduling"><span class="arch-chip is-primary">Load Balancer / Job Scheduler</span></section>
+  <section class="arch-tier" data-label="Compute Cluster"><span class="arch-chip"><b>Compute Node 1</b><i>CPU + GPU</i></span><span class="arch-chip"><b>Compute Node 2</b><i>CPU + GPU</i></span><span class="arch-chip"><b>Compute Node N</b><i>CPU + GPU</i></span><span class="arch-chip is-guard"><b>High-Speed Interconnect</b><i>InfiniBand / Slingshot</i></span></section>
+  <section class="arch-tier" data-label="Shared Storage"><span class="arch-chip"><b>Parallel File System</b><i>Lustre / GPFS</i></span></section>
+  <section class="arch-tier" data-label="Long-Term Storage"><span class="arch-chip"><b>Object / Tape</b><i>archive tier</i></span></section>
+</div>
+<figcaption>Researchers submit work through the scheduler; compute nodes communicate over a high-speed fabric and write through the parallel file system to archival storage.</figcaption>
+</figure>
 
 <div class="zine-doodle" aria-hidden="true" style="--doodle: url('/assets/doodles/hpc.png'); width: min(300px, 72%); aspect-ratio: 360/265; margin: 2rem auto 0.5rem;"></div>
 <p class="hand-note" style="text-align: center; display: block;">your PC, and everyone else's</p>
@@ -313,27 +302,21 @@ The integration between quantum and classical HPC systems has evolved rapidly ov
 - **Quantum Framework scaling**: Recent frameworks are working to coordinate hybrid workflows between classical nodes and quantum backends
 - **Unified quantum platforms**: Emerging platforms provide portable abstraction layers allowing quantum algorithms to run across different QPU architectures without code rewrites[11]
 
-```mermaid
-flowchart TB
-    subgraph Quantum-Classical Hybrid Architecture
-        direction TB
-        P[Problem Definition] --> CP[Classical Preprocessor<br/>Problem Decomposition]
-        CP --> CL[Classical Solver<br/>Standard Subproblems]
-        CP --> QC[Quantum Circuit Compiler<br/>Quantum-Suitable Subproblems]
-        QC --> QPU[Quantum Processor<br/>VQE / QAOA Execution]
-        QPU --> EM[Error Mitigation<br/>Zero-Noise Extrapolation]
-        EM --> OPT{Converged?}
-        CL --> MERGE[Result Aggregation]
-        OPT -->|No| QC
-        OPT -->|Yes| MERGE
-        MERGE --> R[Final Solution]
-    end
-    style QPU fill:#e056a0,color:#fff
-    style CL fill:#4a90d9,color:#fff
-    style CP fill:#4a90d9,color:#fff
-    style EM fill:#e8a838,color:#fff
-    style OPT fill:#00b894,color:#fff
-```
+<div class="flow" aria-label="Quantum-classical hybrid solving path">
+  <div class="flow-node">Problem Definition</div>
+  <div class="flow-node"><b>Classical Preprocessor</b><i>Problem Decomposition</i></div>
+  <div class="flow-parallel">
+    <div class="flow-node"><b>Classical Solver</b><i>Standard Subproblems</i></div>
+    <div class="flow-node"><b>Quantum Circuit Compiler</b><i>Quantum-Suitable Subproblems</i></div>
+  </div>
+  <div class="flow-node"><b>Quantum Processor</b><i>VQE / QAOA Execution</i></div>
+  <div class="flow-node"><b>Error Mitigation</b><i>Zero-Noise Extrapolation</i></div>
+  <div class="flow-node is-gate">Converged?</div>
+  <div class="flow-branch">
+    <div class="flow-leg" data-branch="No"><div class="flow-node is-gate"><b>Repeat Quantum Compile</b><i>run another iteration</i></div></div>
+    <div class="flow-leg" data-branch="Yes"><div class="flow-node is-good"><b>Result Aggregation</b><i>Final Solution</i></div></div>
+  </div>
+</div>
 
 ```python
 # Simplified: Hybrid quantum-classical programming example

--- a/src/posts/2024-09-15-running-llama-raspberry-pi-pipeload.md
+++ b/src/posts/2024-09-15-running-llama-raspberry-pi-pipeload.md
@@ -318,22 +318,10 @@ I attempted splitting LLaMA 2 70B across my 3 Raspberry Pi 5s (16GB each) using 
 
 ### Performance Characteristics
 
-```mermaid
-flowchart LR
-    A[Standard PyTorch] -->|Memory| B[100%]
-    A -->|Speed| C[100%]
-    D[PIPELOAD] -->|Memory| E[10-14%]
-    D -->|Speed| F[88% single device<br/>425% edge vs swap]
-
-    classDef highMemStyle fill:#ef4444,color:#fff
-    classDef lowMemStyle fill:#10b981,color:#fff
-    classDef highSpeedStyle fill:#10b981,color:#fff
-    classDef medSpeedStyle fill:#f59e0b,color:#000
-    class B highMemStyle
-    class E lowMemStyle
-    class C highSpeedStyle
-    class F medSpeedStyle
-```
+| Runtime | Memory | Speed |
+|---|---:|---:|
+| Standard PyTorch | 100% | 100% |
+| PIPELOAD | 10-14% | 88% single device; 425% edge vs swap |
 
 **Bottom line:** PIPELOAD enables inference that's otherwise impossible on edge devices. The 12% latency overhead is acceptable when the alternative is OOM crashes or cloud dependency.
 

--- a/src/posts/2024-09-19-biomimetic-robotics.md
+++ b/src/posts/2024-09-19-biomimetic-robotics.md
@@ -39,21 +39,15 @@ The gecko's climbing ability, the octopus's ability to squeeze through tiny spac
 - Offload processing from CPUs to mechanical design
 - Let physics solve problems instead of software
 
-```mermaid
-flowchart LR
-    A["Biological System\nObservation"] --> B["Principle\nExtraction"]
-    B --> C["Computational\nModeling"]
-    C --> D["Material &\nMorphology Design"]
-    D --> E["Prototype\nFabrication"]
-    E --> F["Performance\nBenchmarking"]
-    F -->|"Gap Analysis"| B
-    style A fill:#2d6a4f,color:#fff
-    style B fill:#40916c,color:#fff
-    style C fill:#52b788,color:#fff
-    style D fill:#74c69d,color:#000
-    style E fill:#95d5b2,color:#000
-    style F fill:#b7e4c7,color:#000
-```
+<div class="flow" aria-label="Biomimetic robotics design process">
+  <div class="flow-node"><b>Biological System</b><i>Observation</i></div>
+  <div class="flow-node"><b>Principle</b><i>Extraction</i></div>
+  <div class="flow-node"><b>Computational</b><i>Modeling</i></div>
+  <div class="flow-node"><b>Material &amp;</b><i>Morphology Design</i></div>
+  <div class="flow-node"><b>Prototype</b><i>Fabrication</i></div>
+  <div class="flow-node"><b>Performance</b><i>Benchmarking</i></div>
+  <div class="flow-node is-gate"><b>Gap Analysis</b><i>feeds the next principle extraction</i></div>
+</div>
 
 This computational approach extends beyond robotics: distributing computation across specialized hardware (whether biological or silicon) yields dramatic efficiency gains.
 
@@ -102,31 +96,14 @@ Bird and insect flight inspired breakthrough micro aerial vehicles. Engineers di
 - Transitions between aerial and ground locomotion
 - Deployable for exploration missions
 
-```mermaid
-graph TD
-    subgraph Legged["Legged (MIT Cheetah)"]
-        L1["Dynamic balance"]
-        L2["Tendon energy storage"]
-        L3["6.4 m/s sprint"]
-    end
-    subgraph Aerial["Aerial (RoboBee / DALER)"]
-        A1["Insect wing mechanics"]
-        A2["90 mg flight platform"]
-        A3["Dual air/ground modes"]
-    end
-    subgraph Aquatic["Aquatic (Soft Robotic Fish)"]
-        Q1["Undulatory propulsion"]
-        Q2["No propeller needed"]
-        Q3["Minimal disturbance"]
-    end
-    BIO["Biological Locomotion\nPrinciples"] --> Legged
-    BIO --> Aerial
-    BIO --> Aquatic
-    style BIO fill:#1b4332,color:#fff
-    style Legged fill:#2d6a4f,color:#fff
-    style Aerial fill:#40916c,color:#fff
-    style Aquatic fill:#52b788,color:#fff
-```
+<figure class="arch-fig">
+<div class="arch" aria-label="Biological locomotion principle examples">
+  <section class="arch-tier" data-label="Legged (MIT Cheetah)"><span class="arch-chip">Dynamic balance</span><span class="arch-chip">Tendon energy storage</span><span class="arch-chip">6.4 m/s sprint</span></section>
+  <section class="arch-tier" data-label="Aerial (RoboBee / DALER)"><span class="arch-chip">Insect wing mechanics</span><span class="arch-chip">90 mg flight platform</span><span class="arch-chip">Dual air/ground modes</span></section>
+  <section class="arch-tier" data-label="Aquatic (Soft Robotic Fish)"><span class="arch-chip">Undulatory propulsion</span><span class="arch-chip">No propeller needed</span><span class="arch-chip">Minimal disturbance</span></section>
+</div>
+<figcaption>Biological locomotion principles map into legged, aerial, and aquatic robot designs.</figcaption>
+</figure>
 
 ### Underwater Grace
 

--- a/src/posts/2024-09-25-gvisor-container-sandboxing-security.md
+++ b/src/posts/2024-09-25-gvisor-container-sandboxing-security.md
@@ -46,29 +46,15 @@ Containers share the host kernel. One bad syscall can break containment. This is
 
 **But:** All these run in the kernel. Kernel bugs bypass them.
 
-```mermaid
-graph TB
-    subgraph "Traditional Container Isolation"
-        C1[Container Process] --> NS[Namespaces]
-        C1 --> CG[Cgroups]
-        C1 --> SC[Seccomp-BPF]
-        C1 --> MAC[AppArmor / SELinux]
-        NS --> K[Host Kernel]
-        CG --> K
-        SC --> K
-        MAC --> K
-        K --> HW[Hardware]
-    end
-
-    style K fill:#f66,stroke:#333,color:#fff
-    style HW fill:#999,stroke:#333,color:#fff
-    style C1 fill:#6af,stroke:#333,color:#fff
-
-    classDef danger fill:#f66,stroke:#333,color:#fff
-    K:::danger
-
-    linkStyle 4,5,6,7 stroke:#f66,stroke-width:2px
-```
+<figure class="arch-fig">
+<div class="arch is-stack" aria-label="Traditional container isolation stack">
+  <section class="arch-tier" data-label="Workload"><span class="arch-chip is-primary">Container Process</span></section>
+  <section class="arch-tier" data-label="Kernel Isolation Controls"><span class="arch-chip is-guard">Namespaces</span><span class="arch-chip is-guard">Cgroups</span><span class="arch-chip is-guard">Seccomp-BPF</span><span class="arch-chip is-guard">AppArmor / SELinux</span></section>
+  <section class="arch-tier" data-label="Shared Boundary"><span class="arch-chip is-bad">Host Kernel</span></section>
+  <section class="arch-tier" data-label="Platform"><span class="arch-chip">Hardware</span></section>
+</div>
+<figcaption>Traditional containers add multiple guardrails, but every path still terminates at the shared host kernel.</figcaption>
+</figure>
 
 > All isolation mechanisms run inside the kernel. A single kernel vulnerability bypasses every layer.
 
@@ -97,33 +83,14 @@ Container → gVisor Sentry (userspace) → Host Kernel
 - Runs with minimal privileges
 - Cannot access host filesystem directly
 
-```mermaid
-graph LR
-    subgraph "Container Sandbox"
-        APP[Container App]
-    end
-
-    subgraph "gVisor Userspace Kernel"
-        SENTRY[Sentry<br/>Go userspace kernel<br/>200+ syscalls reimplemented]
-        GOFER[Gofer<br/>9P filesystem proxy<br/>minimal privileges]
-    end
-
-    subgraph "Host"
-        HK[Host Kernel<br/>limited syscall surface]
-        FS[Host Filesystem]
-    end
-
-    APP -- "All syscalls" --> SENTRY
-    SENTRY -- "Safe syscalls only" --> HK
-    SENTRY -- "File I/O requests" --> GOFER
-    GOFER -- "Scoped file access" --> FS
-
-    style APP fill:#6af,stroke:#333,color:#fff
-    style SENTRY fill:#6c6,stroke:#333,color:#fff
-    style GOFER fill:#6c6,stroke:#333,color:#fff
-    style HK fill:#fc6,color:#000,stroke:#333
-    style FS fill:#fc6,color:#000,stroke:#333
-```
+<figure class="arch-fig">
+<div class="arch is-stack" aria-label="gVisor container sandbox architecture">
+  <section class="arch-tier" data-label="Container Sandbox"><span class="arch-chip is-primary">Container App</span></section>
+  <section class="arch-tier" data-label="gVisor Userspace Kernel"><span class="arch-chip is-guard"><b>Sentry</b><i>Go userspace kernel; 200+ syscalls reimplemented</i></span><span class="arch-chip is-guard"><b>Gofer</b><i>9P filesystem proxy; minimal privileges</i></span></section>
+  <section class="arch-tier" data-label="Host"><span class="arch-chip"><b>Host Kernel</b><i>limited syscall surface</i></span><span class="arch-chip">Host Filesystem</span></section>
+</div>
+<figcaption>Container syscalls hit Sentry first; only safe host syscalls and scoped file requests continue into the host.</figcaption>
+</figure>
 
 **Key insight:** Even if a container exploits a syscall bug, it's exploiting Go code in userspace, not the kernel. No privilege escalation to host.
 
@@ -380,23 +347,26 @@ docker run --rm --runtime=runsc alpine sh -c "echo 'exploit' | tee /proc/self/me
 
 **My decision tree:**
 
-```mermaid
-flowchart TD
-    START([New Workload]) --> Q1{Untrusted image?}
-    Q1 -- Yes --> GVISOR[Use gVisor]
-    Q1 -- No --> Q2{Internet-facing?}
-    Q2 -- Yes --> GVISOR
-    Q2 -- No --> Q3{Needs native<br/>performance?}
-    Q3 -- Yes --> RUNC[Use runc]
-    Q3 -- No --> Q4{Syscall-heavy?}
-    Q4 -- Yes --> RUNC
-    Q4 -- No --> RUNC2[Use runc<br/>principle of least surprise]
-
-    style GVISOR fill:#6c6,stroke:#333,color:#fff
-    style RUNC fill:#fc6,color:#000,stroke:#333
-    style RUNC2 fill:#fc6,color:#000,stroke:#333
-    style START fill:#6af,stroke:#333,color:#fff
-```
+<div class="flow" aria-label="Container runtime selection decision path">
+  <div class="flow-node">New Workload</div>
+  <div class="flow-node is-gate">Untrusted image?</div>
+  <div class="flow-branch">
+    <div class="flow-leg" data-branch="Yes"><div class="flow-node is-good">Use gVisor</div></div>
+    <div class="flow-leg" data-branch="No"><div class="flow-node is-gate">Internet-facing?</div></div>
+  </div>
+  <div class="flow-branch">
+    <div class="flow-leg" data-branch="Yes"><div class="flow-node is-good">Use gVisor</div></div>
+    <div class="flow-leg" data-branch="No"><div class="flow-node is-gate">Needs native performance?</div></div>
+  </div>
+  <div class="flow-branch">
+    <div class="flow-leg" data-branch="Yes"><div class="flow-node">Use runc</div></div>
+    <div class="flow-leg" data-branch="No"><div class="flow-node is-gate">Syscall-heavy?</div></div>
+  </div>
+  <div class="flow-branch">
+    <div class="flow-leg" data-branch="Yes"><div class="flow-node">Use runc</div></div>
+    <div class="flow-leg" data-branch="No"><div class="flow-node"><b>Use runc</b><i>principle of least surprise</i></div></div>
+  </div>
+</div>
 
 **Trade-off:** Security vs performance. I choose security for attack surfaces, performance for internal services.
 
@@ -467,31 +437,16 @@ G-Fuzz demonstrates that even secure-by-design systems need adversarial testing.
 - [Open Policy Agent](https://www.openpolicyagent.org/) for admission control
 - [Tetragon](https://github.com/cilium/tetragon) for eBPF observability
 
-```mermaid
-graph TB
-    subgraph "Defense in Depth Stack"
-        direction TB
-        L1[Admission Control<br/>OPA / Kyverno]
-        L2[Runtime Sandbox<br/>gVisor Sentry + Gofer]
-        L3[Runtime Detection<br/>Falco / Tetragon]
-        L4[Network Policy<br/>Cilium / Calico]
-        L5[Vulnerability Scanning<br/>Grype / Trivy]
-    end
-
-    L1 --> L2 --> L3 --> L4 --> L5
-
-    ATK([Attacker]) -.->|blocked| L1
-    ATK -.->|blocked| L2
-    ATK -.->|detected| L3
-    ATK -.->|contained| L4
-
-    style L1 fill:#69c,stroke:#333,color:#fff
-    style L2 fill:#6c6,stroke:#333,color:#fff
-    style L3 fill:#c96,stroke:#333,color:#fff
-    style L4 fill:#c6c,stroke:#333,color:#fff
-    style L5 fill:#cc6,color:#000,stroke:#333
-    style ATK fill:#f66,stroke:#333,color:#fff
-```
+<figure class="arch-fig">
+<div class="arch is-stack" aria-label="Container defense in depth stack">
+  <section class="arch-tier" data-label="Admission Control"><span class="arch-chip is-guard">OPA / Kyverno</span></section>
+  <section class="arch-tier" data-label="Runtime Sandbox"><span class="arch-chip is-primary">gVisor Sentry + Gofer</span></section>
+  <section class="arch-tier" data-label="Runtime Detection"><span class="arch-chip is-warn">Falco / Tetragon</span></section>
+  <section class="arch-tier" data-label="Network Policy"><span class="arch-chip is-guard">Cilium / Calico</span></section>
+  <section class="arch-tier" data-label="Vulnerability Scanning"><span class="arch-chip">Grype / Trivy</span></section>
+</div>
+<figcaption>Attackers should be blocked at admission or runtime, detected by monitoring, and contained by network policy before scanning closes the loop.</figcaption>
+</figure>
 
 **No silver bullet.** Security is understanding your threat model and layering controls.
 

--- a/src/posts/2024-10-10-blockchain-beyond-cryptocurrency.md
+++ b/src/posts/2024-10-10-blockchain-beyond-cryptocurrency.md
@@ -25,43 +25,15 @@ That has implications far beyond finance, though I'm still figuring out where th
 
 ## How It Actually Works (From My Test Network)
 
-```mermaid
-flowchart TD
-    subgraph network["Network Layer"]
-        P2P[P2P Network]
-        Gossip[Gossip Protocol]
-    end
-
-    subgraph consensus["Consensus"]
-        Mining[Mining/Validation]
-        Consensus[Consensus Algorithm]
-    end
-
-    subgraph data["Data Layer"]
-        Blocks[Blocks]
-        Chain[Blockchain]
-        State[State Tree]
-    end
-
-    subgraph app["Application"]
-        Smart[Smart Contracts]
-        DApp[DApps]
-    end
-
-    P2P --> Gossip
-    Gossip --> Mining
-    Mining --> Consensus
-    Consensus --> Blocks
-    Blocks --> Chain
-    Chain --> State
-    State --> Smart
-    Smart --> DApp
-
-    classDef orange fill:#ff9800,color:#000,stroke:#e65100,stroke-width:2px
-    classDef purple fill:#9c27b0,color:#fff,stroke:#6a1b9a,stroke-width:2px
-    class Consensus orange
-    class Smart purple
-```
+<figure class="arch-fig">
+<div class="arch is-stack" aria-label="Blockchain system layers">
+  <section class="arch-tier" data-label="Network Layer"><span class="arch-chip">P2P Network</span><span class="arch-chip">Gossip Protocol</span></section>
+  <section class="arch-tier" data-label="Consensus"><span class="arch-chip">Mining/Validation</span><span class="arch-chip is-primary">Consensus Algorithm</span></section>
+  <section class="arch-tier" data-label="Data Layer"><span class="arch-chip">Blocks</span><span class="arch-chip">Blockchain</span><span class="arch-chip">State Tree</span></section>
+  <section class="arch-tier" data-label="Application"><span class="arch-chip is-primary">Smart Contracts</span><span class="arch-chip">DApps</span></section>
+</div>
+<figcaption>Blockchain systems build from peer networking through consensus and state storage into smart-contract applications.</figcaption>
+</figure>
 
 My local testnet processed about 47 transactions per second on the Dell R910, which sounds impressive until you compare it to Visa's 24,000 tps. Scalability remains a real challenge, and I'm not convinced we've solved it yet.
 

--- a/src/posts/2024-11-15-gpu-power-monitoring-homelab-ml.md
+++ b/src/posts/2024-11-15-gpu-power-monitoring-homelab-ml.md
@@ -55,41 +55,30 @@ LLM Stack:
 
 I ran each test for at least 30 minutes to capture steady-state behavior. Repeated critical measurements three times for variability. The methodology isn't publication-worthy, but rigorous enough for decision-making.
 
-```mermaid
-graph TD
-    subgraph Hardware Monitoring
-        KAW[Kill-A-Watt P4400<br/>Wall outlet]
-        UPS[APC Back-UPS Pro 1500VA<br/>Inline monitoring]
-    end
-
-    subgraph GPU Rig
-        GPU[RTX 3090 24GB]
-        CPU[i9-9900K]
-        PSU[EVGA 850W 80+ Gold]
-    end
-
-    subgraph Software Stack
-        SMI[nvidia-smi<br/>2s polling]
-        DCGM[DCGM Exporter]
-        PY[Custom Python<br/>logging scripts]
-    end
-
-    subgraph Observability
-        PROM[Prometheus]
-        GRAF[Grafana Dashboards]
-        TEL[Telegram Alerts]
-    end
-
-    KAW -->|total system watts| PY
-    UPS -->|UPS metrics| PROM
-    GPU --> SMI
-    GPU --> DCGM
-    SMI -->|GPU power, temp, clock| PY
-    DCGM -->|GPU telemetry| PROM
-    PY -->|timestamped CSV| PROM
-    PROM --> GRAF
-    GRAF -->|threshold breach| TEL
-```
+<figure>
+<div class="arch" aria-label="GPU power monitoring component zones">
+  <section class="arch-tier" data-label="Hardware Monitoring"><span class="arch-chip"><b>Kill-A-Watt P4400</b><i>Wall outlet</i></span><span class="arch-chip"><b>APC Back-UPS Pro 1500VA</b><i>Inline monitoring</i></span></section>
+  <section class="arch-tier" data-label="GPU Rig"><span class="arch-chip is-primary">RTX 3090 24GB</span><span class="arch-chip">i9-9900K</span><span class="arch-chip">EVGA 850W 80+ Gold</span></section>
+  <section class="arch-tier" data-label="Software Stack"><span class="arch-chip"><b>nvidia-smi</b><i>2s polling</i></span><span class="arch-chip">DCGM Exporter</span><span class="arch-chip"><b>Custom Python</b><i>logging scripts</i></span></section>
+  <section class="arch-tier" data-label="Observability"><span class="arch-chip">Prometheus</span><span class="arch-chip">Grafana Dashboards</span><span class="arch-chip is-warn">Telegram Alerts</span></section>
+</div>
+<div class="flow" aria-label="GPU telemetry collection path">
+  <div class="flow-parallel">
+    <div class="flow-node"><b>Kill-A-Watt</b><i>total system watts</i></div>
+    <div class="flow-node"><b>UPS</b><i>UPS metrics</i></div>
+    <div class="flow-node"><b>RTX 3090</b><i>GPU telemetry</i></div>
+  </div>
+  <div class="flow-parallel">
+    <div class="flow-node"><b>nvidia-smi</b><i>GPU power, temp, clock</i></div>
+    <div class="flow-node">DCGM Exporter</div>
+    <div class="flow-node"><b>Custom Python</b><i>timestamped CSV</i></div>
+  </div>
+  <div class="flow-node">Prometheus</div>
+  <div class="flow-node">Grafana Dashboards</div>
+  <div class="flow-node is-gate">Telegram Alerts</div>
+</div>
+<figcaption>The architecture view shows the monitoring zones; the flow view shows how wall, UPS, and GPU telemetry land in Prometheus and alert through Grafana.</figcaption>
+</figure>
 
 ## What I Learned: Five Surprising Findings
 
@@ -159,25 +148,23 @@ Continuous generation:
 
 Batching queries more than doubled efficiency. The reason seems to be reduced overhead: interactive mode involved constant model state changes, while batch processing kept the GPU consistently loaded. This discovery changed how I structure my workflows. I now accumulate questions and process them together rather than one-by-one.
 
-```mermaid
-graph LR
-    subgraph Interactive Mode
-        Q1[Query 1] --> GPU1[GPU Ramp Up<br/>298W]
-        GPU1 --> R1[Response]
-        R1 --> IDLE1[Idle Gap<br/>87W]
-        IDLE1 --> Q2[Query 2]
-        Q2 --> GPU2[GPU Ramp Up<br/>298W]
-        GPU2 --> R2[Response]
-    end
-
-    subgraph Batch Mode
-        QB[50 Queries<br/>Queued] --> GPUB[GPU Sustained<br/>315W]
-        GPUB --> RB[All 50<br/>Responses]
-    end
-
-    style IDLE1 fill:#f96,color:#000,stroke:#333
-    style GPUB fill:#6b6,color:#fff,stroke:#333
-```
+<figure>
+<div class="flow" aria-label="Interactive GPU query mode">
+  <div class="flow-node">Query 1</div>
+  <div class="flow-node"><b>GPU Ramp Up</b><i>298W</i></div>
+  <div class="flow-node">Response</div>
+  <div class="flow-node is-gate"><b>Idle Gap</b><i>87W</i></div>
+  <div class="flow-node">Query 2</div>
+  <div class="flow-node"><b>GPU Ramp Up</b><i>298W</i></div>
+  <div class="flow-node">Response</div>
+</div>
+<div class="flow" aria-label="Batch GPU query mode">
+  <div class="flow-node"><b>50 Queries</b><i>Queued</i></div>
+  <div class="flow-node is-good"><b>GPU Sustained</b><i>315W</i></div>
+  <div class="flow-node"><b>All 50</b><i>Responses</i></div>
+</div>
+<figcaption>Interactive mode pays repeated ramp and idle costs; batch mode keeps the GPU loaded until the queue drains.</figcaption>
+</figure>
 
 For instance, when writing blog posts, I used to ask the LLM to review each paragraph individually as I wrote it. Now I write the entire draft, then submit all paragraphs in a single batch request. This reduced my average "blog editing" power consumption from 42Wh per post to 18Wh, a 57% improvement.
 
@@ -204,26 +191,33 @@ This failure taught me to add:
 
 These safeguards probably seem obvious to DevOps professionals, but they weren't part of my homelab muscle memory until this expensive lesson.
 
-```mermaid
-flowchart TD
-    GPU[GPU Running<br/>Batch Job] -->|2s polling| PROM[Prometheus<br/>Scrapes nvidia-smi]
-    PROM --> ALERT{Grafana Alert Rule<br/>Power > 300W<br/>for > 2 hours?}
-    ALERT -->|No| PROM
-    ALERT -->|Yes| NOTIFY[Telegram<br/>Notification]
-    NOTIFY --> ME[Owner Checks]
-    ME --> DECIDE{Legitimate<br/>workload?}
-    DECIDE -->|Yes| SNOOZE[Snooze Alert]
-    DECIDE -->|No| KILL[Kill Runaway Job]
-    KILL --> LOG[Log Incident<br/>+ Update Timeout]
-
-    GPU -->|also checked| TIMEOUT{Job Timeout<br/>Exceeded?}
-    TIMEOUT -->|Yes| ABORT[Auto-Abort Job<br/>+ Checkpoint State]
-    TIMEOUT -->|No| GPU
-
-    style ALERT fill:#ff9,color:#000,stroke:#333
-    style KILL fill:#f66,color:#fff,stroke:#333
-    style ABORT fill:#f96,color:#000,stroke:#333
-```
+<figure>
+<div class="flow" aria-label="GPU power alert response path">
+  <div class="flow-node"><b>GPU Running</b><i>Batch Job</i></div>
+  <div class="flow-node"><b>Prometheus</b><i>scrapes nvidia-smi every 2s</i></div>
+  <div class="flow-node is-gate"><b>Grafana Alert Rule</b><i>Power &gt; 300W for &gt; 2 hours?</i></div>
+  <div class="flow-branch">
+    <div class="flow-leg" data-branch="No"><div class="flow-node">Continue Polling</div></div>
+    <div class="flow-leg" data-branch="Yes"><div class="flow-node is-gate">Telegram Notification</div></div>
+  </div>
+  <div class="flow-node">Owner Checks</div>
+  <div class="flow-node is-gate">Legitimate workload?</div>
+  <div class="flow-branch">
+    <div class="flow-leg" data-branch="Yes"><div class="flow-node is-good">Snooze Alert</div></div>
+    <div class="flow-leg" data-branch="No"><div class="flow-node is-bad">Kill Runaway Job</div></div>
+  </div>
+  <div class="flow-node"><b>Log Incident</b><i>+ Update Timeout</i></div>
+</div>
+<div class="flow" aria-label="GPU timeout abort path">
+  <div class="flow-node"><b>GPU Running</b><i>also checked</i></div>
+  <div class="flow-node is-gate">Job Timeout Exceeded?</div>
+  <div class="flow-branch">
+    <div class="flow-leg" data-branch="Yes"><div class="flow-node is-bad"><b>Auto-Abort Job</b><i>+ Checkpoint State</i></div></div>
+    <div class="flow-leg" data-branch="No"><div class="flow-node">Continue Running</div></div>
+  </div>
+</div>
+<figcaption>The alert path handles sustained power draw while the timeout path catches jobs that run past the allowed wall clock.</figcaption>
+</figure>
 
 ## Optimization Strategies That Actually Worked
 
@@ -255,31 +249,25 @@ The trade-off: CPU inference is slower (2.3 tokens/second vs 18.7), but for tiny
 
 For these micro-tasks, CPU is 4x more energy-efficient despite being slower. I'm not sure this would scale to longer queries, but for quick lookups, it's a clear win.
 
-```mermaid
-flowchart TD
-    REQ[Incoming Query] --> SIZE{Token estimate?}
-
-    SIZE -->|< 100 tokens| CPU[Route to CPU<br/>llama.cpp on i9-9900K<br/>95W / 2.3 tok/s]
-    SIZE -->|100+ tokens| COMPLEXITY{Task complexity?}
-
-    COMPLEXITY -->|Simple<br/>summarization, Q&A| PHI[Phi-3 Mini 3.8B<br/>276W avg]
-    COMPLEXITY -->|General<br/>chat, writing| LLAMA8[Llama 3.1 8B<br/>312W avg]
-    COMPLEXITY -->|Complex<br/>code gen, analysis| LLAMA70[Llama 3.1 70B Q4<br/>347W avg]
-
-    CPU --> DONE[Return Response]
-    PHI --> DONE
-    LLAMA8 --> DONE
-    LLAMA70 --> DONE
-
-    DONE --> IDLE{Idle > 15 min?}
-    IDLE -->|Yes| UNLOAD[Unload Model<br/>Drop to 52W baseline]
-    IDLE -->|No| WAIT[Keep Model Loaded<br/>87W standby]
-
-    style CPU fill:#6b6,color:#fff,stroke:#333
-    style PHI fill:#8b8,color:#000,stroke:#333
-    style LLAMA8 fill:#cc8,color:#000,stroke:#333
-    style LLAMA70 fill:#f96,color:#000,stroke:#333
-```
+<div class="flow" aria-label="Power-aware model routing decision path">
+  <div class="flow-node">Incoming Query</div>
+  <div class="flow-node is-gate">Token estimate?</div>
+  <div class="flow-branch">
+    <div class="flow-leg" data-branch="&lt; 100 tokens"><div class="flow-node is-good"><b>Route to CPU</b><i>llama.cpp on i9-9900K; 95W / 2.3 tok/s</i></div></div>
+    <div class="flow-leg" data-branch="100+ tokens"><div class="flow-node is-gate">Task complexity?</div></div>
+  </div>
+  <div class="flow-branch">
+    <div class="flow-leg" data-branch="Simple summarization, Q&amp;A"><div class="flow-node is-good"><b>Phi-3 Mini 3.8B</b><i>276W avg</i></div></div>
+    <div class="flow-leg" data-branch="General chat, writing"><div class="flow-node"><b>Llama 3.1 8B</b><i>312W avg</i></div></div>
+    <div class="flow-leg" data-branch="Complex code gen, analysis"><div class="flow-node is-bad"><b>Llama 3.1 70B Q4</b><i>347W avg</i></div></div>
+  </div>
+  <div class="flow-node">Return Response</div>
+  <div class="flow-node is-gate">Idle &gt; 15 min?</div>
+  <div class="flow-branch">
+    <div class="flow-leg" data-branch="Yes"><div class="flow-node is-good"><b>Unload Model</b><i>Drop to 52W baseline</i></div></div>
+    <div class="flow-leg" data-branch="No"><div class="flow-node"><b>Keep Model Loaded</b><i>87W standby</i></div></div>
+  </div>
+</div>
 
 ## Cost-Benefit Analysis
 

--- a/src/posts/2025-01-12-privacy-preserving-federated-learning-homelab.md
+++ b/src/posts/2025-01-12-privacy-preserving-federated-learning-homelab.md
@@ -31,28 +31,26 @@ Traditional machine learning requires aggregating all training data in one place
 
 This approach breaks privacy in obvious ways. If I'm training a medical diagnosis model, I need patient data from multiple hospitals. But centralizing that data means hospitals lose control, increase their breach surface, and violate privacy regulations.
 
-```mermaid
-graph LR
-    subgraph Centralized Training
-        A[Hospital A Data] -->|Upload| D[(Central Dataset)]
-        B[Hospital B Data] -->|Upload| D
-        C[Hospital C Data] -->|Upload| D
-        D --> M[Train Model]
-    end
-    subgraph Federated Training
-        A2[Hospital A Data] --> M2A[Local Model A]
-        B2[Hospital B Data] --> M2B[Local Model B]
-        C2[Hospital C Data] --> M2C[Local Model C]
-        M2A -->|Gradients only| AGG[Aggregator]
-        M2B -->|Gradients only| AGG
-        M2C -->|Gradients only| AGG
-        AGG -->|Updated weights| M2A
-        AGG -->|Updated weights| M2B
-        AGG -->|Updated weights| M2C
-    end
-    style D fill:#f96,color:#000,stroke:#333
-    style AGG fill:#6b6,color:#fff,stroke:#333
-```
+<figure>
+<div class="flow" aria-label="Centralized training data path">
+  <div class="flow-parallel">
+    <div class="flow-node">Hospital A Data</div>
+    <div class="flow-node">Hospital B Data</div>
+    <div class="flow-node">Hospital C Data</div>
+  </div>
+  <div class="flow-node is-bad"><b>Central Dataset</b><i>uploaded data</i></div>
+  <div class="flow-node">Train Model</div>
+</div>
+<div class="flow" aria-label="Federated training update path">
+  <div class="flow-parallel">
+    <div class="flow-node"><b>Hospital A Data</b><i>Local Model A</i></div>
+    <div class="flow-node"><b>Hospital B Data</b><i>Local Model B</i></div>
+    <div class="flow-node"><b>Hospital C Data</b><i>Local Model C</i></div>
+  </div>
+  <div class="flow-node is-good"><b>Aggregator</b><i>gradients only in; updated weights out</i></div>
+</div>
+<figcaption>Centralized training uploads raw hospital data; federated training keeps data local and exchanges gradients plus updated weights.</figcaption>
+</figure>
 
 **The dilemma:** How do you train accurate models without seeing the raw data?
 
@@ -255,27 +253,24 @@ pie title Training Round Time Breakdown (47 min total)
 
 ### Privacy Guarantees
 
-```mermaid
-flowchart TD
-    RAW[Raw Training Data<br/>Individual examples] --> GB[Granular-Ball Segmentation]
-    GB --> C1[Cluster 1<br/>center, variance, radius]
-    GB --> C2[Cluster 2<br/>center, variance, radius]
-    GB --> C3[Cluster N<br/>center, variance, radius]
-    C1 --> VT{Variance > threshold?}
-    C2 --> VT
-    C3 --> VT
-    VT -->|Yes| SEND[Shared with aggregator]
-    VT -->|No| DROP[Dropped — never leaves device]
-    SEND --> AGG[Aggregation Server]
-
-    ATK[Reconstruction Attack] -.->|Fails| SEND
-    ATK2[Gradient Inversion] -.->|Not applicable| SEND
-
-    style DROP fill:#f66,stroke:#333,color:#fff
-    style SEND fill:#6b6,stroke:#333,color:#fff
-    style ATK stroke-dasharray: 5 5,fill:#fee
-    style ATK2 stroke-dasharray: 5 5,fill:#fee
-```
+<div class="flow" aria-label="Granular-ball segmentation privacy path">
+  <div class="flow-node"><b>Raw Training Data</b><i>Individual examples</i></div>
+  <div class="flow-node">Granular-Ball Segmentation</div>
+  <div class="flow-parallel">
+    <div class="flow-node"><b>Cluster 1</b><i>center, variance, radius</i></div>
+    <div class="flow-node"><b>Cluster 2</b><i>center, variance, radius</i></div>
+    <div class="flow-node"><b>Cluster N</b><i>center, variance, radius</i></div>
+  </div>
+  <div class="flow-node is-gate">Variance &gt; threshold?</div>
+  <div class="flow-branch">
+    <div class="flow-leg" data-branch="Yes"><div class="flow-node is-good"><b>Shared with aggregator</b><i>Aggregation Server</i></div></div>
+    <div class="flow-leg" data-branch="No"><div class="flow-node is-bad">Dropped — never leaves device</div></div>
+  </div>
+  <div class="flow-parallel">
+    <div class="flow-node is-good"><b>Reconstruction Attack</b><i>Fails</i></div>
+    <div class="flow-node is-good"><b>Gradient Inversion</b><i>Not applicable</i></div>
+  </div>
+</div>
 
 The GrBFL paper proves that reconstructing individual training examples from granular-ball statistics is computationally infeasible under certain assumptions. Specifically:
 
@@ -395,4 +390,3 @@ The server aggregation bottleneck is fixable with parallelization, but I didn't 
 - [**K3s Lightweight Kubernetes**](https://k3s.io/) - What I use for orchestrating multi-Pi experiments
 
 - [**Raspberry Pi 5 Specifications**](https://www.raspberrypi.com/products/raspberry-pi-5/) - Hardware details for the 16GB model
-

--- a/src/posts/2025-06-25-local-llm-deployment-privacy-first.md
+++ b/src/posts/2025-06-25-local-llm-deployment-privacy-first.md
@@ -20,51 +20,15 @@ I run local LLMs up to 34B parameters on my RTX 3090 (24GB VRAM), completely off
 
 ## Local LLM Architecture
 
-```mermaid
-flowchart TB
-    subgraph hardware["Hardware"]
-        GPU[GPU/TPU]
-        CPU[CPU]
-        RAM[Memory]
-    end
-    subgraph modellayer["Model Layer"]
-        Models[(Model Files)]
-        Weights[Weights]
-        Config[Configuration]
-    end
-    subgraph inference["Inference"]
-        Engine[Inference Engine]
-        Cache[Token Cache]
-        Batch[Batch Processing]
-    end
-    subgraph interface["Interface"]
-        API[REST API]
-        UI[Web UI]
-        CLI[CLI Tool]
-    end
-
-    GPU --> Engine
-    CPU --> Engine
-    RAM --> Cache
-
-    Models --> Engine
-    Weights --> Engine
-    Config --> Engine
-
-    Engine --> Cache
-    Engine --> Batch
-
-    Batch --> API
-    API --> UI
-    API --> CLI
-
-    classDef orangeNode fill:#ff9800,color:#000
-    classDef greenNode fill:#4caf50,color:#fff
-    classDef blueNode fill:#2196f3,color:#fff
-    class GPU orangeNode
-    class Engine greenNode
-    class API blueNode
-```
+<figure class="arch-fig">
+<div class="arch is-stack" aria-label="Local LLM deployment architecture">
+  <section class="arch-tier" data-label="Hardware"><span class="arch-chip is-primary">GPU/TPU</span><span class="arch-chip">CPU</span><span class="arch-chip">Memory</span></section>
+  <section class="arch-tier" data-label="Model Layer"><span class="arch-chip">Model Files</span><span class="arch-chip">Weights</span><span class="arch-chip">Configuration</span></section>
+  <section class="arch-tier" data-label="Inference"><span class="arch-chip is-primary">Inference Engine</span><span class="arch-chip">Token Cache</span><span class="arch-chip">Batch Processing</span></section>
+  <section class="arch-tier" data-label="Interface"><span class="arch-chip is-primary">REST API</span><span class="arch-chip">Web UI</span><span class="arch-chip">CLI Tool</span></section>
+</div>
+<figcaption>Hardware and model files feed the inference engine, which exposes batch output through local API, web, and CLI interfaces.</figcaption>
+</figure>
 
 
 ## Why I Made the Switch

--- a/src/posts/2025-07-01-ebpf-security-monitoring-practical-guide.md
+++ b/src/posts/2025-07-01-ebpf-security-monitoring-practical-guide.md
@@ -27,48 +27,14 @@ Imagine having X-ray vision into your kernel, seeing every system call, network 
 
 ⚠️ **Warning:** The following diagrams and examples demonstrate security monitoring concepts for educational purposes. eBPF programs require kernel privileges and should only be deployed in controlled environments with proper authorization.
 
-```mermaid
-flowchart TB
-    subgraph attacksurface["Attack Surface"]
-        A1[Process Execution]
-        A2[Network Connections]
-        A3[File Operations]
-        A4[Privilege Changes]
-    end
-    subgraph kernelspace["Kernel Space"]
-        KP[Kernel Probes]
-        BPF[eBPF VM]
-        Maps[(BPF Maps)]
-        Verifier[BPF Verifier]
-    end
-    subgraph userspace["User Space"]
-        Loader[BPF Loader]
-        Monitor[Event Monitor]
-        AI[AI/ML Analysis]
-        SIEM[SIEM Integration]
-    end
-
-    A1 --> KP
-    A2 --> KP
-    A3 --> KP
-    A4 --> KP
-
-    KP --> Verifier
-    Verifier -->|Safe| BPF
-    BPF --> Maps
-
-    Loader -->|Load Program| Verifier
-    Maps -->|Poll Events| Monitor
-    Monitor --> AI
-    AI --> SIEM
-
-    classDef bpfStyle fill:#ff9800,color:#000
-    classDef aiStyle fill:#9c27b0,color:#fff
-    classDef siemStyle fill:#4caf50,color:#fff
-    class BPF bpfStyle
-    class AI aiStyle
-    class SIEM siemStyle
-```
+<figure class="arch-fig">
+<div class="arch is-stack" aria-label="eBPF security monitoring architecture">
+  <section class="arch-tier" data-label="Attack Surface"><span class="arch-chip">Process Execution</span><span class="arch-chip">Network Connections</span><span class="arch-chip">File Operations</span><span class="arch-chip">Privilege Changes</span></section>
+  <section class="arch-tier" data-label="Kernel Space"><span class="arch-chip">Kernel Probes</span><span class="arch-chip is-primary">eBPF VM</span><span class="arch-chip">BPF Maps</span><span class="arch-chip is-guard">BPF Verifier</span></section>
+  <section class="arch-tier" data-label="User Space"><span class="arch-chip">BPF Loader</span><span class="arch-chip">Event Monitor</span><span class="arch-chip is-primary">AI/ML Analysis</span><span class="arch-chip is-primary">SIEM Integration</span></section>
+</div>
+<figcaption>Kernel probes collect activity, the verifier gates safe eBPF execution, and user-space monitors poll maps for analysis and SIEM delivery.</figcaption>
+</figure>
 
 ## Why Traditional Monitoring Falls Short
 
@@ -76,36 +42,24 @@ Let me share a story from my research lab. I once set up a honeypot with traditi
 
 With eBPF monitoring on an identical honeypot, the same attack was detected in 1.3 seconds. Here's what makes the difference:
 
-```mermaid
-flowchart LR
-    subgraph traditionalmonitoring["Traditional Monitoring"]
-        T1[Application Logs]
-        T2[System Logs]
-        T3[Network Logs]
-        T4[SIEM Aggregation]
-        T5[Alert Generation]
-
-        T1 -->|Delayed| T4
-        T2 -->|Can be tampered| T4
-        T3 -->|After the fact| T4
-        T4 -->|Minutes to hours| T5
-    end
-    subgraph ebpfmonitoring["eBPF Monitoring"]
-        E1[Kernel Events]
-        E2[Real-time Processing]
-        E3[In-kernel Filtering]
-        E4[Instant Detection]
-
-        E1 -->|Nanoseconds| E2
-        E2 -->|Microseconds| E3
-        E3 -->|Milliseconds| E4
-    end
-
-    classDef traditionalStyle fill:#f44336,color:#fff
-    classDef ebpfStyle fill:#4caf50,color:#fff
-    class T5 traditionalStyle
-    class E4 ebpfStyle
-```
+<figure>
+<div class="flow" aria-label="Traditional monitoring latency path">
+  <div class="flow-parallel">
+    <div class="flow-node"><b>Application Logs</b><i>Delayed</i></div>
+    <div class="flow-node"><b>System Logs</b><i>Can be tampered</i></div>
+    <div class="flow-node"><b>Network Logs</b><i>After the fact</i></div>
+  </div>
+  <div class="flow-node">SIEM Aggregation</div>
+  <div class="flow-node is-bad"><b>Alert Generation</b><i>Minutes to hours</i></div>
+</div>
+<div class="flow" aria-label="eBPF monitoring latency path">
+  <div class="flow-node"><b>Kernel Events</b><i>Nanoseconds</i></div>
+  <div class="flow-node"><b>Real-time Processing</b><i>Microseconds</i></div>
+  <div class="flow-node"><b>In-kernel Filtering</b><i>Milliseconds</i></div>
+  <div class="flow-node is-good">Instant Detection</div>
+</div>
+<figcaption>Traditional monitoring waits for logs to aggregate; eBPF starts at kernel events and filters before user-space alerting.</figcaption>
+</figure>
 
 ## Real-World Detection Patterns
 

--- a/src/posts/2025-07-15-vulnerability-management-scale-open-source.md
+++ b/src/posts/2025-07-15-vulnerability-management-scale-open-source.md
@@ -40,55 +40,15 @@ Open source vulnerability management can match enterprise capabilities at zero l
 
 Modern vulnerability management requires defense-in-depth strategies. Learn more about [implementing zero-trust architecture](/posts/2024-07-09-zero-trust-architecture-implementation) to complement vulnerability scanning with access controls.
 
-```mermaid
-flowchart TB
-    subgraph datacollection["Data Collection"]
-        NVD[NVD Database]
-        CVE[CVE/MITRE]
-        GitHub[GitHub Advisory]
-        OSV[OSV Database]
-    end
-    subgraph processingpipeline["Processing Pipeline"]
-        Collect[Data Collector]
-        Parse[CVE Parser]
-        Enrich[Data Enricher]
-        Score[Risk Scorer]
-    end
-    subgraph storageanalysis["Storage & Analysis"]
-        DB[(PostgreSQL)]
-        Cache[(Redis Cache)]
-        ML[ML Analysis]
-    end
-    subgraph output["Output"]
-        API[REST API]
-        Dashboard[Dashboard]
-        Alerts[Alert System]
-    end
-
-    NVD --> Collect
-    CVE --> Collect
-    GitHub --> Collect
-    OSV --> Collect
-
-    Collect --> Parse
-    Parse --> Enrich
-    Enrich --> Score
-
-    Score --> DB
-    Score --> Cache
-    DB --> ML
-
-    ML --> API
-    ML --> Dashboard
-    ML --> Alerts
-
-    classDef green fill:#4caf50,color:#fff,stroke:#2e7d32,stroke-width:2px
-    classDef orange fill:#ff9800,color:#000,stroke:#e65100,stroke-width:2px
-    classDef red fill:#f44336,color:#fff,stroke:#c62828,stroke-width:2px
-    class Collect green
-    class Score orange
-    class Alerts red
-```
+<figure class="arch-fig">
+<div class="arch is-stack" aria-label="Open source vulnerability management pipeline architecture">
+  <section class="arch-tier" data-label="Data Collection"><span class="arch-chip">NVD Database</span><span class="arch-chip">CVE/MITRE</span><span class="arch-chip">GitHub Advisory</span><span class="arch-chip">OSV Database</span></section>
+  <section class="arch-tier" data-label="Processing Pipeline"><span class="arch-chip is-primary">Data Collector</span><span class="arch-chip">CVE Parser</span><span class="arch-chip">Data Enricher</span><span class="arch-chip is-warn">Risk Scorer</span></section>
+  <section class="arch-tier" data-label="Storage &amp; Analysis"><span class="arch-chip">PostgreSQL</span><span class="arch-chip">Redis Cache</span><span class="arch-chip">ML Analysis</span></section>
+  <section class="arch-tier" data-label="Output"><span class="arch-chip">REST API</span><span class="arch-chip">Dashboard</span><span class="arch-chip is-bad">Alert System</span></section>
+</div>
+<figcaption>Advisory feeds move through collection, parsing, enrichment, and scoring before storage-backed analysis drives APIs, dashboards, and alerts.</figcaption>
+</figure>
 
 
 

--- a/src/posts/2025-07-22-supercharging-claude-cli-with-standards.md
+++ b/src/posts/2025-07-22-supercharging-claude-cli-with-standards.md
@@ -37,23 +37,10 @@ The humbling part? I discovered I'd been consistently making the same mistake wi
 
 The following diagram illustrates the core problem and solution: instead of repeating context in every session, standards are loaded once and referenced efficiently.
 
-```mermaid
-flowchart LR
-    subgraph Before["Before: Manual Context"]
-        U1["Developer"] -- "Paste standards\n(5000+ tokens)" --> C1["Claude CLI"]
-        U1 -- "Re-explain style\nevery session" --> C1
-        U1 -- "Copy-paste\nrequirements" --> C1
-    end
-
-    subgraph After["After: Standards Repository"]
-        U2["Developer"] -- "@load [CS:python]\n(~100 tokens)" --> CLAUDE_MD["CLAUDE.md<br/>Router"]
-        CLAUDE_MD --> STD["Standards Repo"]
-        STD -- "Auto-load relevant\nstandards" --> C2["Claude CLI"]
-    end
-
-    style Before fill:#ffcccc,color:#000
-    style After fill:#ccffcc,color:#000
-```
+| Mode | Developer action | Context path | Token shape |
+|---|---|---|---|
+| Before: Manual Context | Paste standards; re-explain style every session; copy-paste requirements | Developer to Claude CLI | 5000+ tokens |
+| After: Standards Repository | `@load [CS:python]` | Developer to `CLAUDE.md` router to standards repo to Claude CLI | ~100-token reference, with relevant standards auto-loaded |
 
 ## Enter the Standards Repository
 

--- a/src/posts/2025-07-29-building-mcp-standards-server.md
+++ b/src/posts/2025-07-29-building-mcp-standards-server.md
@@ -127,43 +127,12 @@ I may have overdone it.
 
 The architecture grew from a simple pipe to a multi-layered system across four versions:
 
-```mermaid
-flowchart TD
-    subgraph V1["Version 1: Simple (200 lines)"]
-        STDIO1["stdio in/out"] --> LOAD1["Load Standards"]
-        LOAD1 --> RETURN1["Return to Claude"]
-    end
-
-    subgraph V2["Version 2: + Redis (1,200 lines)"]
-        STDIO2["stdio"] --> REDIS["Redis L1/L2 Cache"]
-        REDIS --> LOAD2["Load Standards"]
-        LOAD2 --> RETURN2["Return"]
-    end
-
-    subgraph V3["Version 3: + Vector Search (3,800 lines)"]
-        STDIO3["stdio"] --> REDIS3["Redis Cache"]
-        STDIO3 --> CHROMA["ChromaDB<br/>Vector Search"]
-        REDIS3 --> LOAD3["Standards"]
-        CHROMA --> LOAD3
-    end
-
-    subgraph V4["Version 4: Kitchen Sink (6,000+ lines)"]
-        STDIO4["stdio / HTTP / WebSocket"]
-        STDIO4 --> REDIS4["Redis Cache"]
-        STDIO4 --> CHROMA4["ChromaDB"]
-        STDIO4 --> RULE["Rule Engine"]
-        STDIO4 --> ANALYZE["6 Language Analyzers"]
-        STDIO4 --> NIST["NIST Compliance"]
-        STDIO4 --> UI["React Web UI"]
-    end
-
-    V1 -.->|"Week 1→2"| V2
-    V2 -.->|"Week 2→3"| V3
-    V3 -.->|"Week 3→4"| V4
-
-    style V1 fill:#27ae60,color:#fff
-    style V4 fill:#e74c3c,color:#fff
-```
+<div class="flow" aria-label="MCP standards server architecture evolution">
+  <div class="flow-node"><b>Version 1: Simple</b><i>stdio in/out, load standards, return to Claude; 200 lines</i></div>
+  <div class="flow-node"><b>Version 2: + Redis</b><i>stdio, Redis L1/L2 cache, load standards, return; 1,200 lines</i></div>
+  <div class="flow-node"><b>Version 3: + Vector Search</b><i>stdio, Redis cache, ChromaDB vector search, standards; 3,800 lines</i></div>
+  <div class="flow-node is-bad"><b>Version 4: Kitchen Sink</b><i>stdio / HTTP / WebSocket, Redis, ChromaDB, rule engine, analyzers, NIST compliance, React web UI; 6,000+ lines</i></div>
+</div>
 
 ## What Actually Works (The Good Parts)
 
@@ -213,32 +182,14 @@ mcp-standards validate src/ --language auto
 
 The following diagram shows how the MCP server registers and exposes tools to the LLM client:
 
-```mermaid
-flowchart LR
-    subgraph Server["MCP Standards Server"]
-        REG["Tool Registry"]
-        REG --> T1["get_standard<br/>Retrieve by name"]
-        REG --> T2["search_standards<br/>Semantic + keyword"]
-        REG --> T3["validate_code<br/>Multi-language lint"]
-        REG --> T4["check_compliance<br/>NIST 800-53r5"]
-        REG --> T5["list_standards<br/>Discovery"]
-    end
-
-    subgraph Client["Claude CLI / Desktop"]
-        LLM["LLM"] -- "tools/list" --> REG
-        LLM -- "tools/call" --> T1
-        LLM -- "tools/call" --> T3
-    end
-
-    subgraph Transport["Transport Layer"]
-        STDIO["stdio (local)"]
-        HTTP["HTTP/SSE (remote)"]
-    end
-
-    Client <--> Transport <--> Server
-
-    style REG fill:#3498db,color:#fff
-```
+<figure class="arch-fig">
+<div class="arch is-stack" aria-label="MCP standards server tool exposure architecture">
+  <section class="arch-tier" data-label="Client"><span class="arch-chip is-primary">Claude CLI / Desktop LLM</span><span class="arch-chip">tools/list</span><span class="arch-chip">tools/call</span></section>
+  <section class="arch-tier" data-label="Transport Layer"><span class="arch-chip">stdio (local)</span><span class="arch-chip">HTTP/SSE (remote)</span></section>
+  <section class="arch-tier" data-label="MCP Standards Server"><span class="arch-chip is-primary">Tool Registry</span><span class="arch-chip"><b>get_standard</b><i>retrieve by name</i></span><span class="arch-chip"><b>search_standards</b><i>semantic + keyword</i></span><span class="arch-chip"><b>validate_code</b><i>multi-language lint</i></span><span class="arch-chip"><b>check_compliance</b><i>NIST 800-53r5</i></span><span class="arch-chip"><b>list_standards</b><i>discovery</i></span></section>
+</div>
+<figcaption>The client discovers and calls tools through the transport layer; the server registry owns the exposed standards operations.</figcaption>
+</figure>
 
 ### Token Optimization That Actually Matters
 
@@ -262,30 +213,25 @@ standard = get_standard("react-patterns", format="compressed")
 
 ## The Struggles (Learning Moments)
 
-```mermaid
-flowchart TD
-    subgraph Caching["Redis L1/L2 Caching Strategy"]
-        REQ["Incoming Request"] --> L1{"L1 Cache<br/>(In-Memory)"}
-        L1 -->|Hit| RET1["Return Cached"]
-        L1 -->|Miss| L2{"L2 Cache<br/>(Redis)"}
-        L2 -->|Hit| PROMOTE["Promote to L1"] --> RET2["Return Cached"]
-        L2 -->|Miss| LOAD["Load from Disk"]
-        LOAD --> STORE["Store in L1 + L2<br/>(30-min TTL)"]
-        STORE --> RET3["Return Fresh"]
-    end
-
-    subgraph Eviction["Eviction Policy"]
-        TTL["30-min TTL expiry"]
-        LRU["LRU when maxmemory hit<br/>(64MB limit)"]
-        MANUAL["Manual invalidation<br/>on standards update"]
-    end
-
-    Caching ~~~ Eviction
-
-    style L1 fill:#3498db,color:#fff
-    style L2 fill:#e67e22,color:#fff
-    style LOAD fill:#27ae60,color:#fff
-```
+<figure class="arch-fig">
+<div class="flow" aria-label="Redis L1 and L2 cache lookup path">
+  <div class="flow-node">Incoming Request</div>
+  <div class="flow-node is-gate"><b>L1 Cache</b><i>in-memory</i></div>
+  <div class="flow-branch">
+    <div class="flow-leg" data-branch="Hit"><div class="flow-node is-good">Return Cached</div></div>
+    <div class="flow-leg" data-branch="Miss"><div class="flow-node"><b>L2 Cache</b><i>Redis</i></div></div>
+  </div>
+  <div class="flow-node is-gate">L2 Result</div>
+  <div class="flow-branch">
+    <div class="flow-leg" data-branch="Hit"><div class="flow-node is-good"><b>Promote to L1</b><i>return cached</i></div></div>
+    <div class="flow-leg" data-branch="Miss"><div class="flow-node"><b>Load from Disk</b><i>store in L1 + L2 with 30-min TTL</i></div></div>
+  </div>
+</div>
+<div class="arch" aria-label="Redis cache eviction policy">
+  <section class="arch-tier" data-label="Eviction Policy"><span class="arch-chip is-guard">30-min TTL expiry</span><span class="arch-chip is-guard">LRU when maxmemory hits 64MB</span><span class="arch-chip is-guard">Manual invalidation on standards update</span></section>
+</div>
+<figcaption>The cache path handles request lookup, while the policy view shows the independent eviction controls.</figcaption>
+</figure>
 
 ### Redis Caching Pitfalls
 
@@ -426,34 +372,12 @@ quadrantChart
     "V4: + React UI": [0.90, 0.55]
 ```
 
-```mermaid
-graph LR
-    subgraph Scope["Scope Creep Timeline"]
-        W1["Week 1<br/>200 lines<br/>1 file"] -->|"Add caching"| W2["Week 2<br/>1,200 lines<br/>8 files"]
-        W2 -->|"Add vector search"| W3["Week 3<br/>3,800 lines<br/>23 files"]
-        W3 -->|"Add web UI"| W4["Week 4<br/>6,000+ lines<br/>47 files"]
-    end
-
-    subgraph Value["Actual Value Added"]
-        V1["High"] ~~~ V2["Marginal"]
-        V2 ~~~ V3["Negative"]
-        V3 ~~~ V4["Mixed"]
-    end
-
-    W1 -.- V1
-    W2 -.- V2
-    W3 -.- V3
-    W4 -.- V4
-
-    style W1 fill:#27ae60,color:#fff
-    style W2 fill:#f39c12,color:#fff
-    style W3 fill:#e67e22,color:#fff
-    style W4 fill:#e74c3c,color:#fff
-    style V1 fill:#27ae60,color:#fff
-    style V2 fill:#f39c12,color:#fff
-    style V3 fill:#e74c3c,color:#fff
-    style V4 fill:#e67e22,color:#fff
-```
+| Week | Scope creep timeline | Actual value added |
+|---|---|---|
+| Week 1 | 200 lines, 1 file | High |
+| Week 2 | Add caching; 1,200 lines, 8 files | Marginal |
+| Week 3 | Add vector search; 3,800 lines, 23 files | Negative |
+| Week 4 | Add web UI; 6,000+ lines, 47 files | Mixed |
 
 ### Start Smaller Than You Think
 

--- a/src/posts/2025-08-07-supercharging-development-claude-flow.md
+++ b/src/posts/2025-08-07-supercharging-development-claude-flow.md
@@ -47,49 +47,14 @@ Claude-Flow supports multiple swarm topologies, each optimized for different sce
 
 ## System Architecture Overview
 
-```mermaid
-flowchart TB
-    subgraph swarmtopologies["Swarm Topologies"]
-        Mesh[Mesh - P2P Collaboration]
-        Hier[Hierarchical - Queen/Worker]
-        Ring[Ring - Sequential Pipeline]
-        Star[Star - Centralized Control]
-    end
-    subgraph coreagents["Core Agents"]
-        Orch[🎭 Orchestrator]
-        Research[🔍 Researcher]
-        Arch[🏗️ Architect]
-        Coder[💻 Coder]
-        Tester[🧪 Tester]
-    end
-    subgraph intelligencelayer["Intelligence Layer"]
-        Memory[(💾 Persistent Memory)]
-        Neural[🧠 Neural Training]
-        Pattern[🔄 Pattern Recognition]
-    end
-
-    Mesh --> Orch
-    Hier --> Orch
-    Ring --> Orch
-    Star --> Orch
-
-    Orch --> Research
-    Orch --> Arch
-    Orch --> Coder
-    Orch --> Tester
-
-    Research --> Memory
-    Arch --> Pattern
-    Coder --> Neural
-    Tester --> Memory
-
-    classDef purpleNode fill:#9c27b0,stroke:#fff,stroke-width:2px,color:#fff
-    classDef yellowNode fill:#ffd54f,color:#000,stroke:#333,stroke-width:2px
-    classDef greenNode fill:#4caf50,stroke:#fff,stroke-width:2px,color:#fff
-    class Orch purpleNode
-    class Memory yellowNode
-    class Neural greenNode
-```
+<figure class="arch-fig">
+<div class="arch is-stack" aria-label="Claude-Flow swarm architecture">
+  <section class="arch-tier" data-label="Swarm Topologies"><span class="arch-chip">Mesh - P2P Collaboration</span><span class="arch-chip">Hierarchical - Queen/Worker</span><span class="arch-chip">Ring - Sequential Pipeline</span><span class="arch-chip">Star - Centralized Control</span></section>
+  <section class="arch-tier" data-label="Core Agents"><span class="arch-chip is-primary">🎭 Orchestrator</span><span class="arch-chip">🔍 Researcher</span><span class="arch-chip">🏗️ Architect</span><span class="arch-chip">💻 Coder</span><span class="arch-chip">🧪 Tester</span></section>
+  <section class="arch-tier" data-label="Intelligence Layer"><span class="arch-chip is-guard">💾 Persistent Memory</span><span class="arch-chip is-guard">🧠 Neural Training</span><span class="arch-chip is-guard">🔄 Pattern Recognition</span></section>
+</div>
+<figcaption>Topology choices feed the orchestrator, which coordinates specialized agents and writes learning back into the intelligence layer.</figcaption>
+</figure>
 
 **Swarm Initialization & Agent Spawning Examples:**
 

--- a/src/posts/2025-08-09-ai-cognitive-infrastructure.md
+++ b/src/posts/2025-08-09-ai-cognitive-infrastructure.md
@@ -25,44 +25,30 @@ According to [Giuseppe Riva's groundbreaking research](https://arxiv.org/abs/250
 
 ⚠️ **Warning:** These diagrams illustrate AI cognitive infrastructure concepts for educational analysis. Understanding these systems' influence requires critical evaluation and awareness of algorithmic mediation.
 
-```mermaid
-flowchart TB
-    subgraph traditionalinfrastructure["Traditional Infrastructure"]
-        Roads[Physical Roads]
-        Power[Electricity Grid]
-        Telecom[Telecommunications]
-    end
-    subgraph cognitiveinfrastructure["Cognitive Infrastructure"]
-        AI[AI Systems]
-        ML[Machine Learning]
-        NLP[Natural Language Processing]
-    end
-    subgraph humancognition["Human Cognition"]
-        Memory[Memory]
-        Decision[Decision Making]
-        Analysis[Analysis]
-        Creativity[Creativity]
-    end
-
-    Roads --> Commerce[Enable Commerce]
-    Power --> Industry[Power Industry]
-    Telecom --> Communication[Enable Communication]
-
-    AI --> Memory
-    ML --> Decision
-    NLP --> Analysis
-    AI --> Creativity
-
-    Memory --> Thinking[Augmented Thinking]
-    Decision --> Thinking
-    Analysis --> Thinking
-    Creativity --> Thinking
-
-    classDef aiStyle fill:#e11d48,color:#fff
-    classDef thinkStyle fill:#10b981,color:#fff
-    class AI,ML,NLP aiStyle
-    class Thinking thinkStyle
-```
+<figure class="arch-fig">
+<div class="flow" aria-label="Traditional infrastructure enablement path">
+  <div class="flow-parallel">
+    <div class="flow-node"><b>Physical Roads</b><i>enable commerce</i></div>
+    <div class="flow-node"><b>Electricity Grid</b><i>powers industry</i></div>
+    <div class="flow-node"><b>Telecommunications</b><i>enable communication</i></div>
+  </div>
+</div>
+<div class="flow" aria-label="Cognitive infrastructure mediation path">
+  <div class="flow-parallel">
+    <div class="flow-node">AI Systems</div>
+    <div class="flow-node">Machine Learning</div>
+    <div class="flow-node">Natural Language Processing</div>
+  </div>
+  <div class="flow-parallel">
+    <div class="flow-node">Memory</div>
+    <div class="flow-node">Decision Making</div>
+    <div class="flow-node">Analysis</div>
+    <div class="flow-node">Creativity</div>
+  </div>
+  <div class="flow-node is-good">Augmented Thinking</div>
+</div>
+<figcaption>Traditional infrastructure moves goods, power, and signals; cognitive infrastructure mediates memory, decisions, analysis, and creativity.</figcaption>
+</figure>
 
 **Three mechanisms define cognitive infrastructure:**
 
@@ -107,36 +93,20 @@ The concept of "epistemic agency" (your ability to determine what's true and rel
 
 ⚠️ **Warning:** This diagram demonstrates how AI systems influence information access and decision-making. Users should maintain awareness of algorithmic filtering and actively seek diverse information sources.
 
-```mermaid
-flowchart TD
-    User[User Query/Interest] --> AI{AI Analysis}
-
-    AI --> Filter[Relevance Filtering]
-    AI --> Rank[Priority Ranking]
-    AI --> Personal[Personalization]
-
-    Filter --> Visible[Visible Options]
-    Filter --> Hidden[Hidden Options]
-
-    Rank --> First[First Results]
-    Rank --> Later[Later Results]
-
-    Personal --> Bubble[Filter Bubble]
-    Personal --> Echo[Echo Chamber]
-
-    Visible --> Decision[User Decision]
-    First --> Decision
-    Bubble --> Decision
-
-    Hidden -.->|Never Seen| Void[Lost Possibilities]
-    Later -.->|Rarely Seen| Void
-    Echo -.->|Reinforcement| Decision
-
-    classDef redStyle fill:#ef4444,color:#fff
-    classDef orangeStyle fill:#f59e0b,color:#000
-    class Hidden,Void redStyle
-    class Bubble,Echo orangeStyle
-```
+<div class="flow" aria-label="AI-mediated information access path">
+  <div class="flow-node">User Query/Interest</div>
+  <div class="flow-node is-gate">AI Analysis</div>
+  <div class="flow-parallel">
+    <div class="flow-node"><b>Relevance Filtering</b><i>visible options / hidden options</i></div>
+    <div class="flow-node"><b>Priority Ranking</b><i>first results / later results</i></div>
+    <div class="flow-node"><b>Personalization</b><i>filter bubble / echo chamber</i></div>
+  </div>
+  <div class="flow-branch">
+    <div class="flow-leg" data-branch="Seen"><div class="flow-node is-good">User Decision</div></div>
+    <div class="flow-leg" data-branch="Filtered"><div class="flow-node is-bad"><b>Lost Possibilities</b><i>never seen or rarely seen</i></div></div>
+    <div class="flow-leg" data-branch="Reinforced"><div class="flow-node">Echo Chamber</div></div>
+  </div>
+</div>
 
 This isn't conspiracy. It's architecture. The structure of AI-mediated information access shapes what you can know and think. When AI determines relevance, it's not organizing information. It's organizing thought itself.
 

--- a/src/posts/2025-08-18-docker-lsm-security-hardening.md
+++ b/src/posts/2025-08-18-docker-lsm-security-hardening.md
@@ -37,30 +37,17 @@ FS privilege escalation
 
 **What I needed:** Defense-in-depth without K8s. Standalone Docker hardening using Linux Security Modules (LSM), seccomp, capabilities, and filesystem restrictions.
 
-```mermaid
-graph LR
-    subgraph Container["Docker Container (User Space)"]
-        App[Application Process]
-    end
-
-    App -->|"syscall (e.g., open, mount, ptrace)"| Kernel
-
-    subgraph Kernel["Linux Kernel"]
-        SC[Syscall Entry] --> LSM{LSM Hooks}
-        LSM -->|Denied| BLOCK["EACCES / EPERM\n(Operation Blocked)"]
-        LSM -->|Allowed| SECCOMP{Seccomp BPF}
-        SECCOMP -->|Denied| BLOCK
-        SECCOMP -->|Allowed| CAPS{Capability Check}
-        CAPS -->|Denied| BLOCK
-        CAPS -->|Allowed| EXEC[Execute Syscall]
-    end
-
-    style BLOCK fill:#e74c3c,color:#fff
-    style EXEC fill:#2ecc71,color:#fff
-    style LSM fill:#f39c12,color:#fff
-    style SECCOMP fill:#f39c12,color:#fff
-    style CAPS fill:#f39c12,color:#fff
-```
+<div class="flow" aria-label="Container syscall security checkpoints">
+  <div class="flow-node"><b>Docker Container</b><i>application process in user space</i></div>
+  <div class="flow-node"><b>Syscall Entry</b><i>open, mount, ptrace</i></div>
+  <div class="flow-node is-gate">LSM Hooks</div>
+  <div class="flow-node is-gate">Seccomp BPF</div>
+  <div class="flow-node is-gate">Capability Check</div>
+  <div class="flow-branch">
+    <div class="flow-leg" data-branch="Denied"><div class="flow-node is-bad"><b>EACCES / EPERM</b><i>operation blocked</i></div></div>
+    <div class="flow-leg" data-branch="Allowed"><div class="flow-node is-good">Execute Syscall</div></div>
+  </div>
+</div>
 
 Each syscall from a container passes through multiple security checkpoints in the kernel before execution. An attacker must bypass all layers to succeed.
 
@@ -94,29 +81,10 @@ LSMs enforce Mandatory Access Control (MAC). Unlike Discretionary Access Control
 
 **My choice:** AppArmor for Ubuntu homelab. SELinux superior for production RHEL environments. Both provide strong container isolation.
 
-```mermaid
-graph TB
-    subgraph AppArmor["AppArmor (Path-Based)"]
-        direction TB
-        AA_Proc[Process: nginx] -->|"access /etc/nginx/conf.d"| AA_Policy{"Policy Check:\nPath in allow list?"}
-        AA_Policy -->|"/etc/nginx/** r ✓"| AA_Allow[ALLOW]
-        AA_Policy -->|"/root/.ssh/** ✗"| AA_Deny[DENY]
-    end
-
-    subgraph SELinux["SELinux (Label-Based)"]
-        direction TB
-        SE_Proc["Process: nginx\n(context: container_t)"] -->|"access config file"| SE_Policy{"Policy Check:\nLabel transition allowed?"}
-        SE_Policy -->|"container_t → httpd_config_t ✓"| SE_Allow[ALLOW]
-        SE_Policy -->|"container_t → shadow_t ✗"| SE_Deny[DENY]
-    end
-
-    style AA_Allow fill:#2ecc71,color:#fff
-    style AA_Deny fill:#e74c3c,color:#fff
-    style SE_Allow fill:#2ecc71,color:#fff
-    style SE_Deny fill:#e74c3c,color:#fff
-    style AA_Policy fill:#3498db,color:#fff
-    style SE_Policy fill:#9b59b6,color:#fff
-```
+| Model | Process example | Policy question | Allowed example | Denied example |
+|---|---|---|---|---|
+| AppArmor (Path-Based) | Process: nginx accessing `/etc/nginx/conf.d` | Path in allow list? | `/etc/nginx/** r` | `/root/.ssh/**` |
+| SELinux (Label-Based) | Process: nginx with context `container_t` accessing config file | Label transition allowed? | `container_t` to `httpd_config_t` | `container_t` to `shadow_t` |
 
 AppArmor resolves access by matching file paths against a profile. SELinux resolves access by checking label transitions between the process security context and the target object label.
 
@@ -297,25 +265,10 @@ docker exec nginx reboot
 
 **Seccomp profile library:** https://gist.github.com/williamzujkowski/0ce385a16936a49a09f5e34ec382ef6f
 
-```mermaid
-flowchart LR
-    subgraph Blocklist["Default: Blocklist Approach"]
-        direction TB
-        B_All["All ~330 syscalls\n(ALLOW by default)"] --> B_Filter["Block ~60 known\ndangerous syscalls"]
-        B_Filter --> B_Result["~270 syscalls\nstill permitted"]
-    end
-
-    subgraph Allowlist["Custom: Allowlist Approach"]
-        direction TB
-        A_All["All ~330 syscalls\n(DENY by default)"] --> A_Filter["Allow only ~45\nrequired syscalls"]
-        A_Filter --> A_Result["~285 syscalls\nblocked"]
-    end
-
-    style B_Result fill:#e67e22,color:#fff
-    style A_Result fill:#2ecc71,color:#fff
-    style B_All fill:#e74c3c,color:#fff
-    style A_All fill:#27ae60,color:#fff
-```
+| Approach | Default posture | Filter rule | Result |
+|---|---|---|---|
+| Default: Blocklist Approach | All ~330 syscalls allowed by default | Block ~60 known dangerous syscalls | ~270 syscalls still permitted |
+| Custom: Allowlist Approach | All ~330 syscalls denied by default | Allow only ~45 required syscalls | ~285 syscalls blocked |
 
 The allowlist approach is far more secure: unknown or newly added syscalls are blocked by default, while the blocklist approach must be updated whenever new dangerous syscalls are identified.
 

--- a/src/posts/2025-08-25-network-traffic-analysis-suricata-homelab.md
+++ b/src/posts/2025-08-25-network-traffic-analysis-suricata-homelab.md
@@ -23,59 +23,15 @@ That's the case for Suricata in one line: you can't protect what you can't see. 
 
 ⚠️ **Warning:** Network traffic analysis must comply with privacy laws and organizational policies. Deploy only on networks you own or have explicit authorization to monitor.
 
-```mermaid
-flowchart TB
-    subgraph trafficcollection["Traffic Collection"]
-        Mirror[Port Mirroring]
-        Tap[Network TAP]
-        Span[SPAN Port]
-    end
-    subgraph suricataengine["Suricata Engine"]
-        Capture[Packet Capture]
-        Decode[Protocol Decoder]
-        Detection[Detection Engine]
-        Logger[Event Logger]
-    end
-    subgraph rulemanagement["Rule Management"]
-        Emerging[Emerging Threats]
-        Custom[Custom Rules]
-        ETPRO[ET Pro Rules]
-        Update[Rule Updates]
-    end
-    subgraph analysisresponse["Analysis & Response"]
-        EVE[EVE JSON Logs]
-        Filebeat[Filebeat Shipper]
-        Elastic[Elasticsearch]
-        Kibana[Kibana Dashboard]
-        Wazuh[Wazuh SIEM]
-    end
-
-    Mirror --> Capture
-    Tap --> Capture
-    Span --> Capture
-
-    Capture --> Decode
-    Decode --> Detection
-    Detection --> Logger
-
-    Emerging --> Detection
-    Custom --> Detection
-    ETPRO --> Detection
-    Update --> Detection
-
-    Logger --> EVE
-    EVE --> Filebeat
-    Filebeat --> Elastic
-    Filebeat --> Wazuh
-    Elastic --> Kibana
-
-    classDef criticalStyle fill:#f44336,color:#fff
-    classDef successStyle fill:#4caf50,color:#fff
-    classDef infoStyle fill:#00bcd4,color:#fff
-    class Detection criticalStyle
-    class Elastic successStyle
-    class Kibana infoStyle
-```
+<figure class="arch-fig">
+<div class="arch is-stack" aria-label="Suricata traffic analysis architecture">
+  <section class="arch-tier" data-label="Traffic Collection"><span class="arch-chip">Port Mirroring</span><span class="arch-chip">Network TAP</span><span class="arch-chip">SPAN Port</span></section>
+  <section class="arch-tier" data-label="Rule Management"><span class="arch-chip is-guard">Emerging Threats</span><span class="arch-chip is-guard">Custom Rules</span><span class="arch-chip is-guard">ET Pro Rules</span><span class="arch-chip is-guard">Rule Updates</span></section>
+  <section class="arch-tier" data-label="Suricata Engine"><span class="arch-chip">Packet Capture</span><span class="arch-chip">Protocol Decoder</span><span class="arch-chip is-primary">Detection Engine</span><span class="arch-chip">Event Logger</span></section>
+  <section class="arch-tier" data-label="Analysis &amp; Response"><span class="arch-chip">EVE JSON Logs</span><span class="arch-chip">Filebeat Shipper</span><span class="arch-chip">Elasticsearch</span><span class="arch-chip">Kibana Dashboard</span><span class="arch-chip">Wazuh SIEM</span></section>
+</div>
+<figcaption>Traffic collection feeds Suricata, rule sources shape detection, and EVE logs move into search, dashboards, and SIEM response.</figcaption>
+</figure>
 
 Building my network traffic analysis lab with Suricata turned my homelab from a black box into something that actually admits what it's been doing at 3 AM. Here's how I did it.
 

--- a/src/posts/2025-09-08-zero-trust-vlan-segmentation-homelab.md
+++ b/src/posts/2025-09-08-zero-trust-vlan-segmentation-homelab.md
@@ -22,60 +22,18 @@ All because I put it on the same network as my trusted devices. That camera is n
 
 ## Zero Trust Network Architecture
 
-```mermaid
-flowchart TB
-    subgraph internetedge["Internet Edge"]
-        WAN[WAN Connection]
-        UDM[Dream Machine Pro]
-    end
-    subgraph managementvlan10["Management VLAN 10"]
-        Admin[Admin Devices]
-        Proxmox[Proxmox Host]
-        Switches[Network Switches]
-    end
-    subgraph trustedvlan20["Trusted VLAN 20"]
-        Workstation[Workstations]
-        Laptops[Laptops]
-        Phones[Personal Phones]
-    end
-    subgraph servervlan30["Server VLAN 30"]
-        Web[Web Servers]
-        DB[Databases]
-        Apps[Applications]
-    end
-    subgraph iotvlan40["IoT VLAN 40"]
-        Camera[IP Cameras]
-        Smart[Smart Devices]
-        Sensors[IoT Sensors]
-    end
-    subgraph guestvlan50["Guest VLAN 50"]
-        GuestDevices[Guest Devices]
-    end
-    subgraph securityservices["Security Services"]
-        Firewall[Firewall Rules]
-        IDS[Suricata IDS]
-        DNS[Pi-hole DNS]
-    end
-
-    WAN --> UDM
-    UDM --> Firewall
-
-    Firewall --> Admin
-    Firewall --> Workstation
-    Firewall --> Web
-    Firewall --> Camera
-    Firewall --> GuestDevices
-
-    Firewall --> IDS
-    Firewall --> DNS
-
-    classDef redNode fill:#f44336,color:#fff
-    classDef orangeNode fill:#ff9800,color:#fff
-    classDef deepOrangeNode fill:#ff5722,color:#fff
-    class Firewall redNode
-    class Camera,Smart,Sensors orangeNode
-    class GuestDevices deepOrangeNode
-```
+<figure class="arch-fig">
+<div class="arch" aria-label="Zero trust VLAN segmentation zones">
+  <section class="arch-tier" data-label="Internet Edge"><span class="arch-chip">WAN Connection</span><span class="arch-chip is-primary">Dream Machine Pro</span></section>
+  <section class="arch-tier" data-label="Management VLAN 10"><span class="arch-chip is-guard">Admin Devices</span><span class="arch-chip">Proxmox Host</span><span class="arch-chip">Network Switches</span></section>
+  <section class="arch-tier" data-label="Trusted VLAN 20"><span class="arch-chip">Workstations</span><span class="arch-chip">Laptops</span><span class="arch-chip">Personal Phones</span></section>
+  <section class="arch-tier" data-label="Server VLAN 30"><span class="arch-chip">Web Servers</span><span class="arch-chip">Databases</span><span class="arch-chip">Applications</span></section>
+  <section class="arch-tier" data-label="IoT VLAN 40"><span class="arch-chip is-warn">IP Cameras</span><span class="arch-chip is-warn">Smart Devices</span><span class="arch-chip is-warn">IoT Sensors</span></section>
+  <section class="arch-tier" data-label="Guest VLAN 50"><span class="arch-chip is-bad">Guest Devices</span></section>
+  <section class="arch-tier" data-label="Security Services"><span class="arch-chip is-guard">Firewall Rules</span><span class="arch-chip is-guard">Suricata IDS</span><span class="arch-chip is-guard">Pi-hole DNS</span></section>
+</div>
+<figcaption>The firewall mediates traffic between peer VLAN zones, with IDS and DNS controls attached as shared security services.</figcaption>
+</figure>
 
 ## VLAN Design Philosophy
 

--- a/src/posts/2025-09-20-iot-security-homelab-owasp.md
+++ b/src/posts/2025-09-20-iot-security-homelab-owasp.md
@@ -33,18 +33,16 @@ Before diving into vulnerabilities, let's set up a proper isolated environment. 
 
 Here's my home lab IoT security setup using VLANs and a dedicated analysis subnet. I moved all IoT devices to a separate VLAN (192.168.50.0/24) with firewall rules blocking LAN access. My Nest thermostat immediately stopped working until I allowed specific port 443 traffic to Google servers. The **trade-off**: security versus convenience. You gain isolation **but** lose easy device-to-device communication. For a complete approach to this architecture, see my guide on [building a security-focused homelab](/posts/2025-04-24-building-secure-homelab-adventure).
 
-```mermaid
-flowchart TD
-    A[Main Network<br/>VLAN 10] -->|Firewall| F[pfSense/OPNsense]
-    B[IoT Production<br/>VLAN 20] -->|Isolated| F
-    C[IoT Testing<br/>VLAN 666] -->|No Internet| F
-    D[Analysis VM<br/>VLAN 30] -->|Monitor Only| F
-    C --> E[IoTGoat Device]
-    C --> G[Packet Capture]
-    D --> H[Burp Suite]
-    D --> I[Wireshark]
-    D --> J[MQTT Explorer]
-```
+<figure class="arch-fig">
+<div class="arch" aria-label="IoT security lab network zones">
+  <section class="arch-tier" data-label="Firewall"><span class="arch-chip is-primary">pfSense/OPNsense</span></section>
+  <section class="arch-tier" data-label="Main Network VLAN 10"><span class="arch-chip">Main Network</span></section>
+  <section class="arch-tier" data-label="IoT Production VLAN 20"><span class="arch-chip is-guard">Isolated</span></section>
+  <section class="arch-tier" data-label="IoT Testing VLAN 666"><span class="arch-chip is-bad">No Internet</span><span class="arch-chip">IoTGoat Device</span><span class="arch-chip">Packet Capture</span></section>
+  <section class="arch-tier" data-label="Analysis VM VLAN 30"><span class="arch-chip is-guard">Monitor Only</span><span class="arch-chip">Burp Suite</span><span class="arch-chip">Wireshark</span><span class="arch-chip">MQTT Explorer</span></section>
+</div>
+<figcaption>The firewall separates the main network, production IoT, vulnerable testing devices, and analysis tooling into peer zones.</figcaption>
+</figure>
 
 ### Essential Tools Setup
 
@@ -208,4 +206,3 @@ Remember: in IoT security, paranoia is just good planning. Or maybe it's overkil
 2. **[IoT Security Foundation Best Practice Guidelines](https://www.iotsecurityfoundation.org/best-practice-guidelines/)** (2024)
    - IoT Security Foundation
    - *Industry Security Standards*
-

--- a/src/posts/2025-09-20-vulnerability-prioritization-epss-kev.md
+++ b/src/posts/2025-09-20-vulnerability-prioritization-epss-kev.md
@@ -73,16 +73,20 @@ Let me walk through creating a practical system that combines these data sources
 
 ⚠️ **Warning:** This architecture integrates multiple external APIs (NVD, EPSS, CISA KEV). Implement proper authentication, rate limiting, and error handling for production deployments.
 
-```mermaid
-flowchart TD
-    A[NVD API] -->|CVE Details| D[Data Aggregator]
-    B[EPSS API] -->|Probability Scores| D
-    C[CISA KEV] -->|Active Exploitation| D
-    D --> E[Risk Calculator]
-    E --> F[Priority Queue]
-    F --> G[Ticketing System]
-    H[Asset Inventory] -->|Criticality| E
-```
+<div class="flow" aria-label="Vulnerability prioritization data pipeline">
+  <div class="flow-parallel">
+    <div class="flow-node"><b>NVD API</b><i>CVE details</i></div>
+    <div class="flow-node"><b>EPSS API</b><i>probability scores</i></div>
+    <div class="flow-node"><b>CISA KEV</b><i>active exploitation</i></div>
+  </div>
+  <div class="flow-node">Data Aggregator</div>
+  <div class="flow-parallel">
+    <div class="flow-node">Risk Calculator</div>
+    <div class="flow-node"><b>Asset Inventory</b><i>criticality</i></div>
+  </div>
+  <div class="flow-node">Priority Queue</div>
+  <div class="flow-node is-good">Ticketing System</div>
+</div>
 
 ### Setting Up Data Collection
 

--- a/src/posts/2025-09-29-proxmox-high-availability-homelab.md
+++ b/src/posts/2025-09-29-proxmox-high-availability-homelab.md
@@ -23,63 +23,16 @@ This incident became a driving force behind [building a security-focused homelab
 
 ## High Availability Architecture
 
-```mermaid
-flowchart TB
-    subgraph clusternodes["Cluster Nodes"]
-        Node1[Proxmox Node 1<br/>Dell R910]
-        Node2[Proxmox Node 2<br/>Dell R730]
-        Node3[Proxmox Node 3<br/>Custom Build]
-    end
-    subgraph sharedstorage["Shared Storage"]
-        Ceph[(Ceph Cluster<br/>Distributed Storage)]
-    end
-    subgraph networkinfrastructure["Network Infrastructure"]
-        Switch1[10Gb Switch<br/>Primary]
-        Switch2[1Gb Switch<br/>Management]
-    end
-    subgraph haservices["HA Services"]
-        Corosync[Corosync<br/>Cluster Communication]
-        PVE[PVE HA Manager<br/>Failover Orchestration]
-        Fencing[Fencing Agent<br/>Split-Brain Prevention]
-    end
-    subgraph vmswithha["VMs with HA"]
-        DNS[Pi-hole DNS]
-        Vault[Bitwarden]
-        Monitor[Wazuh SIEM]
-        Web[Web Services]
-    end
-
-    Node1 --> Ceph
-    Node2 --> Ceph
-    Node3 --> Ceph
-
-    Node1 --> Switch1
-    Node2 --> Switch1
-    Node3 --> Switch1
-
-    Node1 --> Switch2
-    Node2 --> Switch2
-    Node3 --> Switch2
-
-    Corosync --> Node1
-    Corosync --> Node2
-    Corosync --> Node3
-
-    PVE --> Corosync
-    Fencing --> PVE
-
-    Ceph --> DNS
-    Ceph --> Vault
-    Ceph --> Monitor
-    Ceph --> Web
-
-    classDef greenNode fill:#4caf50,color:#fff
-    classDef blueNode fill:#2196f3,color:#fff
-    classDef redNode fill:#f44336,color:#fff
-    class Ceph greenNode
-    class Corosync blueNode
-    class Fencing redNode
-```
+<figure class="arch-fig">
+<div class="arch" aria-label="Proxmox high availability homelab architecture">
+  <section class="arch-tier" data-label="Cluster Nodes"><span class="arch-chip"><b>Proxmox Node 1</b><i>Dell R910</i></span><span class="arch-chip"><b>Proxmox Node 2</b><i>Dell R730</i></span><span class="arch-chip"><b>Proxmox Node 3</b><i>Custom Build</i></span></section>
+  <section class="arch-tier" data-label="Shared Storage"><span class="arch-chip is-primary"><b>Ceph Cluster</b><i>distributed storage</i></span></section>
+  <section class="arch-tier" data-label="Network Infrastructure"><span class="arch-chip"><b>10Gb Switch</b><i>primary</i></span><span class="arch-chip"><b>1Gb Switch</b><i>management</i></span></section>
+  <section class="arch-tier" data-label="HA Services"><span class="arch-chip is-guard"><b>Corosync</b><i>cluster communication</i></span><span class="arch-chip is-primary"><b>PVE HA Manager</b><i>failover orchestration</i></span><span class="arch-chip is-bad"><b>Fencing Agent</b><i>split-brain prevention</i></span></section>
+  <section class="arch-tier" data-label="VMs with HA"><span class="arch-chip">Pi-hole DNS</span><span class="arch-chip">Bitwarden</span><span class="arch-chip">Wazuh SIEM</span><span class="arch-chip">Web Services</span></section>
+</div>
+<figcaption>Cluster nodes share storage and network fabric while HA services coordinate failover for the protected VMs.</figcaption>
+</figure>
 
 ## Planning Your HA Cluster
 

--- a/src/posts/2025-10-06-automated-security-scanning-pipeline.md
+++ b/src/posts/2025-10-06-automated-security-scanning-pipeline.md
@@ -25,65 +25,32 @@ I built an automated security pipeline that scans every commit with Grype, OSV-S
 
 ⚠️ **Warning:** Security scanning pipelines must be configured with appropriate policies and approval gates. Automated remediation should include review processes for production environments.
 
-```mermaid
-flowchart TB
-    subgraph coderepository["Code Repository"]
-        Git[Git Push]
-        PR[Pull Request]
-    end
-    subgraph cicdpipeline["CI/CD Pipeline"]
-        Trigger[GitHub Actions Trigger]
-        Build[Build Stage]
-        Test[Test Stage]
-        Scan[Security Scan Stage]
-    end
-    subgraph securitytools["Security Tools"]
-        Grype[Grype<br/>Container Scanning]
-        OSV[OSV-Scanner<br/>Dependency Scanning]
-        Trivy[Trivy<br/>Multi-Scanner]
-    end
-    subgraph analysisreporting["Analysis & Reporting"]
-        SARIF[SARIF Reports]
-        GH[GitHub Security]
-        Slack[Slack Alerts]
-        Wazuh[Wazuh SIEM]
-    end
-    subgraph policyenforcement["Policy Enforcement"]
-        Gates[Quality Gates]
-        Block[Block on Critical]
-        Approve[Manual Review]
-    end
-
-    Git --> Trigger
-    PR --> Trigger
-
-    Trigger --> Build
-    Build --> Test
-    Test --> Scan
-
-    Scan --> Grype
-    Scan --> OSV
-    Scan --> Trivy
-
-    Grype --> SARIF
-    OSV --> SARIF
-    Trivy --> SARIF
-
-    SARIF --> GH
-    SARIF --> Slack
-    SARIF --> Wazuh
-
-    SARIF --> Gates
-    Gates --> Block
-    Gates --> Approve
-
-    classDef redNode fill:#f44336,color:#fff
-    classDef orangeNode fill:#ff9800,color:#fff
-    classDef darkRedNode fill:#d32f2f,color:#fff
-    class Scan redNode
-    class Gates orangeNode
-    class Block darkRedNode
-```
+<div class="flow" aria-label="Automated security scanning pipeline">
+  <div class="flow-parallel">
+    <div class="flow-node">Git Push</div>
+    <div class="flow-node">Pull Request</div>
+  </div>
+  <div class="flow-node">GitHub Actions Trigger</div>
+  <div class="flow-node">Build Stage</div>
+  <div class="flow-node">Test Stage</div>
+  <div class="flow-node is-gate">Security Scan Stage</div>
+  <div class="flow-parallel">
+    <div class="flow-node"><b>Grype</b><i>container scanning</i></div>
+    <div class="flow-node"><b>OSV-Scanner</b><i>dependency scanning</i></div>
+    <div class="flow-node"><b>Trivy</b><i>multi-scanner</i></div>
+  </div>
+  <div class="flow-node">SARIF Reports</div>
+  <div class="flow-parallel">
+    <div class="flow-node">GitHub Security</div>
+    <div class="flow-node">Slack Alerts</div>
+    <div class="flow-node">Wazuh SIEM</div>
+  </div>
+  <div class="flow-node is-gate">Quality Gates</div>
+  <div class="flow-branch">
+    <div class="flow-leg" data-branch="Critical"><div class="flow-node is-bad">Block on Critical</div></div>
+    <div class="flow-leg" data-branch="Review"><div class="flow-node">Manual Review</div></div>
+  </div>
+</div>
 
 Today, every commit to my repositories is automatically scanned for vulnerabilities. Critical findings block deployment. Here's how I built it.
 

--- a/src/posts/2025-10-13-embodied-ai-robots-physical-world.md
+++ b/src/posts/2025-10-13-embodied-ai-robots-physical-world.md
@@ -32,26 +32,23 @@ That gap is closing. VLA models combine three capabilities:
 - **Language**: Processing natural language instructions and context
 - **Action**: Generating physical control signals for robotic systems
 
-```mermaid
-flowchart LR
-    subgraph traditionalaiagents["Traditional AI Agents"]
-        A[Text Input] --> B[Language Model]
-        B --> C[Text Output]
-    end
-    subgraph visionlanguageactionmodels["Vision-Language-Action Models"]
-        D[Visual Input] --> E[VLA Model]
-        F[Language Input] --> E
-        E --> G[Physical Actions]
-        G --> H[Robot Control]
-    end
-
-    C -.evolves into.-> E
-
-    classDef highlight1 fill:#e11d48,color:#fff
-    classDef highlight2 fill:#10b981,color:#fff
-    class E highlight1
-    class H highlight2
-```
+<figure class="arch-fig">
+<div class="flow" aria-label="Traditional AI agent path">
+  <div class="flow-node">Text Input</div>
+  <div class="flow-node">Language Model</div>
+  <div class="flow-node">Text Output</div>
+</div>
+<div class="flow" aria-label="Vision-Language-Action model path">
+  <div class="flow-parallel">
+    <div class="flow-node">Visual Input</div>
+    <div class="flow-node">Language Input</div>
+  </div>
+  <div class="flow-node is-gate">VLA Model</div>
+  <div class="flow-node">Physical Actions</div>
+  <div class="flow-node is-good">Robot Control</div>
+</div>
+<figcaption>Traditional agents end at text output; VLA systems add perception and language inputs that become robot control.</figcaption>
+</figure>
 
 The breakthrough: direct mapping from perception and language to low-level robotic control. Traditional robotics required extensive programming for each task. VLA models learn generalizable manipulation skills from demonstration data.
 
@@ -141,29 +138,15 @@ Formal safety frameworks for robotics exist, but most VLA deployments lack rigor
 
 ⚠️ **Warning:** Embodied AI systems that interact with the physical world require extensive safety testing. Physical robotics experiments must follow proper safety protocols and risk assessments.
 
-```mermaid
-flowchart TB
-    subgraph safetylayers["Safety Layers"]
-        A[VLA Model] --> B[Action Filter]
-        B --> C[Collision Detection]
-        C --> D[Force Limits]
-        D --> E[Emergency Stop]
-        E --> F[Physical Robot]
-    end
-
-    G[Safety Monitor] --> B
-    G --> C
-    G --> D
-
-    H[Human Supervisor] --> E
-
-    classDef highlight1 fill:#3b82f6,color:#fff
-    classDef highlight2 fill:#ef4444,color:#fff
-    classDef highlight3 fill:#f59e0b,color:#000
-    class A highlight1
-    class E highlight2
-    class G highlight3
-```
+<figure class="arch-fig">
+<div class="arch is-stack" aria-label="Embodied AI safety layers">
+  <section class="arch-tier" data-label="Model"><span class="arch-chip is-primary">VLA Model</span></section>
+  <section class="arch-tier" data-label="Runtime Guards"><span class="arch-chip is-guard">Action Filter</span><span class="arch-chip is-guard">Collision Detection</span><span class="arch-chip is-guard">Force Limits</span><span class="arch-chip is-warn">Safety Monitor</span></section>
+  <section class="arch-tier" data-label="Stop Controls"><span class="arch-chip is-bad">Emergency Stop</span><span class="arch-chip is-guard">Human Supervisor</span></section>
+  <section class="arch-tier" data-label="Actuator"><span class="arch-chip">Physical Robot</span></section>
+</div>
+<figcaption>Model output passes through runtime guards and stop controls before it can move the physical robot.</figcaption>
+</figure>
 
 **Required safety layers:**
 

--- a/src/posts/2025-10-17-progressive-context-loading-llm-workflows.md
+++ b/src/posts/2025-10-17-progressive-context-loading-llm-workflows.md
@@ -34,25 +34,10 @@ Traditional LLM workflows suffer from "context obesity": stuffing every possible
 
 ⚠️ **Warning:** This diagram illustrates LLM context loading strategies for educational purposes. Implement proper security controls and access restrictions when deploying progressive loading systems in production environments.
 
-```mermaid
-flowchart TD
-    A[Context Loading Strategy] --> B[Monolithic Load]
-    A --> C[Progressive Load]
-
-    B --> D[Pros: Complete info upfront]
-    B --> E[Cons: 150K tokens, slow, expensive]
-
-    C --> F[Pros: 2K initial, fast, cheap]
-    C --> G[Cons: Must predict needs]
-
-    E --> H[99% unused context]
-    G --> I[98% accuracy in prediction]
-
-    classDef monolithicStyle fill:#ff6b6b,color:#fff
-    classDef progressiveStyle fill:#51cf66,color:#000
-    class E monolithicStyle
-    class G progressiveStyle
-```
+| Context loading strategy | Pros | Cons | Outcome |
+|---|---|---|---|
+| Monolithic Load | Complete info upfront | 150K tokens, slow, expensive | 99% unused context |
+| Progressive Load | 2K initial, fast, cheap | Must predict needs | 98% accuracy in prediction |
 
 **My homelab challenge**:
 - Enforce coding standards across 47 file types
@@ -165,26 +150,19 @@ The design goal: preserve critical context, discard irrelevant information, and 
 
 Task flow:
 
-```mermaid
-flowchart LR
-    A[Task Arrives] --> B{Parse File Types}
-    B --> C[Query Product Matrix]
-    C --> D{Determine Skills}
-    D --> E[Load Primary Skills 2K tokens]
-    E --> F{Task Complete?}
-    F -->|Yes| G[Return Result]
-    F -->|No| H{Need More Context?}
-    H -->|Yes| I[Load Dependencies +3K tokens]
-    I --> F
-    H -->|No| J[Request Clarification]
-
-    classDef primaryStyle fill:#51cf66,color:#000
-    classDef dependencyStyle fill:#ffd93d,color:#000
-    classDef clarificationStyle fill:#6bcfff,color:#000
-    class E primaryStyle
-    class I dependencyStyle
-    class J clarificationStyle
-```
+<div class="flow" aria-label="Dynamic context assembly workflow">
+  <div class="flow-node">Task Arrives</div>
+  <div class="flow-node is-gate">Parse File Types</div>
+  <div class="flow-node">Query Product Matrix</div>
+  <div class="flow-node is-gate">Determine Skills</div>
+  <div class="flow-node is-good"><b>Load Primary Skills</b><i>2K tokens</i></div>
+  <div class="flow-node is-gate">Task Complete?</div>
+  <div class="flow-branch">
+    <div class="flow-leg" data-branch="Yes"><div class="flow-node is-good">Return Result</div></div>
+    <div class="flow-leg" data-branch="Need Context"><div class="flow-node"><b>Load Dependencies</b><i>+3K tokens, then re-check task</i></div></div>
+    <div class="flow-leg" data-branch="No Context"><div class="flow-node">Request Clarification</div></div>
+  </div>
+</div>
 
 **Performance** (measured in my homelab):
 - Simple tasks: 2K tokens

--- a/src/posts/2025-10-29-post-quantum-cryptography-homelab.md
+++ b/src/posts/2025-10-29-post-quantum-cryptography-homelab.md
@@ -36,32 +36,27 @@ According to RAND Corporation's analysis,[^rand-analysis] if your data needs to 
 
 The math is simple and it's called [Mosca's Theorem](https://globalriskinstitute.org/publication/2023-quantum-threat-timeline-report/): If **X** (how long your data must stay secret) + **Y** (how long it takes to migrate) > **Z** (when quantum computers arrive), you're already behind schedule.
 
-```mermaid
-flowchart LR
-    subgraph Mosca["Mosca's Theorem: X + Y > Z = Already Behind"]
-        X["X: Data Secrecy<br/>Requirement<br/>(10-30 years)"]
-        Y["Y: Migration<br/>Time Needed<br/>(5-15 years)"]
-        Z["Z: Quantum Computer<br/>Arrival<br/>(2033-2040?)"]
-    end
-
-    X --> SUM["X + Y"]
-    Y --> SUM
-    SUM --> CMP{"X + Y > Z?"}
-    CMP -- "Yes" --> LATE["Already Behind<br/>Schedule"]
-    CMP -- "No" --> SAFE["Time Remaining<br/>to Migrate"]
-
-    subgraph SNDL["Store Now, Decrypt Later"]
-        CAP["Adversary Captures<br/>Encrypted Traffic<br/>(Today)"]
-        WAIT["Stores Until Quantum<br/>Computer Available"]
-        CRACK["Decrypts Historical<br/>Traffic"]
-    end
-
-    CAP --> WAIT --> CRACK
-
-    style LATE fill:#e74c3c,color:#fff
-    style SAFE fill:#27ae60,color:#fff
-    style SNDL fill:#f39c12,color:#000
-```
+<figure class="arch-fig">
+<div class="flow" aria-label="Mosca theorem migration timing test">
+  <div class="flow-parallel">
+    <div class="flow-node"><b>X: Data Secrecy Requirement</b><i>10-30 years</i></div>
+    <div class="flow-node"><b>Y: Migration Time Needed</b><i>5-15 years</i></div>
+    <div class="flow-node"><b>Z: Quantum Computer Arrival</b><i>2033-2040?</i></div>
+  </div>
+  <div class="flow-node">X + Y</div>
+  <div class="flow-node is-gate">X + Y &gt; Z?</div>
+  <div class="flow-branch">
+    <div class="flow-leg" data-branch="Yes"><div class="flow-node is-bad"><b>Already Behind</b><i>schedule</i></div></div>
+    <div class="flow-leg" data-branch="No"><div class="flow-node is-good"><b>Time Remaining</b><i>to migrate</i></div></div>
+  </div>
+</div>
+<div class="flow" aria-label="Store Now Decrypt Later attack path">
+  <div class="flow-node"><b>Adversary Captures Encrypted Traffic</b><i>today</i></div>
+  <div class="flow-node"><b>Stores Until Quantum Computer</b><i>available</i></div>
+  <div class="flow-node is-bad">Decrypts Historical Traffic</div>
+</div>
+<figcaption>Mosca's timing test explains whether migration is already late; the SNDL path explains why old encrypted traffic is still at risk.</figcaption>
+</figure>
 
 For my homelab, that meant my encrypted backups, my self-hosted Bitwarden vault snapshots, and even my personal notes stored on TrueNAS, all potentially exposed if someone's recording my network traffic today. That realization made spending three weekends on PQC suddenly feel a lot more urgent.
 
@@ -69,26 +64,15 @@ For my homelab, that meant my encrypted backups, my self-hosted Bitwarden vault 
 
 The following diagram compares the three NIST-standardized post-quantum algorithms and their roles:
 
-```mermaid
-flowchart TD
-    NIST["NIST PQC Standards<br/>(August 2024)"]
-
-    NIST --> KEM["ML-KEM (FIPS 203)<br/>Key Encapsulation"]
-    NIST --> DSA["ML-DSA (FIPS 204)<br/>Digital Signatures"]
-    NIST --> SLH["SLH-DSA (FIPS 205)<br/>Hash-Based Signatures"]
-
-    KEM --> KEM_USE["Replaces: ECDH / X25519<br/>Used in: TLS handshakes<br/>Key sizes: 800-1568 bytes"]
-    DSA --> DSA_USE["Replaces: RSA / ECDSA<br/>Used in: Certificates, code signing<br/>Sig sizes: 2420-4595 bytes"]
-    SLH --> SLH_USE["Backup for: ML-DSA<br/>Used in: Long-term archival<br/>Based on: Hash functions only"]
-
-    KEM_USE --> LATTICE["Lattice-Based Math<br/>(Learning With Errors)"]
-    DSA_USE --> LATTICE
-    SLH_USE --> HASH["Hash Functions<br/>(Different math basis)"]
-
-    style KEM fill:#3498db,color:#fff
-    style DSA fill:#27ae60,color:#fff
-    style SLH fill:#f39c12,color:#fff
-```
+<figure class="arch-fig">
+<div class="arch is-stack" aria-label="NIST post-quantum cryptography standards">
+  <section class="arch-tier" data-label="Standards"><span class="arch-chip is-primary"><b>NIST PQC Standards</b><i>August 2024</i></span></section>
+  <section class="arch-tier" data-label="Algorithms"><span class="arch-chip"><b>ML-KEM (FIPS 203)</b><i>key encapsulation</i></span><span class="arch-chip"><b>ML-DSA (FIPS 204)</b><i>digital signatures</i></span><span class="arch-chip"><b>SLH-DSA (FIPS 205)</b><i>hash-based signatures</i></span></section>
+  <section class="arch-tier" data-label="Uses"><span class="arch-chip"><b>ML-KEM</b><i>replaces ECDH / X25519; TLS handshakes; 800-1568 byte keys</i></span><span class="arch-chip"><b>ML-DSA</b><i>replaces RSA / ECDSA; certificates and code signing; 2420-4595 byte signatures</i></span><span class="arch-chip"><b>SLH-DSA</b><i>backup for ML-DSA; long-term archival; hash functions only</i></span></section>
+  <section class="arch-tier" data-label="Math Basis"><span class="arch-chip is-guard"><b>Lattice-Based Math</b><i>Learning With Errors</i></span><span class="arch-chip is-guard"><b>Hash Functions</b><i>different math basis</i></span></section>
+</div>
+<figcaption>ML-KEM and ML-DSA rely on lattice-based assumptions; SLH-DSA provides a hash-based signature fallback.</figcaption>
+</figure>
 
 NIST's standardization process evaluated 82 algorithms over eight years and selected three winners. Here's what actually made it to production. If you need a refresher on the classical cryptography these algorithms are replacing, check out my [cryptography fundamentals guide](/posts/2024-01-18-demystifying-cryptography-beginners-guide).
 
@@ -648,40 +632,17 @@ My personal risk tolerance says these trade-offs are acceptable for homelab expe
 
 The migration strategy follows four phases, prioritizing services by their exposure to Store Now, Decrypt Later attacks:
 
-```mermaid
-flowchart TD
-    subgraph Phase1["Phase 1: Test (Weekend 1)"]
-        VM["Isolated VM<br/>Ubuntu 24.04"]
-        VM --> CADDY["Install Caddy 2.10<br/>PQC enabled by default"]
-        CADDY --> VERIFY["Verify x25519_kyber768<br/>in handshake"]
-    end
-
-    subgraph Phase2["Phase 2: Certificates (Weekend 1)"]
-        CLASSICAL["Classical Certs<br/>(RSA/ECDSA)"]
-        CLASSICAL --> HYBRID_KE["+ PQC Key Exchange<br/>(ML-KEM-768)"]
-        HYBRID_KE --> FUTURE["Future: ML-DSA Certs<br/>(2026-2027)"]
-    end
-
-    subgraph Phase3["Phase 3: Rollout (Weekend 2)"]
-        HIGH["High Priority<br/>Bitwarden, TrueNAS, VPN"]
-        MED["Medium Priority<br/>Nextcloud, Wikis"]
-        LOW["Lower Priority<br/>Jellyfin, Grafana"]
-        HIGH --> MED --> LOW
-    end
-
-    subgraph Phase4["Phase 4: Monitor (Ongoing)"]
-        MON["Prometheus + Grafana"]
-        MON --> HANDSHAKE["Track handshake latency"]
-        MON --> COMPAT["Monitor client failures"]
-        MON --> CERTS["Certificate expiration"]
-    end
-
-    Phase1 --> Phase2 --> Phase3 --> Phase4
-
-    style HIGH fill:#e74c3c,color:#fff
-    style MED fill:#f39c12,color:#fff
-    style LOW fill:#27ae60,color:#fff
-```
+<div class="flow" aria-label="Post-quantum cryptography homelab migration phases">
+  <div class="flow-node"><b>Phase 1: Test</b><i>Weekend 1; isolated Ubuntu 24.04 VM, Caddy 2.10, verify x25519_kyber768 handshake</i></div>
+  <div class="flow-node"><b>Phase 2: Certificates</b><i>Weekend 1; classical certs, PQC key exchange with ML-KEM-768, future ML-DSA certs in 2026-2027</i></div>
+  <div class="flow-node is-gate"><b>Phase 3: Rollout</b><i>Weekend 2</i></div>
+  <div class="flow-parallel">
+    <div class="flow-node is-bad"><b>High Priority</b><i>Bitwarden, TrueNAS, VPN</i></div>
+    <div class="flow-node"><b>Medium Priority</b><i>Nextcloud, Wikis</i></div>
+    <div class="flow-node is-good"><b>Lower Priority</b><i>Jellyfin, Grafana</i></div>
+  </div>
+  <div class="flow-node"><b>Phase 4: Monitor</b><i>ongoing; Prometheus + Grafana, handshake latency, client failures, certificate expiration</i></div>
+</div>
 
 Here's the process I'd follow if I had to start over, knowing what I know now:
 

--- a/src/posts/2025-10-29-privacy-first-ai-lab-local-llms.md
+++ b/src/posts/2025-10-29-privacy-first-ai-lab-local-llms.md
@@ -33,29 +33,14 @@ But privacy isn't just about where the compute happens. It's about the entire st
 
 After that wake-up call, I rebuilt my thinking around three distinct threat layers:
 
-```mermaid
-graph TB
-    subgraph Network["Network Layer"]
-        N1[Endpoint Access Control]
-        N2[Telemetry Monitoring]
-        N3[Network Boundary Rules]
-    end
-    subgraph Storage["Storage Layer"]
-        S1[Prompt/Response Encryption]
-        S2[Docker Volume Protection]
-        S3[Model File Integrity]
-    end
-    subgraph Inference["Inference Layer"]
-        I1[GPU Memory Isolation]
-        I2[KV Cache Protection]
-        I3[Process Sandboxing]
-    end
-
-    Network --> Storage --> Inference
-    style Network fill:#e74c3c,color:#fff
-    style Storage fill:#f39c12,color:#fff
-    style Inference fill:#2ecc71,color:#fff
-```
+<figure class="arch-fig">
+<div class="arch is-stack" aria-label="Local LLM privacy threat model layers">
+  <section class="arch-tier" data-label="Network Layer"><span class="arch-chip is-guard">Endpoint Access Control</span><span class="arch-chip is-guard">Telemetry Monitoring</span><span class="arch-chip is-guard">Network Boundary Rules</span></section>
+  <section class="arch-tier" data-label="Storage Layer"><span class="arch-chip is-guard">Prompt / Response Encryption</span><span class="arch-chip is-guard">Docker Volume Protection</span><span class="arch-chip is-guard">Model File Integrity</span></section>
+  <section class="arch-tier" data-label="Inference Layer"><span class="arch-chip is-primary">GPU Memory Isolation</span><span class="arch-chip is-primary">KV Cache Protection</span><span class="arch-chip is-primary">Process Sandboxing</span></section>
+</div>
+<figcaption>The model is only private when controls hold at the network, storage, and inference layers.</figcaption>
+</figure>
 
 **Network Layer:** Who can access my LLM endpoints? What data crosses network boundaries? Is telemetry being sent somewhere?
 
@@ -218,34 +203,15 @@ Maybe in 3-5 years this'll be viable for homelab use. For now, it's research-onl
 
 Here's how I actually locked things down. This took about 6 hours to configure properly, but it's the foundation of everything else.
 
-```mermaid
-graph LR
-    subgraph VLAN1["VLAN 1 — Main Network"]
-        Laptop[Laptop/Desktop]
-    end
-    subgraph VLAN10["VLAN 10 — DMZ"]
-        IoT[IoT Devices]
-    end
-    subgraph VLAN20["VLAN 20 — AI Services"]
-        Proxmox[Proxmox Host]
-        VM[Ubuntu VM + RTX 3090]
-        Ollama[Ollama / LM Studio]
-        Proxmox --> VM --> Ollama
-    end
-    subgraph VLAN30["VLAN 30 — Monitoring"]
-        Wazuh[Wazuh SIEM]
-        Prom[Prometheus]
-    end
-
-    Laptop -->|VPN Only| VLAN20
-    VLAN10 -.->|BLOCKED| VLAN20
-    VLAN20 -->|Metrics| VLAN30
-    VLAN20 -.->|BLOCKED| Internet((Internet))
-
-    style VLAN20 fill:#2c3e50,color:#ecf0f1
-    style VLAN10 fill:#c0392b,color:#fff
-    style VLAN30 fill:#27ae60,color:#fff
-```
+<figure class="arch-fig">
+<div class="arch" aria-label="AI lab VLAN zones">
+  <section class="arch-tier" data-label="VLAN 1 - Main Network"><span class="arch-chip">Laptop / Desktop</span></section>
+  <section class="arch-tier" data-label="VLAN 10 - DMZ"><span class="arch-chip is-bad">IoT Devices</span></section>
+  <section class="arch-tier" data-label="VLAN 20 - AI Services"><span class="arch-chip">Proxmox Host</span><span class="arch-chip">Ubuntu VM + RTX 3090</span><span class="arch-chip is-primary">Ollama / LM Studio</span></section>
+  <section class="arch-tier" data-label="VLAN 30 - Monitoring"><span class="arch-chip is-guard">Wazuh SIEM</span><span class="arch-chip is-guard">Prometheus</span></section>
+</div>
+<figcaption>VLAN 20 accepts main-network access only over VPN, exports metrics to monitoring, and blocks DMZ and internet paths by policy.</figcaption>
+</figure>
 
 ### VLAN 20: AI Services Isolation
 
@@ -343,25 +309,19 @@ Running everything locally means I'm limited to models that fit in 24GB VRAM ful
 
 I use a separate Claude subscription for this blog writing. None of my sensitive homelab data ever touches cloud APIs.
 
-```mermaid
-flowchart TD
-    Start{What data are you processing?} -->|Sensitive / Regulated| Local
-    Start -->|Public / Non-sensitive| Cloud
-    Local -->|Budget > $3k?| HW[Buy GPU Hardware]
-    Local -->|Budget limited| CPU[CPU-Only Inference]
-    HW --> Harden[Harden: VLAN + Encryption + DP]
-    CPU --> Harden
-    Cloud -->|Need latest?| API[Cloud API — 405B+ models]
-    Cloud -->|General use| Managed[Managed Service]
-    Harden --> Monitor[Deploy Monitoring]
-    API --> Done([Production Ready])
-    Managed --> Done
-    Monitor --> Done
-
-    style Local fill:#27ae60,color:#fff
-    style Cloud fill:#3498db,color:#fff
-    style Harden fill:#e74c3c,color:#fff
-```
+<div class="flow" aria-label="Local versus cloud LLM routing decision">
+  <div class="flow-node is-gate">What data are you processing?</div>
+  <div class="flow-branch">
+    <div class="flow-leg" data-branch="Sensitive / Regulated"><div class="flow-node is-good"><b>Local Processing</b><i>GPU hardware or CPU-only inference</i></div></div>
+    <div class="flow-leg" data-branch="Public / Non-sensitive"><div class="flow-node"><b>Cloud Processing</b><i>Cloud API or managed service</i></div></div>
+  </div>
+  <div class="flow-node is-gate">Match budget and capability needs</div>
+  <div class="flow-branch">
+    <div class="flow-leg" data-branch="Local"><div class="flow-node is-good"><b>Harden</b><i>VLAN + encryption + DP + monitoring</i></div></div>
+    <div class="flow-leg" data-branch="Cloud"><div class="flow-node"><b>Choose service</b><i>405B+ API or general managed use</i></div></div>
+  </div>
+  <div class="flow-node is-good">Production Ready</div>
+</div>
 
 ### Decision Matrix: Local vs Cloud
 

--- a/src/posts/2025-11-05-siem-homelab-wazuh-graylog-comparison.md
+++ b/src/posts/2025-11-05-siem-homelab-wazuh-graylog-comparison.md
@@ -37,31 +37,32 @@ Both use agent-based collection, centralized storage, and web UI. Architectures 
 
 **Wazuh architecture:**
 
-```mermaid
-flowchart LR
-    Agent1[Wazuh Agent\nHost 1] -->|Logs| Manager[Wazuh Manager]
-    Agent2[Wazuh Agent\nHost 2] -->|Logs| Manager
-    Manager -->|Index| Indexer[Wazuh Indexer\nOpenSearch]
-    Manager -->|Alerts| Dashboard[Wazuh Dashboard]
-    Dashboard -->|Query| Indexer
-
-    classDef wazuh fill:#3498db,color:#fff
-    class Agent1,Agent2,Manager,Indexer,Dashboard wazuh
-```
+<div class="flow" aria-label="Wazuh log collection architecture">
+  <div class="flow-parallel">
+    <div class="flow-node"><b>Wazuh Agent</b><i>Host 1 logs</i></div>
+    <div class="flow-node"><b>Wazuh Agent</b><i>Host 2 logs</i></div>
+  </div>
+  <div class="flow-node">Wazuh Manager</div>
+  <div class="flow-branch">
+    <div class="flow-leg" data-branch="Index"><div class="flow-node"><b>Wazuh Indexer</b><i>OpenSearch</i></div></div>
+    <div class="flow-leg" data-branch="Alerts"><div class="flow-node"><b>Wazuh Dashboard</b><i>queries indexer</i></div></div>
+  </div>
+</div>
 
 **Graylog architecture:**
 
-```mermaid
-flowchart LR
-    Beats1[Filebeat\nHost 1] -->|Syslog| Graylog[Graylog Server]
-    Beats2[Filebeat\nHost 2] -->|Syslog| Graylog
-    Graylog -->|Store| Mongo[(MongoDB)]
-    Graylog -->|Index| Elastic[(Elasticsearch)]
-    Graylog -->|Search| WebUI[Graylog Web]
-
-    classDef graylog fill:#e74c3c,color:#fff
-    class Beats1,Beats2,Graylog,Mongo,Elastic,WebUI graylog
-```
+<div class="flow" aria-label="Graylog log collection architecture">
+  <div class="flow-parallel">
+    <div class="flow-node"><b>Filebeat</b><i>Host 1 syslog</i></div>
+    <div class="flow-node"><b>Filebeat</b><i>Host 2 syslog</i></div>
+  </div>
+  <div class="flow-node">Graylog Server</div>
+  <div class="flow-parallel">
+    <div class="flow-node"><b>MongoDB</b><i>store</i></div>
+    <div class="flow-node"><b>Elasticsearch</b><i>index</i></div>
+    <div class="flow-node"><b>Graylog Web</b><i>search</i></div>
+  </div>
+</div>
 
 **Key differences:**
 
@@ -336,20 +337,15 @@ Some teams run Wazuh + Graylog together. Wazuh handles threat detection, Graylog
 
 **Hybrid architecture:**
 
-```mermaid
-flowchart LR
-    Hosts[Homelab Hosts] -->|Security Logs| Wazuh[Wazuh Manager]
-    Hosts -->|Application Logs| Graylog[Graylog Server]
-
-    Wazuh -->|Alerts| Alerts[Alert Dashboard]
-    Graylog -->|Search| Investigate[Investigation UI]
-
-    Wazuh -.->|Forward Alerts| Graylog
-    Graylog -.->|Enrich| Wazuh
-
-    classDef hybrid fill:#9b59b6,color:#fff
-    class Wazuh,Graylog hybrid
-```
+<figure class="arch-fig">
+<div class="arch" aria-label="Hybrid Wazuh and Graylog deployment">
+  <section class="arch-tier" data-label="Inputs"><span class="arch-chip">Homelab Hosts</span></section>
+  <section class="arch-tier" data-label="Security Path"><span class="arch-chip is-primary">Wazuh Manager</span><span class="arch-chip">Alert Dashboard</span></section>
+  <section class="arch-tier" data-label="Application Path"><span class="arch-chip is-primary">Graylog Server</span><span class="arch-chip">Investigation UI</span></section>
+  <section class="arch-tier" data-label="Integration"><span class="arch-chip is-guard">Forward Wazuh Alerts to Graylog</span><span class="arch-chip is-guard">Enrich Graylog Events in Wazuh</span></section>
+</div>
+<figcaption>Security logs flow to Wazuh, application logs flow to Graylog, and the two systems exchange alerts for unified investigation.</figcaption>
+</figure>
 
 **Integration patterns:**
 

--- a/src/posts/2025-11-12-quantum-error-correction-willow-breakthrough.md
+++ b/src/posts/2025-11-12-quantum-error-correction-willow-breakthrough.md
@@ -21,35 +21,14 @@ Here's the catch that almost doomed the field: traditional error correction make
 
 The theoretical solution has been known since the 1990s: surface codes and logical qubits. Instead of using individual physical qubits for computation, you use groups of physical qubits to create one "logical qubit" protected by quantum error correction. The math said this should work below a critical error threshold around 1%.
 
-```mermaid
-graph TB
-    subgraph Surface["Surface Code Layout"]
-        direction TB
-        D1((D)) --- S1{S} --- D2((D))
-        D2 --- S2{S} --- D3((D))
-        D3 --- S3{S} --- D4((D))
-        D4 --- S4{S} --- D5((D))
-    end
-
-    subgraph Logical["Logical Qubit"]
-        LQ[1 Logical Qubit]
-    end
-
-    Surface -->|"Error correction<br/>decoding"| Logical
-
-    note1["D = Data Qubit<br/>S = Syndrome (Ancilla) Qubit"]
-
-    style D1 fill:#3498db,color:#fff
-    style D2 fill:#3498db,color:#fff
-    style D3 fill:#3498db,color:#fff
-    style D4 fill:#3498db,color:#fff
-    style D5 fill:#3498db,color:#fff
-    style S1 fill:#e74c3c,color:#fff
-    style S2 fill:#e74c3c,color:#fff
-    style S3 fill:#e74c3c,color:#fff
-    style S4 fill:#e74c3c,color:#fff
-    style LQ fill:#2ecc71,color:#fff
-```
+<figure class="arch-fig">
+<div class="arch is-stack" aria-label="Surface code error correction path">
+  <section class="arch-tier" data-label="Surface Code Layout"><span class="arch-chip is-primary"><b>D</b><i>Data Qubit</i></span><span class="arch-chip is-guard"><b>S</b><i>Syndrome Ancilla</i></span><span class="arch-chip is-primary"><b>D</b><i>Data Qubit</i></span><span class="arch-chip is-guard"><b>S</b><i>Syndrome Ancilla</i></span><span class="arch-chip is-primary"><b>D</b><i>Data Qubit</i></span></section>
+  <section class="arch-tier" data-label="Error Correction"><span class="arch-chip is-guard">Syndrome Measurement</span><span class="arch-chip is-guard">Decoding</span></section>
+  <section class="arch-tier" data-label="Logical Qubit"><span class="arch-chip is-primary">1 Logical Qubit</span></section>
+</div>
+<figcaption>Physical data qubits and syndrome ancillas form a surface-code layout that decodes into one protected logical qubit.</figcaption>
+</figure>
 
 **The problem:** Nobody could prove it actually worked at scale. Every demonstration either used too few qubits or showed errors getting worse as systems grew larger.
 

--- a/src/posts/2025-11-19-promsketch-prometheus-optimization.md
+++ b/src/posts/2025-11-19-promsketch-prometheus-optimization.md
@@ -46,27 +46,18 @@ PromSketch sits between Grafana and Prometheus as a caching proxy. It uses proba
 
 **Architecture:**
 
-```mermaid
-flowchart LR
-    Grafana[Grafana Dashboard] -->|PromQL Query| PromSketch[PromSketch Proxy]
-    PromSketch -->|Parse Query| Optimizer[Query Optimizer]
-    Optimizer -->|Sketch-eligible?| Cache[Sketch Cache]
-    Optimizer -->|Pass-through| Prom[Prometheus]
-
-    Cache -->|Approximation| Result[Fast Result]
-    Prom -->|Exact Data| Result
-
-    Prom -.->|Background| Sketcher[Sketch Builder]
-    Sketcher -.->|Update| Cache
-
-    classDef fast fill:#2ecc71,color:#000
-    classDef slow fill:#e74c3c,color:#fff
-    classDef optimize fill:#3498db,color:#fff
-
-    class PromSketch,Optimizer,Cache,Sketcher optimize
-    class Result fast
-    class Prom slow
-```
+<div class="flow" aria-label="PromSketch query optimization path">
+  <div class="flow-node">Grafana Dashboard</div>
+  <div class="flow-node">PromSketch Proxy</div>
+  <div class="flow-node">Query Optimizer</div>
+  <div class="flow-node is-gate">Sketch-eligible?</div>
+  <div class="flow-branch">
+    <div class="flow-leg" data-branch="Yes"><div class="flow-node is-good"><b>Sketch Cache</b><i>approximation</i></div></div>
+    <div class="flow-leg" data-branch="No"><div class="flow-node"><b>Prometheus</b><i>exact data</i></div></div>
+  </div>
+  <div class="flow-node is-good">Fast Result</div>
+  <div class="flow-node"><b>Background Sketch Builder</b><i>Prometheus updates cache</i></div>
+</div>
 
 **How it works:**
 

--- a/src/posts/2025-11-23-nodeshield-runtime-sbom-enforcement.md
+++ b/src/posts/2025-11-23-nodeshield-runtime-sbom-enforcement.md
@@ -51,24 +51,21 @@ NodeShield uses V8 engine hooks to intercept `require()` calls. When a module tr
 
 **Architecture:**
 
-```mermaid
-flowchart LR
-    App[Node.js App] -->|require module| NSHook[NodeShield Hook]
-    NSHook -->|Check CBOM| Policy[CBOM Policy]
-    Policy -->|Authorized| Allow[Load Module]
-    Policy -->|Unauthorized| Block[Block + Log]
-
-    SBOM[Static SBOM] -.->|Generate| Policy
-    Outliner[Static Outliner] -.->|Analyze| SBOM
-
-    classDef runtime fill:#e74c3c,color:#fff
-    classDef static fill:#3498db,color:#fff
-    classDef policy fill:#2ecc71,color:#000
-
-    class NSHook,Block runtime
-    class SBOM,Outliner static
-    class Policy policy
-```
+<div class="flow" aria-label="NodeShield runtime enforcement path">
+  <div class="flow-node">Node.js App</div>
+  <div class="flow-node">NodeShield Hook</div>
+  <div class="flow-node is-gate">Check CBOM Policy</div>
+  <div class="flow-branch">
+    <div class="flow-leg" data-branch="Authorized"><div class="flow-node is-good">Load Module</div></div>
+    <div class="flow-leg" data-branch="Unauthorized"><div class="flow-node is-bad">Block + Log</div></div>
+  </div>
+</div>
+<div class="flow" aria-label="NodeShield policy generation path">
+  <div class="flow-node">Static Outliner</div>
+  <div class="flow-node">Static SBOM</div>
+  <div class="flow-node is-good">CBOM Policy</div>
+</div>
+The split view separates runtime enforcement from the static SBOM-to-CBOM policy generation step.
 
 **Why this matters:** SolarWinds-style attacks require filesystem access, network egress, or process manipulation. NodeShield blocks all three if the compromised module's CBOM doesn't authorize them.
 

--- a/src/posts/2025-12-10-homelab-security-dashboard-grafana-prometheus.md
+++ b/src/posts/2025-12-10-homelab-security-dashboard-grafana-prometheus.md
@@ -46,34 +46,14 @@ With proper dashboards? Real-time alerts caught similar attempts in under 2 minu
 - **Blackbox Exporter**: Service availability
 - **Custom exporters**: Security-specific metrics
 
-```mermaid
-graph LR
-    subgraph Sources["Data Sources"]
-        NE[Node Exporter]
-        SSH[SSH Monitor]
-        FW[Firewall Exporter]
-        BB[Blackbox Exporter]
-        TI[Threat Intel Feed]
-    end
-
-    subgraph Core["Core Stack"]
-        Prom[(Prometheus<br/>TSDB — 90 day retention)]
-        AM[Alertmanager]
-    end
-
-    subgraph Viz["Visualization"]
-        Grafana[Grafana Dashboards]
-    end
-
-    NE & SSH & FW & BB & TI -->|scrape / push| Prom
-    Prom -->|alert rules| AM
-    Prom -->|query| Grafana
-    AM -->|critical| Webhook1[Immediate Notify]
-    AM -->|warning| Webhook2[Hourly Summary]
-
-    style Core fill:#2c3e50,color:#ecf0f1
-    style Viz fill:#27ae60,color:#fff
-```
+<figure class="arch-fig">
+<div class="arch is-stack" aria-label="Homelab security dashboard architecture">
+  <section class="arch-tier" data-label="Data Sources"><span class="arch-chip">Node Exporter</span><span class="arch-chip">SSH Monitor</span><span class="arch-chip">Firewall Exporter</span><span class="arch-chip">Blackbox Exporter</span><span class="arch-chip">Threat Intel Feed</span></section>
+  <section class="arch-tier" data-label="Core Stack"><span class="arch-chip is-primary"><b>Prometheus</b><i>TSDB, 90-day retention</i></span><span class="arch-chip is-guard">Alertmanager</span></section>
+  <section class="arch-tier" data-label="Outputs"><span class="arch-chip is-primary">Grafana Dashboards</span><span class="arch-chip is-bad">Immediate Notify</span><span class="arch-chip is-warn">Hourly Summary</span></section>
+</div>
+<figcaption>Exporters feed Prometheus; Prometheus drives Grafana queries and Alertmanager notification paths.</figcaption>
+</figure>
 
 **Why this stack:**
 - Prometheus handles time-series data efficiently
@@ -352,22 +332,21 @@ groups:
 
 ### Alert Fatigue Prevention
 
-```mermaid
-flowchart TD
-    Event[Security Event] --> Prom[Prometheus Evaluates Rules]
-    Prom --> Thresh{Exceeds Threshold?}
-    Thresh -->|No| Drop[Log Only — Info]
-    Thresh -->|Yes| Sev{Severity?}
-    Sev -->|Critical| Imm[Immediate Notification<br/>Webhook — respond NOW]
-    Sev -->|Warning| Hourly[Hourly Summary Batch<br/>Investigate within 4h]
-    Imm --> Group[Alertmanager Groups<br/>by alertname, 5m intervals]
-    Hourly --> Group
-    Group --> Dedup[Deduplicate<br/>12h repeat interval]
-
-    style Imm fill:#e74c3c,color:#fff
-    style Hourly fill:#f39c12,color:#fff
-    style Drop fill:#95a5a6,color:#fff
-```
+<div class="flow" aria-label="Security alert routing and deduplication">
+  <div class="flow-node">Security Event</div>
+  <div class="flow-node">Prometheus Evaluates Rules</div>
+  <div class="flow-node is-gate">Exceeds Threshold?</div>
+  <div class="flow-branch">
+    <div class="flow-leg" data-branch="No"><div class="flow-node">Log Only - Info</div></div>
+    <div class="flow-leg" data-branch="Yes"><div class="flow-node is-gate">Severity?</div></div>
+  </div>
+  <div class="flow-branch">
+    <div class="flow-leg" data-branch="Critical"><div class="flow-node is-bad"><b>Immediate Notification</b><i>webhook, respond now</i></div></div>
+    <div class="flow-leg" data-branch="Warning"><div class="flow-node"><b>Hourly Summary Batch</b><i>investigate within 4h</i></div></div>
+  </div>
+  <div class="flow-node"><b>Alertmanager Groups</b><i>by alertname, 5m intervals</i></div>
+  <div class="flow-node">Deduplicate - 12h repeat interval</div>
+</div>
 
 **The problem:** Too many alerts = ignored alerts. I started with 23 different alert rules. Average: 15 alerts per day. Response rate: 30%.
 
@@ -526,35 +505,20 @@ def geolocate_ip(ip_address):
 
 ### Correlation Dashboard
 
-```mermaid
-flowchart LR
-    subgraph Signals["Independent Signals"]
-        SSH[SSH Failed Logins]
-        Scan[Port Scans]
-        DNS[DNS Anomalies]
-        Proc[Unusual Processes]
-    end
-
-    subgraph Correlate["Correlation Engine"]
-        Join["PromQL join on source_ip"]
-    end
-
-    subgraph Verdict["Threat Classification"]
-        Low[Opportunistic Scan]
-        Med[Targeted Probe]
-        High[Active Compromise]
-    end
-
-    SSH & Scan --> Join
-    DNS & Proc --> Join
-    Join -->|"1 signal"| Low
-    Join -->|"2 signals"| Med
-    Join -->|"3+ signals"| High
-
-    style High fill:#e74c3c,color:#fff
-    style Med fill:#f39c12,color:#fff
-    style Low fill:#f1c40f,color:#000
-```
+<div class="flow" aria-label="Security signal correlation workflow">
+  <div class="flow-parallel">
+    <div class="flow-node">SSH Failed Logins</div>
+    <div class="flow-node">Port Scans</div>
+    <div class="flow-node">DNS Anomalies</div>
+    <div class="flow-node">Unusual Processes</div>
+  </div>
+  <div class="flow-node is-gate"><b>Correlation Engine</b><i>PromQL join on source_ip</i></div>
+  <div class="flow-branch">
+    <div class="flow-leg" data-branch="1 signal"><div class="flow-node">Opportunistic Scan</div></div>
+    <div class="flow-leg" data-branch="2 signals"><div class="flow-node">Targeted Probe</div></div>
+    <div class="flow-leg" data-branch="3+ signals"><div class="flow-node is-bad">Active Compromise</div></div>
+  </div>
+</div>
 
 Built secondary dashboard correlating multiple data sources:
 

--- a/src/posts/2025-12-17-docker-container-hardening-homelab.md
+++ b/src/posts/2025-12-17-docker-container-hardening-homelab.md
@@ -45,32 +45,10 @@ Container security isn't binary. You can't just "enable security" and assume you
 
 ## Layer 1: Minimal Base Images
 
-```mermaid
-flowchart LR
-    subgraph Before["Ubuntu Base — 72 MB"]
-        direction TB
-        OS1[OS Libraries]
-        PM1[Package Manager]
-        Shell1[Shell — bash, sh]
-        Utils1[Utilities — curl, wget, etc.]
-        App1[Application]
-    end
-
-    subgraph After["Distroless — 12 MB"]
-        direction TB
-        RT[Minimal Runtime]
-        App2[Application]
-    end
-
-    Before -->|"Multi-stage build"| After
-    Before -.-|"43 CVEs"| X1((X))
-    After -.-|"2 CVEs"| Check1((OK))
-
-    style Before fill:#e74c3c,color:#fff
-    style After fill:#2ecc71,color:#fff
-    style X1 fill:#c0392b,color:#fff
-    style Check1 fill:#27ae60,color:#fff
-```
+| Image | Size | Contents | CVE Count | Build path |
+|---|---:|---|---:|---|
+| Ubuntu Base | 72 MB | OS libraries, package manager, shell, utilities, application | 43 | Source stage |
+| Distroless | 12 MB | Minimal runtime, application | 2 | Multi-stage output |
 
 Smaller images = smaller attack surface. I switched from full OS base images to distroless containers.
 
@@ -294,30 +272,14 @@ docker run \
 
 ## Layer 7: Network Segmentation
 
-```mermaid
-graph TB
-    Internet([Internet]) --> LB[Load Balancer]
-
-    subgraph Frontend["frontend-network — 172.20.1.0/24"]
-        LB --> Nginx[Nginx Reverse Proxy]
-        Nginx --> WebApp[Web Application]
-    end
-
-    subgraph Backend["backend-network — 172.20.2.0/24 (internal)"]
-        API[API Server]
-        DB[(PostgreSQL)]
-        Cache[(Redis)]
-        API --> DB
-        API --> Cache
-    end
-
-    WebApp -->|"Allowed: port 8080"| API
-    Nginx -.->|"BLOCKED"| DB
-    Internet -.->|"BLOCKED"| Backend
-
-    style Frontend fill:#3498db,color:#fff
-    style Backend fill:#2c3e50,color:#ecf0f1
-```
+<figure class="arch-fig">
+<div class="arch" aria-label="Docker frontend and backend network zones">
+  <section class="arch-tier" data-label="Internet Edge"><span class="arch-chip">Internet</span><span class="arch-chip">Load Balancer</span></section>
+  <section class="arch-tier" data-label="frontend-network - 172.20.1.0/24"><span class="arch-chip">Nginx Reverse Proxy</span><span class="arch-chip is-primary">Web Application</span></section>
+  <section class="arch-tier" data-label="backend-network - 172.20.2.0/24 (internal)"><span class="arch-chip is-primary">API Server</span><span class="arch-chip is-guard">PostgreSQL</span><span class="arch-chip is-guard">Redis</span></section>
+</div>
+<figcaption>The frontend can reach the API on port 8080; direct Nginx-to-database and internet-to-backend paths stay blocked.</figcaption>
+</figure>
 
 Isolate containers using custom Docker networks. Default bridge network allows all containers to communicate, which creates risk for lateral movement.
 

--- a/src/posts/2025-12-24-private-cloud-homelab-proxmox-security.md
+++ b/src/posts/2025-12-24-private-cloud-homelab-proxmox-security.md
@@ -35,36 +35,14 @@ My setup runs on a single Dell R910:
 
 This single node handles 30+ VMs and containers comfortably. With 256GB RAM, careful resource allocation is key, but it's more than sufficient for a full-featured homelab. Uptime averages 99.7% - better than some cloud providers I've used.
 
-```mermaid
-graph TB
-    subgraph "Dell R910"
-        PVE["Proxmox VE Host<br/>4x Xeon E7540<br/>256GB RAM"]
-        subgraph "Compute"
-            VMs["30+ VMs"]
-            LXC["LXC Containers"]
-        end
-        NVMe["ZFS Pool<br/>OS + VM Storage"]
-        HDD["12TB HDD<br/>Bulk Storage"]
-    end
-
-    subgraph "Network - Ubiquiti"
-        UDM["UDM Pro<br/>Firewall / Router"]
-        USW["UniFi Switch 24 PoE"]
-    end
-
-    subgraph "Storage Server"
-        TN["TrueNAS Core<br/>~30TB Usable (RAIDZ2)"]
-    end
-
-    PVE -->|"Manages"| VMs
-    PVE -->|"Manages"| LXC
-    PVE --- NVMe
-    PVE --- HDD
-    PVE -->|"10GbE iSCSI"| TN
-    PVE -->|"Mgmt"| USW
-    USW --- UDM
-    VMs -->|"Traffic"| USW
-```
+<figure class="arch-fig">
+<div class="arch" aria-label="Private cloud physical architecture">
+  <section class="arch-tier" data-label="Dell R910"><span class="arch-chip is-primary"><b>Proxmox VE Host</b><i>4x Xeon E7540, 256GB RAM</i></span><span class="arch-chip">30+ VMs</span><span class="arch-chip">LXC Containers</span><span class="arch-chip">ZFS Pool - OS + VM Storage</span><span class="arch-chip">12TB HDD - Bulk Storage</span></section>
+  <section class="arch-tier" data-label="Network - Ubiquiti"><span class="arch-chip is-guard">UDM Pro - Firewall / Router</span><span class="arch-chip">UniFi Switch 24 PoE</span></section>
+  <section class="arch-tier" data-label="Storage Server"><span class="arch-chip is-primary"><b>TrueNAS Core</b><i>~30TB usable, RAIDZ2</i></span></section>
+</div>
+<figcaption>Proxmox manages compute locally, connects to Ubiquiti for management and VM traffic, and uses TrueNAS over 10GbE iSCSI for shared storage.</figcaption>
+</figure>
 
 ### Storage Architecture That Actually Works
 
@@ -82,30 +60,14 @@ Proxmox supports multiple storage backends. I tested five configurations over 12
 
 **Winner:** ZFS over iSCSI. My TrueNAS Core server provides ~30TB usable storage (from 40TB raw) with RAIDZ2 protection. Proxmox sees it as shared block storage, perfect for VM disks and backups.
 
-```mermaid
-graph LR
-    subgraph "Proxmox Host"
-        PVE["Proxmox VE"]
-    end
-
-    subgraph "Local Storage"
-        NVMe["ZFS Pool<br/>VM Disks (Fast)"]
-        HDD["12TB HDD<br/>Bulk / ISOs"]
-    end
-
-    subgraph "Network Storage"
-        TN["TrueNAS Core"]
-        RAIDZ2["RAIDZ2 Pool<br/>40TB Raw → 30TB Usable"]
-    end
-
-    PVE -->|"Direct"| NVMe
-    PVE -->|"Direct"| HDD
-    PVE -->|"iSCSI over 10GbE"| TN
-    TN --- RAIDZ2
-
-    style NVMe fill:#2d6a4f,color:#fff
-    style RAIDZ2 fill:#1b4332,color:#fff
-```
+<figure class="arch-fig">
+<div class="arch" aria-label="Proxmox storage architecture">
+  <section class="arch-tier" data-label="Proxmox Host"><span class="arch-chip is-primary">Proxmox VE</span></section>
+  <section class="arch-tier" data-label="Local Storage"><span class="arch-chip"><b>ZFS Pool</b><i>VM disks, fast</i></span><span class="arch-chip"><b>12TB HDD</b><i>bulk / ISOs</i></span></section>
+  <section class="arch-tier" data-label="Network Storage"><span class="arch-chip is-primary">TrueNAS Core</span><span class="arch-chip is-guard"><b>RAIDZ2 Pool</b><i>40TB raw to 30TB usable</i></span></section>
+</div>
+<figcaption>Proxmox uses local disks directly and reaches the TrueNAS RAIDZ2 pool over 10GbE iSCSI.</figcaption>
+</figure>
 
 ### Network Segmentation Strategy
 
@@ -140,45 +102,17 @@ I implemented five VLANs using my Ubiquiti Dream Machine Pro and UniFi Switch 24
 
 Each VLAN has specific firewall rules enforced by the Dream Machine Pro. Cross-VLAN communication requires explicit allow rules. The UniFi ecosystem makes this manageable through a single interface.
 
-```mermaid
-graph TB
-    Internet["Internet"]
-    UDM["UDM Pro<br/>Firewall / Router"]
-    Internet --- UDM
-
-    subgraph "VLAN 10 - Management<br/>192.168.10.0/24"
-        PVE["Proxmox Host"]
-        TN["TrueNAS"]
-        Bastion["Bastion Host"]
-    end
-
-    subgraph "VLAN 20 - Services<br/>192.168.20.0/24"
-        GitLab["GitLab CE"]
-        BookStack["BookStack"]
-        Jellyfin["Jellyfin"]
-    end
-
-    subgraph "VLAN 30 - IoT<br/>192.168.30.0/24"
-        HA["Home Assistant"]
-        Devices["Smart Devices"]
-    end
-
-    subgraph "VLAN 40 - Guest<br/>192.168.40.0/24"
-        Guest["Guest Devices<br/>Internet Only"]
-    end
-
-    subgraph "VLAN 50 - Lab<br/>192.168.50.0/24"
-        K3s["K3s Cluster<br/>3x Pi 5 + 1x Pi 4"]
-    end
-
-    UDM --- PVE
-    UDM --- GitLab
-    UDM --- HA
-    UDM --- Guest
-    UDM --- K3s
-    HA -.->|"Bridge"| GitLab
-    Bastion -.->|"SSH"| PVE
-```
+<figure class="arch-fig">
+<div class="arch" aria-label="Private cloud VLAN segmentation">
+  <section class="arch-tier" data-label="Edge"><span class="arch-chip">Internet</span><span class="arch-chip is-guard"><b>UDM Pro</b><i>firewall / router</i></span></section>
+  <section class="arch-tier" data-label="VLAN 10 - Management - 192.168.10.0/24"><span class="arch-chip is-primary">Proxmox Host</span><span class="arch-chip">TrueNAS</span><span class="arch-chip is-guard">Bastion Host</span></section>
+  <section class="arch-tier" data-label="VLAN 20 - Services - 192.168.20.0/24"><span class="arch-chip">GitLab CE</span><span class="arch-chip">BookStack</span><span class="arch-chip">Jellyfin</span></section>
+  <section class="arch-tier" data-label="VLAN 30 - IoT - 192.168.30.0/24"><span class="arch-chip">Home Assistant</span><span class="arch-chip is-warn">Smart Devices</span></section>
+  <section class="arch-tier" data-label="VLAN 40 - Guest - 192.168.40.0/24"><span class="arch-chip is-guard">Guest Devices - Internet Only</span></section>
+  <section class="arch-tier" data-label="VLAN 50 - Lab - 192.168.50.0/24"><span class="arch-chip"><b>K3s Cluster</b><i>3x Pi 5 + 1x Pi 4</i></span></section>
+</div>
+<figcaption>The UDM Pro routes each VLAN; Home Assistant bridges only to approved services, and bastion SSH is the management entry point.</figcaption>
+</figure>
 
 ## Security Hardening That Matters
 
@@ -265,35 +199,15 @@ Backups are boring until you need them. I learned this during a storage controll
 
 **Tier 3 - Offsite replication:** Restic backups to Backblaze B2. Critical data encrypted and synced daily, full backups weekly. 90-day retention with versioning.
 
-```mermaid
-flowchart LR
-    subgraph Tier1["Tier 1 — Local"]
-        ZSnap["ZFS Snapshots<br/>Every Hour<br/>48h Retention"]
-    end
-
-    subgraph Tier2["Tier 2 — On-Site"]
-        Full["Weekly Full Backup"]
-        Inc["Daily Incrementals"]
-        Store["TrueNAS RAIDZ2<br/>30-day Retention"]
-    end
-
-    subgraph Tier3["Tier 3 — Offsite"]
-        Restic["Restic Encrypted"]
-        B2["Backblaze B2<br/>90-day Retention"]
-    end
-
-    VMs["VMs &<br/>Containers"] --> ZSnap
-    VMs --> Full
-    VMs --> Inc
-    Full --> Store
-    Inc --> Store
-    Store -->|"Daily Sync"| Restic
-    Restic --> B2
-
-    style Tier1 fill:#1a1a2e,color:#fff
-    style Tier2 fill:#16213e,color:#fff
-    style Tier3 fill:#0f3460,color:#fff
-```
+<figure class="arch-fig">
+<div class="arch is-stack" aria-label="Three-tier Proxmox backup strategy">
+  <section class="arch-tier" data-label="Source"><span class="arch-chip is-primary">VMs &amp; Containers</span></section>
+  <section class="arch-tier" data-label="Tier 1 - Local"><span class="arch-chip"><b>ZFS Snapshots</b><i>every hour, 48h retention</i></span></section>
+  <section class="arch-tier" data-label="Tier 2 - On-Site"><span class="arch-chip">Weekly Full Backup</span><span class="arch-chip">Daily Incrementals</span><span class="arch-chip is-guard"><b>TrueNAS RAIDZ2</b><i>30-day retention</i></span></section>
+  <section class="arch-tier" data-label="Tier 3 - Offsite"><span class="arch-chip is-guard">Restic Encrypted</span><span class="arch-chip is-primary"><b>Backblaze B2</b><i>90-day retention</i></span></section>
+</div>
+<figcaption>Local snapshots handle fast rollback, on-site backups cover VM recovery, and encrypted Restic syncs critical data offsite.</figcaption>
+</figure>
 
 ### Backup Testing (The Part Everyone Skips)
 

--- a/src/posts/2026-01-15-routellm-contextual-bandits-model-router-research.md
+++ b/src/posts/2026-01-15-routellm-contextual-bandits-model-router-research.md
@@ -102,25 +102,17 @@ Not every paper I read was useful. A few approaches I tried and discarded:
 
 ## The Full Pipeline
 
-```mermaid
-flowchart LR
-    Task[Task Input] --> BR[Budget Router]
-    BR --> ZR[Zero Router]
-    ZR --> PR[Preference Router]
-    PR --> TR[TOPSIS Router]
-    TR --> LB[LinUCB Bandit]
-    LB --> Model[Selected Model]
-    Model --> Exec[Execute Task]
-    Exec --> Outcome[Task Outcome]
-    Outcome -.->|reward signal| LB
-
-    classDef routerNode fill:#4f46e5,stroke:#fff,stroke-width:2px,color:#fff
-    classDef ioNode fill:#f59e0b,color:#000,stroke:#333,stroke-width:2px
-    classDef adaptNode fill:#10b981,stroke:#fff,stroke-width:2px,color:#fff
-    class BR,ZR,PR,TR routerNode
-    class Task,Model,Exec,Outcome ioNode
-    class LB adaptNode
-```
+<div class="flow" aria-label="RouteLLM contextual bandit routing pipeline">
+  <div class="flow-node">Task Input</div>
+  <div class="flow-node">Budget Router</div>
+  <div class="flow-node">Zero Router</div>
+  <div class="flow-node">Preference Router</div>
+  <div class="flow-node">TOPSIS Router</div>
+  <div class="flow-node is-gate">LinUCB Bandit</div>
+  <div class="flow-node">Selected Model</div>
+  <div class="flow-node">Execute Task</div>
+  <div class="flow-node is-good"><b>Task Outcome</b><i>reward signal updates LinUCB</i></div>
+</div>
 
 The final router runs five stages in sequence:
 

--- a/src/posts/2026-01-28-consensus-voting-ai-models-multi-agent.md
+++ b/src/posts/2026-01-28-consensus-voting-ai-models-multi-agent.md
@@ -39,34 +39,23 @@ These findings led to two design decisions: role-based agent assignment with rou
 
 ## How Consensus Voting Works
 
-```mermaid
-flowchart TB
-    Proposal[Proposal Text] --> Assign[Round-Robin Model Assignment]
-    Assign --> Arch[Architect]
-    Assign --> Sec[Security Engineer]
-    Assign --> DevEx[DevEx Advocate]
-    Assign --> PM[Product Manager]
-    Assign --> Cat[Catfish]
-    Arch --> Agg[Vote Aggregation]
-    Sec --> Agg
-    DevEx --> Agg
-    PM --> Agg
-    Cat --> Agg
-    Agg --> Check{Strategy Threshold}
-    Check -->|Met| Pass[APPROVED]
-    Check -->|Not Met| Fail[REJECTED]
-
-    classDef agentNode fill:#4f46e5,stroke:#fff,stroke-width:2px,color:#fff
-    classDef catfishNode fill:#dc2626,stroke:#fff,stroke-width:2px,color:#fff
-    classDef processNode fill:#f59e0b,color:#000,stroke:#333,stroke-width:2px
-    classDef resultNode fill:#10b981,stroke:#fff,stroke-width:2px,color:#fff
-    classDef rejectNode fill:#ef4444,stroke:#fff,stroke-width:2px,color:#fff
-    class Arch,Sec,DevEx,PM agentNode
-    class Cat catfishNode
-    class Proposal,Assign,Agg,Check processNode
-    class Pass resultNode
-    class Fail rejectNode
-```
+<div class="flow" aria-label="Consensus voting decision workflow">
+  <div class="flow-node">Proposal Text</div>
+  <div class="flow-node">Round-Robin Model Assignment</div>
+  <div class="flow-parallel">
+    <div class="flow-node">Architect</div>
+    <div class="flow-node">Security Engineer</div>
+    <div class="flow-node">DevEx Advocate</div>
+    <div class="flow-node">Product Manager</div>
+    <div class="flow-node is-bad">Catfish</div>
+  </div>
+  <div class="flow-node">Vote Aggregation</div>
+  <div class="flow-node is-gate">Strategy Threshold</div>
+  <div class="flow-branch">
+    <div class="flow-leg" data-branch="Met"><div class="flow-node is-good">APPROVED</div></div>
+    <div class="flow-leg" data-branch="Not Met"><div class="flow-node is-bad">REJECTED</div></div>
+  </div>
+</div>
 
 For a given proposal, the system creates five specialized agent roles:
 

--- a/src/posts/2026-02-09-building-nexus-agents-multi-model-orchestration.md
+++ b/src/posts/2026-02-09-building-nexus-agents-multi-model-orchestration.md
@@ -35,47 +35,15 @@ MCP gave me a standard interface that any compatible client could use. Claude Co
 
 An [STPA safety analysis of MCP](https://arxiv.org/abs/2601.08012) later validated some of my security concerns about the protocol. More on that below.
 
-```mermaid
-graph TB
-    subgraph Clients["MCP Clients"]
-        CC["Claude Code"]
-        Cursor["Cursor"]
-        WS["Windsurf"]
-    end
-
-    subgraph "Nexus-Agents MCP Server"
-        MCP["MCP Protocol Layer<br/>25 Tools"]
-        Orch["Orchestrator"]
-        Router["CompositeRouter<br/>5-Stage Pipeline"]
-        Consensus["Consensus Engine"]
-        Graph["Graph Workflows"]
-        Pipeline["Plugin Pipeline"]
-    end
-
-    subgraph Adapters["CLI Adapters"]
-        Claude["Claude Adapter"]
-        Gemini["Gemini Adapter"]
-        Codex["Codex Adapter"]
-        OC["OpenCode Adapter"]
-    end
-
-    subgraph Models["AI Models"]
-        M1["Claude Opus / Sonnet"]
-        M2["Gemini Pro / Flash"]
-        M3["Codex"]
-    end
-
-    CC & Cursor & WS -->|"MCP (stdio/SSE)"| MCP
-    MCP --> Orch
-    Orch --> Router
-    Orch --> Consensus
-    Orch --> Graph
-    Orch --> Pipeline
-    Router --> Claude & Gemini & Codex & OC
-    Claude --> M1
-    Gemini --> M2
-    Codex --> M3
-```
+<figure class="arch-fig">
+<div class="arch is-stack" aria-label="Nexus-Agents MCP orchestration architecture">
+  <section class="arch-tier" data-label="MCP Clients"><span class="arch-chip">Claude Code</span><span class="arch-chip">Cursor</span><span class="arch-chip">Windsurf</span></section>
+  <section class="arch-tier" data-label="Nexus-Agents MCP Server"><span class="arch-chip is-primary"><b>MCP Protocol Layer</b><i>25 tools</i></span><span class="arch-chip">Orchestrator</span><span class="arch-chip">CompositeRouter - 5-Stage Pipeline</span><span class="arch-chip">Consensus Engine</span><span class="arch-chip">Graph Workflows</span><span class="arch-chip">Plugin Pipeline</span></section>
+  <section class="arch-tier" data-label="CLI Adapters"><span class="arch-chip">Claude Adapter</span><span class="arch-chip">Gemini Adapter</span><span class="arch-chip">Codex Adapter</span><span class="arch-chip">OpenCode Adapter</span></section>
+  <section class="arch-tier" data-label="AI Models"><span class="arch-chip is-primary">Claude Opus / Sonnet</span><span class="arch-chip is-primary">Gemini Pro / Flash</span><span class="arch-chip is-primary">Codex</span></section>
+</div>
+<figcaption>MCP clients enter through the server, the orchestrator selects routing, consensus, workflow, or plugin tools, and adapters call the underlying models.</figcaption>
+</figure>
 
 ### CLI Adapter Pattern
 
@@ -109,31 +77,15 @@ Picking the right model for a task isn't simple. I built a five-stage routing pi
 
 The entire pipeline runs in under 10ms. I was surprised how fast TOPSIS is when you're only ranking 6-8 models. The routing decision is nearly free compared to actual model inference. I wrote a [deeper dive on the routing research](/posts/2026-01-15-routellm-contextual-bandits-model-router-research/) separately, including the approaches that didn't work.
 
-```mermaid
-flowchart LR
-    Task["Incoming Task"]
-
-    subgraph Pipeline["5-Stage Routing Pipeline"]
-        direction LR
-        S1["1. Budget<br/>Router"]
-        S2["2. Zero<br/>Router"]
-        S3["3. Preference<br/>Router"]
-        S4["4. TOPSIS<br/>Router"]
-        S5["5. LinUCB<br/>Bandit"]
-        S1 --> S2 --> S3 --> S4 --> S5
-    end
-
-    Task --> S1
-    S5 --> Selected["Selected<br/>Model"]
-
-    Feedback["Outcome<br/>Feedback"] -.->|"Adjusts Weights"| S5
-
-    style S1 fill:#264653,color:#fff
-    style S2 fill:#2a9d8f,color:#fff
-    style S3 fill:#e9c46a,color:#000
-    style S4 fill:#f4a261,color:#000
-    style S5 fill:#e76f51,color:#fff
-```
+<div class="flow" aria-label="Nexus-Agents five-stage routing pipeline">
+  <div class="flow-node">Incoming Task</div>
+  <div class="flow-node"><b>1. Budget</b><i>Router</i></div>
+  <div class="flow-node"><b>2. Zero</b><i>Router</i></div>
+  <div class="flow-node"><b>3. Preference</b><i>Router</i></div>
+  <div class="flow-node"><b>4. TOPSIS</b><i>Router</i></div>
+  <div class="flow-node is-gate"><b>5. LinUCB</b><i>Bandit</i></div>
+  <div class="flow-node is-good"><b>Selected Model</b><i>outcome feedback adjusts LinUCB weights</i></div>
+</div>
 
 ## Consensus Voting: Multiple Perspectives on Hard Decisions
 


### PR DESCRIPTION
The big one — bulk conversion of the remaining Mermaid **architecture** diagrams to the native patterns, per `docs/content-visuals.md`. Completes the #414 diagram migration.

## Scope (39 posts)
- **`.arch`** for layered/tiered systems (34 blocks) — transformer, MCP server, gVisor, eBPF, blockchain, local-LLM, vuln-mgmt pipeline, etc.
- **`.flow`** for processes incl. split sub-views (56 blocks)
- **Markdown tables** for matrices/comparisons
- **Split** dense graphs into focused `.arch`+`.flow`+table views
- **Left as Mermaid** (conservative): genuine essential-cross-link node graphs, cycles, and `sequenceDiagram`/`pie`/`timeline`/`gantt`/`quadrantChart`/`block-beta`/`stateDiagram`
- Hardcoded `fill:#hex`/`classDef` colors dropped on converted blocks

## Delegation + verification
Converted by codex across 3 batches against the canonical guide; gated here:
- Format validator: **0 real issues across 90 native blocks** (col-0, no interior blank lines, escaped entities, known classes, no fills)
- `pnpm build` green · **no markdown-block breakage in dist** · 13px type floor clean
- Visual spot-checks at 390px, light + dark: transformer, MCP server, gVisor, Docker-hardening, Bitwarden all render legibly

CI (axe / remarque / links) gates the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)