### PR TITLE
fix(diagrams): a11y + vestigial fixes from consensus review (#414)

### DIFF
--- a/astro-site/src/styles/global.css
+++ b/astro-site/src/styles/global.css
@@ -935,7 +935,6 @@ article .prose > p:first-of-type::first-letter {
   display: flex; flex-wrap: wrap; gap: 0.5rem; justify-content: center; width: 100%;
 }
 .prose .flow-parallel .flow-node { flex: 1 1 7rem; min-width: 6rem; margin-top: 0; }
-.prose .flow-parallel .flow-node::before, .prose .flow-parallel .flow-node::after { content: none; }
 /* two-way branch — legs wrap/stack; each carries a labelled pill */
 .prose .flow-branch {
   display: flex; flex-wrap: wrap; gap: 1rem; justify-content: center; width: 100%;
@@ -999,10 +998,7 @@ article .prose > p:first-of-type::first-letter {
 .prose .arch-chip.is-guard { border-style: dashed; border-color: var(--color-accent); }
 .prose .arch-chip.is-warn { border-color: var(--color-warning); color: var(--color-warning); }
 .prose .arch-chip.is-bad { border-color: var(--color-error); color: var(--color-error); }
-.prose .arch-fig figcaption {
-  color: var(--color-fg-muted); font-size: 0.8125rem; font-style: italic;
-  text-align: center; margin-top: 0.6rem;
-}
+/* .arch captions use the canonical `.prose :where(figcaption)` styling. */
 
 /* ===== Footer ===== */
 .site-footer {

--- a/docs/content-visuals.md
+++ b/docs/content-visuals.md
@@ -22,17 +22,17 @@ arrow characters or connector markup.
 Class contract:
 
 ```html
-<div class="flow" aria-label="Short diagram purpose">
+<div class="flow" role="group" aria-label="Short diagram purpose">
   <div class="flow-node">Step</div>
   <div class="flow-node is-gate">Decision / gate</div>
   <div class="flow-parallel">
     <div class="flow-node">Parallel step</div>
   </div>
   <div class="flow-branch">
-    <div class="flow-leg" data-branch="Pass">
+    <div class="flow-leg" data-branch="Pass" role="group" aria-label="Pass">
       <div class="flow-node is-good">Good result</div>
     </div>
-    <div class="flow-leg" data-branch="Fail">
+    <div class="flow-leg" data-branch="Fail" role="group" aria-label="Fail">
       <div class="flow-node is-bad">Bad result</div>
     </div>
   </div>
@@ -52,7 +52,7 @@ Raw HTML rules:
 Copy-paste example:
 
 ```html
-<div class="flow" aria-label="Security scanning pipeline">
+<div class="flow" role="group" aria-label="Security scanning pipeline">
   <div class="flow-node">Git Push / PR</div>
   <div class="flow-node is-gate">Trigger Pipeline</div>
   <div class="flow-parallel">
@@ -63,8 +63,8 @@ Copy-paste example:
   <div class="flow-node">Upload SARIF</div>
   <div class="flow-node is-gate">Security Gate</div>
   <div class="flow-branch">
-    <div class="flow-leg" data-branch="Pass"><div class="flow-node is-good">Deploy</div></div>
-    <div class="flow-leg" data-branch="Critical"><div class="flow-node is-bad">Block &amp; Alert</div></div>
+    <div class="flow-leg" data-branch="Pass" role="group" aria-label="Pass"><div class="flow-node is-good">Deploy</div></div>
+    <div class="flow-leg" data-branch="Critical" role="group" aria-label="Critical"><div class="flow-node is-bad">Block &amp; Alert</div></div>
   </div>
 </div>
 ```
@@ -79,8 +79,8 @@ Class contract:
 
 ```html
 <figure class="arch-fig">
-<div class="arch is-stack" aria-label="Short diagram purpose">
-  <section class="arch-tier" data-label="Tier label">
+<div class="arch is-stack" role="group" aria-label="Short diagram purpose">
+  <section class="arch-tier" data-label="Tier label" role="group" aria-label="Tier label">
     <span class="arch-chip is-primary"><b>Main component</b><i>second line</i></span>
     <span class="arch-chip is-guard">Guardrail</span>
     <span class="arch-chip is-warn">Warning</span>
@@ -104,18 +104,18 @@ Raw HTML rules:
 - Use no blank lines inside the block.
 - Use 2-space indentation.
 - Escape HTML-sensitive characters: `&` -> `&amp;`, `<` -> `&lt;`, `>` -> `&gt;`.
-- Set `aria-label` on the `.arch` when the diagram needs a text purpose.
+- Set `role="group"` and `aria-label` on the `.arch`.
 
 Copy-paste example:
 
 ```html
 <figure class="arch-fig">
-<div class="arch is-stack" aria-label="Self-hosted vault architecture">
-  <section class="arch-tier" data-label="Client Access"><span class="arch-chip">Web Vault</span><span class="arch-chip">Mobile Apps</span><span class="arch-chip">Browser Extensions</span></section>
-  <section class="arch-tier" data-label="Ingress Protection"><span class="arch-chip is-guard">Firewall Rules</span><span class="arch-chip is-guard">TLS 1.3</span><span class="arch-chip is-guard">Fail2ban</span></section>
-  <section class="arch-tier" data-label="Application Edge"><span class="arch-chip">Nginx Reverse Proxy</span></section>
-  <section class="arch-tier" data-label="Vault Service"><span class="arch-chip is-primary">Vaultwarden</span></section>
-  <section class="arch-tier" data-label="Data Store"><span class="arch-chip"><b>SQLite / PostgreSQL</b><i>encrypted at rest</i></span></section>
+<div class="arch is-stack" role="group" aria-label="Self-hosted vault architecture">
+  <section class="arch-tier" data-label="Client Access" role="group" aria-label="Client Access"><span class="arch-chip">Web Vault</span><span class="arch-chip">Mobile Apps</span><span class="arch-chip">Browser Extensions</span></section>
+  <section class="arch-tier" data-label="Ingress Protection" role="group" aria-label="Ingress Protection"><span class="arch-chip is-guard">Firewall Rules</span><span class="arch-chip is-guard">TLS 1.3</span><span class="arch-chip is-guard">Fail2ban</span></section>
+  <section class="arch-tier" data-label="Application Edge" role="group" aria-label="Application Edge"><span class="arch-chip">Nginx Reverse Proxy</span></section>
+  <section class="arch-tier" data-label="Vault Service" role="group" aria-label="Vault Service"><span class="arch-chip is-primary">Vaultwarden</span></section>
+  <section class="arch-tier" data-label="Data Store" role="group" aria-label="Data Store"><span class="arch-chip"><b>SQLite / PostgreSQL</b><i>encrypted at rest</i></span></section>
 </div>
 <figcaption>Clients enter through the protected edge; the vault service writes to a private database.</figcaption>
 </figure>
@@ -181,5 +181,6 @@ from the post metadata. Do not add hero-image frontmatter.
   `fill:#hex`, inline SVG colors, or theme-specific CSS.
 - Keep all visual text at `0.8125rem` or larger. That is the USWDS 13px floor.
 - Diagrams must reflow on mobile without horizontal scroll.
-- Set an `aria-label` on diagrams when the purpose is not obvious.
+- Keep diagram `aria-label` text concise and purpose-focused.
+- Root `.flow` / `.arch` need `role="group"` + `aria-label`; mirror each `.arch-tier` `data-label` and `.flow-leg` `data-branch` into `role="group"` + `aria-label`. CSS `::before` labels are visual-only.
 - Add a `<figcaption>` when interpretation helps.

--- a/src/posts/2024-01-18-demystifying-cryptography-beginners-guide.md
+++ b/src/posts/2024-01-18-demystifying-cryptography-beginners-guide.md
@@ -39,7 +39,7 @@ I used to think of encryption like placing letters in sealed envelopes, but my r
 ### Symmetric Encryption: Speed vs. Key Distribution
 
 <figure>
-<div class="flow" aria-label="Symmetric encryption path">
+<div class="flow" role="group" aria-label="Symmetric encryption path">
   <div class="flow-node"><b>🔑 Shared Secret Key</b><i>used to encrypt and decrypt</i></div>
   <div class="flow-node">Plaintext</div>
   <div class="flow-node">Encrypt</div>
@@ -47,7 +47,7 @@ I used to think of encryption like placing letters in sealed envelopes, but my r
   <div class="flow-node">Decrypt</div>
   <div class="flow-node">Plaintext</div>
 </div>
-<div class="flow" aria-label="Asymmetric encryption path">
+<div class="flow" role="group" aria-label="Asymmetric encryption path">
   <div class="flow-node"><b>🔓 Public Key</b><i>used to encrypt</i></div>
   <div class="flow-node">Plaintext</div>
   <div class="flow-node">Encrypt</div>
@@ -225,7 +225,7 @@ If hashing creates fingerprints, digital signatures are like notarizing those fi
 
 ### How Digital Signatures Work
 
-<div class="flow" aria-label="Digital signature signing and verification path">
+<div class="flow" role="group" aria-label="Digital signature signing and verification path">
   <div class="flow-node"><b>📄 Original Document</b><i>sender</i></div>
   <div class="flow-node">SHA-256 Hash</div>
   <div class="flow-node"><b>Hash Digest</b><i>a591a6d4...</i></div>
@@ -239,8 +239,8 @@ If hashing creates fingerprints, digital signatures are like notarizing those fi
   </div>
   <div class="flow-node is-gate">Match?</div>
   <div class="flow-branch">
-    <div class="flow-leg" data-branch="Yes"><div class="flow-node is-good">✅ Authentic &amp; Unaltered</div></div>
-    <div class="flow-leg" data-branch="No"><div class="flow-node is-bad">❌ Tampered or Forged</div></div>
+    <div class="flow-leg" data-branch="Yes" role="group" aria-label="Yes"><div class="flow-node is-good">✅ Authentic &amp; Unaltered</div></div>
+    <div class="flow-leg" data-branch="No" role="group" aria-label="No"><div class="flow-node is-bad">❌ Tampered or Forged</div></div>
   </div>
 </div>
 

--- a/src/posts/2024-01-30-python-vulnerability-scanner-automation.md
+++ b/src/posts/2024-01-30-python-vulnerability-scanner-automation.md
@@ -61,7 +61,7 @@ My scanner uses three components: package inventory, NVD query engine, and alert
 
 **System design:**
 
-<div class="flow">
+<div class="flow" role="group" aria-label="Vulnerability scanner architecture">
   <div class="flow-node"><b>Package Inventory</b><i>list installed</i></div>
   <div class="flow-node"><b>Vulnerability Scanner</b><i>query CVEs</i></div>
   <div class="flow-node"><b>NVD API 2.0</b><i>CVE details</i></div>

--- a/src/posts/2024-03-20-transformer-architecture-deep-dive.md
+++ b/src/posts/2024-03-20-transformer-architecture-deep-dive.md
@@ -18,10 +18,10 @@ In late 2018, I implemented my first Transformer from scratch for a machine tran
 ## How It Works
 
 <figure class="arch-fig">
-<div class="arch is-stack" aria-label="Transformer encoder and decoder architecture">
-  <section class="arch-tier" data-label="Input"><span class="arch-chip">Token Embeddings</span><span class="arch-chip">Positional Encoding</span></section>
-  <section class="arch-tier" data-label="Encoder Stack"><span class="arch-chip is-primary">Multi-Head Attention</span><span class="arch-chip">Feed Forward</span><span class="arch-chip">Layer Norm</span></section>
-  <section class="arch-tier" data-label="Decoder Stack"><span class="arch-chip">Masked Attention</span><span class="arch-chip is-primary">Cross Attention</span><span class="arch-chip">Feed Forward</span></section>
+<div class="arch is-stack" role="group" aria-label="Transformer encoder and decoder architecture">
+  <section class="arch-tier" data-label="Input" role="group" aria-label="Input"><span class="arch-chip">Token Embeddings</span><span class="arch-chip">Positional Encoding</span></section>
+  <section class="arch-tier" data-label="Encoder Stack" role="group" aria-label="Encoder Stack"><span class="arch-chip is-primary">Multi-Head Attention</span><span class="arch-chip">Feed Forward</span><span class="arch-chip">Layer Norm</span></section>
+  <section class="arch-tier" data-label="Decoder Stack" role="group" aria-label="Decoder Stack"><span class="arch-chip">Masked Attention</span><span class="arch-chip is-primary">Cross Attention</span><span class="arch-chip">Feed Forward</span></section>
 </div>
 <figcaption>Token and position inputs move through the encoder stack before decoder attention combines masked and cross-attention paths.</figcaption>
 </figure>

--- a/src/posts/2024-06-11-zero-knowledge-authentication-homelab.md
+++ b/src/posts/2024-06-11-zero-knowledge-authentication-homelab.md
@@ -54,7 +54,7 @@ My homelab SSO replaces password transmission with ZK-SNARK proof generation and
 
 **System design:**
 
-<div class="flow">
+<div class="flow" role="group" aria-label="ZK-SNARK authentication flow">
   <div class="flow-node">User Browser</div>
   <div class="flow-node"><b>ZK Client</b><i>JavaScript; username, password local only</i></div>
   <div class="flow-node"><b>Proof Generator</b><i>zk-SNARK proof π</i></div>

--- a/src/posts/2024-06-25-designing-resilient-systems.md
+++ b/src/posts/2024-06-25-designing-resilient-systems.md
@@ -22,7 +22,7 @@ On paper, the system had everything — load balancers, database replicas, circu
 5. Circuit breakers open, but fallback services are also overwhelmed
 6. Total platform outage
 
-<div class="flow">
+<div class="flow" role="group" aria-label="Cascade failure sequence">
   <div class="flow-node is-bad">DB Timeout</div>
   <div class="flow-node">Connection Pools Fill Up</div>
   <div class="flow-node">Health Checks Fail</div>

--- a/src/posts/2024-07-16-sustainable-computing-carbon-footprint.md
+++ b/src/posts/2024-07-16-sustainable-computing-carbon-footprint.md
@@ -42,10 +42,10 @@ Computational demands were growing faster than efficiency improvements, meaning 
 Before optimizing, I needed to understand where the emissions were coming from. The following diagram illustrates the three emission scopes and how they relate to an organization's computing infrastructure:
 
 <figure class="arch-fig">
-<div class="arch" aria-label="Organization computing carbon footprint scopes">
-  <section class="arch-tier" data-label="Scope 1: Direct Energy Use"><span class="arch-chip">Office Electricity</span><span class="arch-chip">Backup Generators</span><span class="arch-chip">Company Vehicles</span></section>
-  <section class="arch-tier" data-label="Scope 2: Indirect Energy Use"><span class="arch-chip">Cloud Computing</span><span class="arch-chip">Purchased Electricity</span><span class="arch-chip">Cooling &amp; HVAC</span></section>
-  <section class="arch-tier" data-label="Scope 3: Supply Chain Emissions"><span class="arch-chip">Device Manufacturing</span><span class="arch-chip">Employee Commuting</span><span class="arch-chip">Third-Party Services</span></section>
+<div class="arch" role="group" aria-label="Organization computing carbon footprint scopes">
+  <section class="arch-tier" data-label="Scope 1: Direct Energy Use" role="group" aria-label="Scope 1: Direct Energy Use"><span class="arch-chip">Office Electricity</span><span class="arch-chip">Backup Generators</span><span class="arch-chip">Company Vehicles</span></section>
+  <section class="arch-tier" data-label="Scope 2: Indirect Energy Use" role="group" aria-label="Scope 2: Indirect Energy Use"><span class="arch-chip">Cloud Computing</span><span class="arch-chip">Purchased Electricity</span><span class="arch-chip">Cooling &amp; HVAC</span></section>
+  <section class="arch-tier" data-label="Scope 3: Supply Chain Emissions" role="group" aria-label="Scope 3: Supply Chain Emissions"><span class="arch-chip">Device Manufacturing</span><span class="arch-chip">Employee Commuting</span><span class="arch-chip">Third-Party Services</span></section>
 </div>
 <figcaption>An organization's computing carbon footprint spans direct energy, purchased energy, and supply-chain emissions.</figcaption>
 </figure>
@@ -86,7 +86,7 @@ Before optimizing, I needed to understand where the emissions were coming from. 
 
 The overall flow from energy consumption through to carbon impact follows this pattern:
 
-<div class="flow" aria-label="Carbon footprint measurement path">
+<div class="flow" role="group" aria-label="Carbon footprint measurement path">
   <div class="flow-node"><b>Energy Source</b><i>Grid / Renewable</i></div>
   <div class="flow-node"><b>Data Center</b><i>PUE Measurement</i></div>
   <div class="flow-node"><b>Compute Workload</b><i>CPU, GPU, Storage</i></div>
@@ -164,7 +164,7 @@ Choosing data center locations based on carbon intensity:
 
 The following diagram shows how carbon-aware workload scheduling interacts with renewable energy availability:
 
-<div class="flow" aria-label="Carbon-aware scheduling decision path">
+<div class="flow" role="group" aria-label="Carbon-aware scheduling decision path">
   <div class="flow-parallel">
     <div class="flow-node"><b>Solar Generation</b><i>Peak: 11AM-3PM</i></div>
     <div class="flow-node"><b>Wind Generation</b><i>Peak: 2AM-6AM</i></div>
@@ -174,9 +174,9 @@ The following diagram shows how carbon-aware workload scheduling interacts with 
   <div class="flow-node">Workload Queue</div>
   <div class="flow-node is-gate">Carbon Intensity Below Threshold?</div>
   <div class="flow-branch">
-    <div class="flow-leg" data-branch="Yes"><div class="flow-node is-good"><b>Run Workload Now</b><i>Low Carbon</i></div></div>
-    <div class="flow-leg" data-branch="No, deferrable"><div class="flow-node is-gate">Defer to Low-Carbon Window</div></div>
-    <div class="flow-leg" data-branch="No, urgent"><div class="flow-node">Migrate to Green Region</div></div>
+    <div class="flow-leg" data-branch="Yes" role="group" aria-label="Yes"><div class="flow-node is-good"><b>Run Workload Now</b><i>Low Carbon</i></div></div>
+    <div class="flow-leg" data-branch="No, deferrable" role="group" aria-label="No, deferrable"><div class="flow-node is-gate">Defer to Low-Carbon Window</div></div>
+    <div class="flow-leg" data-branch="No, urgent" role="group" aria-label="No, urgent"><div class="flow-node">Migrate to Green Region</div></div>
   </div>
 </div>
 

--- a/src/posts/2024-08-02-quantum-computing-leap-forward.md
+++ b/src/posts/2024-08-02-quantum-computing-leap-forward.md
@@ -18,7 +18,7 @@ That learning experience taught me something critical. Quantum computing isn't j
 
 ## How It Works
 
-<div class="flow" aria-label="Two-qubit quantum circuit path">
+<div class="flow" role="group" aria-label="Two-qubit quantum circuit path">
   <div class="flow-parallel">
     <div class="flow-node">Qubit 0: Zero State</div>
     <div class="flow-node">Qubit 1: Zero State</div>

--- a/src/posts/2024-08-13-high-performance-computing.md
+++ b/src/posts/2024-08-13-high-performance-computing.md
@@ -27,12 +27,12 @@ When the Department of Energy's Frontier system broke the exascale barrier in 20
 This convergence of power, efficiency, and accessibility is why I found myself standing in front of a supercomputer on a Tuesday afternoon, about to witness firsthand what happens when theoretical computational limits become engineering reality.
 
 <figure class="arch-fig">
-<div class="arch is-stack" aria-label="Compute cluster architecture">
-  <section class="arch-tier" data-label="Access"><span class="arch-chip">Users / Researchers</span></section>
-  <section class="arch-tier" data-label="Scheduling"><span class="arch-chip is-primary">Load Balancer / Job Scheduler</span></section>
-  <section class="arch-tier" data-label="Compute Cluster"><span class="arch-chip"><b>Compute Node 1</b><i>CPU + GPU</i></span><span class="arch-chip"><b>Compute Node 2</b><i>CPU + GPU</i></span><span class="arch-chip"><b>Compute Node N</b><i>CPU + GPU</i></span><span class="arch-chip is-guard"><b>High-Speed Interconnect</b><i>InfiniBand / Slingshot</i></span></section>
-  <section class="arch-tier" data-label="Shared Storage"><span class="arch-chip"><b>Parallel File System</b><i>Lustre / GPFS</i></span></section>
-  <section class="arch-tier" data-label="Long-Term Storage"><span class="arch-chip"><b>Object / Tape</b><i>archive tier</i></span></section>
+<div class="arch is-stack" role="group" aria-label="Compute cluster architecture">
+  <section class="arch-tier" data-label="Access" role="group" aria-label="Access"><span class="arch-chip">Users / Researchers</span></section>
+  <section class="arch-tier" data-label="Scheduling" role="group" aria-label="Scheduling"><span class="arch-chip is-primary">Load Balancer / Job Scheduler</span></section>
+  <section class="arch-tier" data-label="Compute Cluster" role="group" aria-label="Compute Cluster"><span class="arch-chip"><b>Compute Node 1</b><i>CPU + GPU</i></span><span class="arch-chip"><b>Compute Node 2</b><i>CPU + GPU</i></span><span class="arch-chip"><b>Compute Node N</b><i>CPU + GPU</i></span><span class="arch-chip is-guard"><b>High-Speed Interconnect</b><i>InfiniBand / Slingshot</i></span></section>
+  <section class="arch-tier" data-label="Shared Storage" role="group" aria-label="Shared Storage"><span class="arch-chip"><b>Parallel File System</b><i>Lustre / GPFS</i></span></section>
+  <section class="arch-tier" data-label="Long-Term Storage" role="group" aria-label="Long-Term Storage"><span class="arch-chip"><b>Object / Tape</b><i>archive tier</i></span></section>
 </div>
 <figcaption>Researchers submit work through the scheduler; compute nodes communicate over a high-speed fabric and write through the parallel file system to archival storage.</figcaption>
 </figure>
@@ -302,7 +302,7 @@ The integration between quantum and classical HPC systems has evolved rapidly ov
 - **Quantum Framework scaling**: Recent frameworks are working to coordinate hybrid workflows between classical nodes and quantum backends
 - **Unified quantum platforms**: Emerging platforms provide portable abstraction layers allowing quantum algorithms to run across different QPU architectures without code rewrites[11]
 
-<div class="flow" aria-label="Quantum-classical hybrid solving path">
+<div class="flow" role="group" aria-label="Quantum-classical hybrid solving path">
   <div class="flow-node">Problem Definition</div>
   <div class="flow-node"><b>Classical Preprocessor</b><i>Problem Decomposition</i></div>
   <div class="flow-parallel">
@@ -313,8 +313,8 @@ The integration between quantum and classical HPC systems has evolved rapidly ov
   <div class="flow-node"><b>Error Mitigation</b><i>Zero-Noise Extrapolation</i></div>
   <div class="flow-node is-gate">Converged?</div>
   <div class="flow-branch">
-    <div class="flow-leg" data-branch="No"><div class="flow-node is-gate"><b>Repeat Quantum Compile</b><i>run another iteration</i></div></div>
-    <div class="flow-leg" data-branch="Yes"><div class="flow-node is-good"><b>Result Aggregation</b><i>Final Solution</i></div></div>
+    <div class="flow-leg" data-branch="No" role="group" aria-label="No"><div class="flow-node is-gate"><b>Repeat Quantum Compile</b><i>run another iteration</i></div></div>
+    <div class="flow-leg" data-branch="Yes" role="group" aria-label="Yes"><div class="flow-node is-good"><b>Result Aggregation</b><i>Final Solution</i></div></div>
   </div>
 </div>
 

--- a/src/posts/2024-09-15-running-llama-raspberry-pi-pipeload.md
+++ b/src/posts/2024-09-15-running-llama-raspberry-pi-pipeload.md
@@ -99,7 +99,7 @@ Combined with layer unloading, peak memory usage drops by 90.3% for GPT-style mo
 
 ⚠️ **Warning:** This diagram demonstrates layer-wise loading architecture for educational purposes. Implementation requires proper memory management and hardware configuration.
 
-<div class="flow">
+<div class="flow" role="group" aria-label="PIPELOAD layer loading path">
   <div class="flow-node">Input Tokens</div>
   <div class="flow-node">Layer 0</div>
   <div class="flow-node">Unload Layer 0</div>

--- a/src/posts/2024-09-19-biomimetic-robotics.md
+++ b/src/posts/2024-09-19-biomimetic-robotics.md
@@ -39,7 +39,7 @@ The gecko's climbing ability, the octopus's ability to squeeze through tiny spac
 - Offload processing from CPUs to mechanical design
 - Let physics solve problems instead of software
 
-<div class="flow" aria-label="Biomimetic robotics design process">
+<div class="flow" role="group" aria-label="Biomimetic robotics design process">
   <div class="flow-node"><b>Biological System</b><i>Observation</i></div>
   <div class="flow-node"><b>Principle</b><i>Extraction</i></div>
   <div class="flow-node"><b>Computational</b><i>Modeling</i></div>
@@ -97,10 +97,10 @@ Bird and insect flight inspired breakthrough micro aerial vehicles. Engineers di
 - Deployable for exploration missions
 
 <figure class="arch-fig">
-<div class="arch" aria-label="Biological locomotion principle examples">
-  <section class="arch-tier" data-label="Legged (MIT Cheetah)"><span class="arch-chip">Dynamic balance</span><span class="arch-chip">Tendon energy storage</span><span class="arch-chip">6.4 m/s sprint</span></section>
-  <section class="arch-tier" data-label="Aerial (RoboBee / DALER)"><span class="arch-chip">Insect wing mechanics</span><span class="arch-chip">90 mg flight platform</span><span class="arch-chip">Dual air/ground modes</span></section>
-  <section class="arch-tier" data-label="Aquatic (Soft Robotic Fish)"><span class="arch-chip">Undulatory propulsion</span><span class="arch-chip">No propeller needed</span><span class="arch-chip">Minimal disturbance</span></section>
+<div class="arch" role="group" aria-label="Biological locomotion principle examples">
+  <section class="arch-tier" data-label="Legged (MIT Cheetah)" role="group" aria-label="Legged (MIT Cheetah)"><span class="arch-chip">Dynamic balance</span><span class="arch-chip">Tendon energy storage</span><span class="arch-chip">6.4 m/s sprint</span></section>
+  <section class="arch-tier" data-label="Aerial (RoboBee / DALER)" role="group" aria-label="Aerial (RoboBee / DALER)"><span class="arch-chip">Insect wing mechanics</span><span class="arch-chip">90 mg flight platform</span><span class="arch-chip">Dual air/ground modes</span></section>
+  <section class="arch-tier" data-label="Aquatic (Soft Robotic Fish)" role="group" aria-label="Aquatic (Soft Robotic Fish)"><span class="arch-chip">Undulatory propulsion</span><span class="arch-chip">No propeller needed</span><span class="arch-chip">Minimal disturbance</span></section>
 </div>
 <figcaption>Biological locomotion principles map into legged, aerial, and aquatic robot designs.</figcaption>
 </figure>

--- a/src/posts/2024-09-25-gvisor-container-sandboxing-security.md
+++ b/src/posts/2024-09-25-gvisor-container-sandboxing-security.md
@@ -47,11 +47,11 @@ Containers share the host kernel. One bad syscall can break containment. This is
 **But:** All these run in the kernel. Kernel bugs bypass them.
 
 <figure class="arch-fig">
-<div class="arch is-stack" aria-label="Traditional container isolation stack">
-  <section class="arch-tier" data-label="Workload"><span class="arch-chip is-primary">Container Process</span></section>
-  <section class="arch-tier" data-label="Kernel Isolation Controls"><span class="arch-chip is-guard">Namespaces</span><span class="arch-chip is-guard">Cgroups</span><span class="arch-chip is-guard">Seccomp-BPF</span><span class="arch-chip is-guard">AppArmor / SELinux</span></section>
-  <section class="arch-tier" data-label="Shared Boundary"><span class="arch-chip is-bad">Host Kernel</span></section>
-  <section class="arch-tier" data-label="Platform"><span class="arch-chip">Hardware</span></section>
+<div class="arch is-stack" role="group" aria-label="Traditional container isolation stack">
+  <section class="arch-tier" data-label="Workload" role="group" aria-label="Workload"><span class="arch-chip is-primary">Container Process</span></section>
+  <section class="arch-tier" data-label="Kernel Isolation Controls" role="group" aria-label="Kernel Isolation Controls"><span class="arch-chip is-guard">Namespaces</span><span class="arch-chip is-guard">Cgroups</span><span class="arch-chip is-guard">Seccomp-BPF</span><span class="arch-chip is-guard">AppArmor / SELinux</span></section>
+  <section class="arch-tier" data-label="Shared Boundary" role="group" aria-label="Shared Boundary"><span class="arch-chip is-bad">Host Kernel</span></section>
+  <section class="arch-tier" data-label="Platform" role="group" aria-label="Platform"><span class="arch-chip">Hardware</span></section>
 </div>
 <figcaption>Traditional containers add multiple guardrails, but every path still terminates at the shared host kernel.</figcaption>
 </figure>
@@ -84,10 +84,10 @@ Container → gVisor Sentry (userspace) → Host Kernel
 - Cannot access host filesystem directly
 
 <figure class="arch-fig">
-<div class="arch is-stack" aria-label="gVisor container sandbox architecture">
-  <section class="arch-tier" data-label="Container Sandbox"><span class="arch-chip is-primary">Container App</span></section>
-  <section class="arch-tier" data-label="gVisor Userspace Kernel"><span class="arch-chip is-guard"><b>Sentry</b><i>Go userspace kernel; 200+ syscalls reimplemented</i></span><span class="arch-chip is-guard"><b>Gofer</b><i>9P filesystem proxy; minimal privileges</i></span></section>
-  <section class="arch-tier" data-label="Host"><span class="arch-chip"><b>Host Kernel</b><i>limited syscall surface</i></span><span class="arch-chip">Host Filesystem</span></section>
+<div class="arch is-stack" role="group" aria-label="gVisor container sandbox architecture">
+  <section class="arch-tier" data-label="Container Sandbox" role="group" aria-label="Container Sandbox"><span class="arch-chip is-primary">Container App</span></section>
+  <section class="arch-tier" data-label="gVisor Userspace Kernel" role="group" aria-label="gVisor Userspace Kernel"><span class="arch-chip is-guard"><b>Sentry</b><i>Go userspace kernel; 200+ syscalls reimplemented</i></span><span class="arch-chip is-guard"><b>Gofer</b><i>9P filesystem proxy; minimal privileges</i></span></section>
+  <section class="arch-tier" data-label="Host" role="group" aria-label="Host"><span class="arch-chip"><b>Host Kernel</b><i>limited syscall surface</i></span><span class="arch-chip">Host Filesystem</span></section>
 </div>
 <figcaption>Container syscalls hit Sentry first; only safe host syscalls and scoped file requests continue into the host.</figcaption>
 </figure>
@@ -347,24 +347,24 @@ docker run --rm --runtime=runsc alpine sh -c "echo 'exploit' | tee /proc/self/me
 
 **My decision tree:**
 
-<div class="flow" aria-label="Container runtime selection decision path">
+<div class="flow" role="group" aria-label="Container runtime selection decision path">
   <div class="flow-node">New Workload</div>
   <div class="flow-node is-gate">Untrusted image?</div>
   <div class="flow-branch">
-    <div class="flow-leg" data-branch="Yes"><div class="flow-node is-good">Use gVisor</div></div>
-    <div class="flow-leg" data-branch="No"><div class="flow-node is-gate">Internet-facing?</div></div>
+    <div class="flow-leg" data-branch="Yes" role="group" aria-label="Yes"><div class="flow-node is-good">Use gVisor</div></div>
+    <div class="flow-leg" data-branch="No" role="group" aria-label="No"><div class="flow-node is-gate">Internet-facing?</div></div>
   </div>
   <div class="flow-branch">
-    <div class="flow-leg" data-branch="Yes"><div class="flow-node is-good">Use gVisor</div></div>
-    <div class="flow-leg" data-branch="No"><div class="flow-node is-gate">Needs native performance?</div></div>
+    <div class="flow-leg" data-branch="Yes" role="group" aria-label="Yes"><div class="flow-node is-good">Use gVisor</div></div>
+    <div class="flow-leg" data-branch="No" role="group" aria-label="No"><div class="flow-node is-gate">Needs native performance?</div></div>
   </div>
   <div class="flow-branch">
-    <div class="flow-leg" data-branch="Yes"><div class="flow-node">Use runc</div></div>
-    <div class="flow-leg" data-branch="No"><div class="flow-node is-gate">Syscall-heavy?</div></div>
+    <div class="flow-leg" data-branch="Yes" role="group" aria-label="Yes"><div class="flow-node">Use runc</div></div>
+    <div class="flow-leg" data-branch="No" role="group" aria-label="No"><div class="flow-node is-gate">Syscall-heavy?</div></div>
   </div>
   <div class="flow-branch">
-    <div class="flow-leg" data-branch="Yes"><div class="flow-node">Use runc</div></div>
-    <div class="flow-leg" data-branch="No"><div class="flow-node"><b>Use runc</b><i>principle of least surprise</i></div></div>
+    <div class="flow-leg" data-branch="Yes" role="group" aria-label="Yes"><div class="flow-node">Use runc</div></div>
+    <div class="flow-leg" data-branch="No" role="group" aria-label="No"><div class="flow-node"><b>Use runc</b><i>principle of least surprise</i></div></div>
   </div>
 </div>
 
@@ -438,12 +438,12 @@ G-Fuzz demonstrates that even secure-by-design systems need adversarial testing.
 - [Tetragon](https://github.com/cilium/tetragon) for eBPF observability
 
 <figure class="arch-fig">
-<div class="arch is-stack" aria-label="Container defense in depth stack">
-  <section class="arch-tier" data-label="Admission Control"><span class="arch-chip is-guard">OPA / Kyverno</span></section>
-  <section class="arch-tier" data-label="Runtime Sandbox"><span class="arch-chip is-primary">gVisor Sentry + Gofer</span></section>
-  <section class="arch-tier" data-label="Runtime Detection"><span class="arch-chip is-warn">Falco / Tetragon</span></section>
-  <section class="arch-tier" data-label="Network Policy"><span class="arch-chip is-guard">Cilium / Calico</span></section>
-  <section class="arch-tier" data-label="Vulnerability Scanning"><span class="arch-chip">Grype / Trivy</span></section>
+<div class="arch is-stack" role="group" aria-label="Container defense in depth stack">
+  <section class="arch-tier" data-label="Admission Control" role="group" aria-label="Admission Control"><span class="arch-chip is-guard">OPA / Kyverno</span></section>
+  <section class="arch-tier" data-label="Runtime Sandbox" role="group" aria-label="Runtime Sandbox"><span class="arch-chip is-primary">gVisor Sentry + Gofer</span></section>
+  <section class="arch-tier" data-label="Runtime Detection" role="group" aria-label="Runtime Detection"><span class="arch-chip is-warn">Falco / Tetragon</span></section>
+  <section class="arch-tier" data-label="Network Policy" role="group" aria-label="Network Policy"><span class="arch-chip is-guard">Cilium / Calico</span></section>
+  <section class="arch-tier" data-label="Vulnerability Scanning" role="group" aria-label="Vulnerability Scanning"><span class="arch-chip">Grype / Trivy</span></section>
 </div>
 <figcaption>Attackers should be blocked at admission or runtime, detected by monitoring, and contained by network policy before scanning closes the loop.</figcaption>
 </figure>

--- a/src/posts/2024-10-10-blockchain-beyond-cryptocurrency.md
+++ b/src/posts/2024-10-10-blockchain-beyond-cryptocurrency.md
@@ -26,11 +26,11 @@ That has implications far beyond finance, though I'm still figuring out where th
 ## How It Actually Works (From My Test Network)
 
 <figure class="arch-fig">
-<div class="arch is-stack" aria-label="Blockchain system layers">
-  <section class="arch-tier" data-label="Network Layer"><span class="arch-chip">P2P Network</span><span class="arch-chip">Gossip Protocol</span></section>
-  <section class="arch-tier" data-label="Consensus"><span class="arch-chip">Mining/Validation</span><span class="arch-chip is-primary">Consensus Algorithm</span></section>
-  <section class="arch-tier" data-label="Data Layer"><span class="arch-chip">Blocks</span><span class="arch-chip">Blockchain</span><span class="arch-chip">State Tree</span></section>
-  <section class="arch-tier" data-label="Application"><span class="arch-chip is-primary">Smart Contracts</span><span class="arch-chip">DApps</span></section>
+<div class="arch is-stack" role="group" aria-label="Blockchain system layers">
+  <section class="arch-tier" data-label="Network Layer" role="group" aria-label="Network Layer"><span class="arch-chip">P2P Network</span><span class="arch-chip">Gossip Protocol</span></section>
+  <section class="arch-tier" data-label="Consensus" role="group" aria-label="Consensus"><span class="arch-chip">Mining/Validation</span><span class="arch-chip is-primary">Consensus Algorithm</span></section>
+  <section class="arch-tier" data-label="Data Layer" role="group" aria-label="Data Layer"><span class="arch-chip">Blocks</span><span class="arch-chip">Blockchain</span><span class="arch-chip">State Tree</span></section>
+  <section class="arch-tier" data-label="Application" role="group" aria-label="Application"><span class="arch-chip is-primary">Smart Contracts</span><span class="arch-chip">DApps</span></section>
 </div>
 <figcaption>Blockchain systems build from peer networking through consensus and state storage into smart-contract applications.</figcaption>
 </figure>

--- a/src/posts/2024-11-15-gpu-power-monitoring-homelab-ml.md
+++ b/src/posts/2024-11-15-gpu-power-monitoring-homelab-ml.md
@@ -56,13 +56,13 @@ LLM Stack:
 I ran each test for at least 30 minutes to capture steady-state behavior. Repeated critical measurements three times for variability. The methodology isn't publication-worthy, but rigorous enough for decision-making.
 
 <figure>
-<div class="arch" aria-label="GPU power monitoring component zones">
-  <section class="arch-tier" data-label="Hardware Monitoring"><span class="arch-chip"><b>Kill-A-Watt P4400</b><i>Wall outlet</i></span><span class="arch-chip"><b>APC Back-UPS Pro 1500VA</b><i>Inline monitoring</i></span></section>
-  <section class="arch-tier" data-label="GPU Rig"><span class="arch-chip is-primary">RTX 3090 24GB</span><span class="arch-chip">i9-9900K</span><span class="arch-chip">EVGA 850W 80+ Gold</span></section>
-  <section class="arch-tier" data-label="Software Stack"><span class="arch-chip"><b>nvidia-smi</b><i>2s polling</i></span><span class="arch-chip">DCGM Exporter</span><span class="arch-chip"><b>Custom Python</b><i>logging scripts</i></span></section>
-  <section class="arch-tier" data-label="Observability"><span class="arch-chip">Prometheus</span><span class="arch-chip">Grafana Dashboards</span><span class="arch-chip is-warn">Telegram Alerts</span></section>
+<div class="arch" role="group" aria-label="GPU power monitoring component zones">
+  <section class="arch-tier" data-label="Hardware Monitoring" role="group" aria-label="Hardware Monitoring"><span class="arch-chip"><b>Kill-A-Watt P4400</b><i>Wall outlet</i></span><span class="arch-chip"><b>APC Back-UPS Pro 1500VA</b><i>Inline monitoring</i></span></section>
+  <section class="arch-tier" data-label="GPU Rig" role="group" aria-label="GPU Rig"><span class="arch-chip is-primary">RTX 3090 24GB</span><span class="arch-chip">i9-9900K</span><span class="arch-chip">EVGA 850W 80+ Gold</span></section>
+  <section class="arch-tier" data-label="Software Stack" role="group" aria-label="Software Stack"><span class="arch-chip"><b>nvidia-smi</b><i>2s polling</i></span><span class="arch-chip">DCGM Exporter</span><span class="arch-chip"><b>Custom Python</b><i>logging scripts</i></span></section>
+  <section class="arch-tier" data-label="Observability" role="group" aria-label="Observability"><span class="arch-chip">Prometheus</span><span class="arch-chip">Grafana Dashboards</span><span class="arch-chip is-warn">Telegram Alerts</span></section>
 </div>
-<div class="flow" aria-label="GPU telemetry collection path">
+<div class="flow" role="group" aria-label="GPU telemetry collection path">
   <div class="flow-parallel">
     <div class="flow-node"><b>Kill-A-Watt</b><i>total system watts</i></div>
     <div class="flow-node"><b>UPS</b><i>UPS metrics</i></div>
@@ -149,7 +149,7 @@ Continuous generation:
 Batching queries more than doubled efficiency. The reason seems to be reduced overhead: interactive mode involved constant model state changes, while batch processing kept the GPU consistently loaded. This discovery changed how I structure my workflows. I now accumulate questions and process them together rather than one-by-one.
 
 <figure>
-<div class="flow" aria-label="Interactive GPU query mode">
+<div class="flow" role="group" aria-label="Interactive GPU query mode">
   <div class="flow-node">Query 1</div>
   <div class="flow-node"><b>GPU Ramp Up</b><i>298W</i></div>
   <div class="flow-node">Response</div>
@@ -158,7 +158,7 @@ Batching queries more than doubled efficiency. The reason seems to be reduced ov
   <div class="flow-node"><b>GPU Ramp Up</b><i>298W</i></div>
   <div class="flow-node">Response</div>
 </div>
-<div class="flow" aria-label="Batch GPU query mode">
+<div class="flow" role="group" aria-label="Batch GPU query mode">
   <div class="flow-node"><b>50 Queries</b><i>Queued</i></div>
   <div class="flow-node is-good"><b>GPU Sustained</b><i>315W</i></div>
   <div class="flow-node"><b>All 50</b><i>Responses</i></div>
@@ -192,28 +192,28 @@ This failure taught me to add:
 These safeguards probably seem obvious to DevOps professionals, but they weren't part of my homelab muscle memory until this expensive lesson.
 
 <figure>
-<div class="flow" aria-label="GPU power alert response path">
+<div class="flow" role="group" aria-label="GPU power alert response path">
   <div class="flow-node"><b>GPU Running</b><i>Batch Job</i></div>
   <div class="flow-node"><b>Prometheus</b><i>scrapes nvidia-smi every 2s</i></div>
   <div class="flow-node is-gate"><b>Grafana Alert Rule</b><i>Power &gt; 300W for &gt; 2 hours?</i></div>
   <div class="flow-branch">
-    <div class="flow-leg" data-branch="No"><div class="flow-node">Continue Polling</div></div>
-    <div class="flow-leg" data-branch="Yes"><div class="flow-node is-gate">Telegram Notification</div></div>
+    <div class="flow-leg" data-branch="No" role="group" aria-label="No"><div class="flow-node">Continue Polling</div></div>
+    <div class="flow-leg" data-branch="Yes" role="group" aria-label="Yes"><div class="flow-node is-gate">Telegram Notification</div></div>
   </div>
   <div class="flow-node">Owner Checks</div>
   <div class="flow-node is-gate">Legitimate workload?</div>
   <div class="flow-branch">
-    <div class="flow-leg" data-branch="Yes"><div class="flow-node is-good">Snooze Alert</div></div>
-    <div class="flow-leg" data-branch="No"><div class="flow-node is-bad">Kill Runaway Job</div></div>
+    <div class="flow-leg" data-branch="Yes" role="group" aria-label="Yes"><div class="flow-node is-good">Snooze Alert</div></div>
+    <div class="flow-leg" data-branch="No" role="group" aria-label="No"><div class="flow-node is-bad">Kill Runaway Job</div></div>
   </div>
   <div class="flow-node"><b>Log Incident</b><i>+ Update Timeout</i></div>
 </div>
-<div class="flow" aria-label="GPU timeout abort path">
+<div class="flow" role="group" aria-label="GPU timeout abort path">
   <div class="flow-node"><b>GPU Running</b><i>also checked</i></div>
   <div class="flow-node is-gate">Job Timeout Exceeded?</div>
   <div class="flow-branch">
-    <div class="flow-leg" data-branch="Yes"><div class="flow-node is-bad"><b>Auto-Abort Job</b><i>+ Checkpoint State</i></div></div>
-    <div class="flow-leg" data-branch="No"><div class="flow-node">Continue Running</div></div>
+    <div class="flow-leg" data-branch="Yes" role="group" aria-label="Yes"><div class="flow-node is-bad"><b>Auto-Abort Job</b><i>+ Checkpoint State</i></div></div>
+    <div class="flow-leg" data-branch="No" role="group" aria-label="No"><div class="flow-node">Continue Running</div></div>
   </div>
 </div>
 <figcaption>The alert path handles sustained power draw while the timeout path catches jobs that run past the allowed wall clock.</figcaption>
@@ -249,23 +249,23 @@ The trade-off: CPU inference is slower (2.3 tokens/second vs 18.7), but for tiny
 
 For these micro-tasks, CPU is 4x more energy-efficient despite being slower. I'm not sure this would scale to longer queries, but for quick lookups, it's a clear win.
 
-<div class="flow" aria-label="Power-aware model routing decision path">
+<div class="flow" role="group" aria-label="Power-aware model routing decision path">
   <div class="flow-node">Incoming Query</div>
   <div class="flow-node is-gate">Token estimate?</div>
   <div class="flow-branch">
-    <div class="flow-leg" data-branch="&lt; 100 tokens"><div class="flow-node is-good"><b>Route to CPU</b><i>llama.cpp on i9-9900K; 95W / 2.3 tok/s</i></div></div>
-    <div class="flow-leg" data-branch="100+ tokens"><div class="flow-node is-gate">Task complexity?</div></div>
+    <div class="flow-leg" data-branch="&lt; 100 tokens" role="group" aria-label="&lt; 100 tokens"><div class="flow-node is-good"><b>Route to CPU</b><i>llama.cpp on i9-9900K; 95W / 2.3 tok/s</i></div></div>
+    <div class="flow-leg" data-branch="100+ tokens" role="group" aria-label="100+ tokens"><div class="flow-node is-gate">Task complexity?</div></div>
   </div>
   <div class="flow-branch">
-    <div class="flow-leg" data-branch="Simple summarization, Q&amp;A"><div class="flow-node is-good"><b>Phi-3 Mini 3.8B</b><i>276W avg</i></div></div>
-    <div class="flow-leg" data-branch="General chat, writing"><div class="flow-node"><b>Llama 3.1 8B</b><i>312W avg</i></div></div>
-    <div class="flow-leg" data-branch="Complex code gen, analysis"><div class="flow-node is-bad"><b>Llama 3.1 70B Q4</b><i>347W avg</i></div></div>
+    <div class="flow-leg" data-branch="Simple summarization, Q&amp;A" role="group" aria-label="Simple summarization, Q&amp;A"><div class="flow-node is-good"><b>Phi-3 Mini 3.8B</b><i>276W avg</i></div></div>
+    <div class="flow-leg" data-branch="General chat, writing" role="group" aria-label="General chat, writing"><div class="flow-node"><b>Llama 3.1 8B</b><i>312W avg</i></div></div>
+    <div class="flow-leg" data-branch="Complex code gen, analysis" role="group" aria-label="Complex code gen, analysis"><div class="flow-node is-bad"><b>Llama 3.1 70B Q4</b><i>347W avg</i></div></div>
   </div>
   <div class="flow-node">Return Response</div>
   <div class="flow-node is-gate">Idle &gt; 15 min?</div>
   <div class="flow-branch">
-    <div class="flow-leg" data-branch="Yes"><div class="flow-node is-good"><b>Unload Model</b><i>Drop to 52W baseline</i></div></div>
-    <div class="flow-leg" data-branch="No"><div class="flow-node"><b>Keep Model Loaded</b><i>87W standby</i></div></div>
+    <div class="flow-leg" data-branch="Yes" role="group" aria-label="Yes"><div class="flow-node is-good"><b>Unload Model</b><i>Drop to 52W baseline</i></div></div>
+    <div class="flow-leg" data-branch="No" role="group" aria-label="No"><div class="flow-node"><b>Keep Model Loaded</b><i>87W standby</i></div></div>
   </div>
 </div>
 

--- a/src/posts/2025-01-12-privacy-preserving-federated-learning-homelab.md
+++ b/src/posts/2025-01-12-privacy-preserving-federated-learning-homelab.md
@@ -32,7 +32,7 @@ Traditional machine learning requires aggregating all training data in one place
 This approach breaks privacy in obvious ways. If I'm training a medical diagnosis model, I need patient data from multiple hospitals. But centralizing that data means hospitals lose control, increase their breach surface, and violate privacy regulations.
 
 <figure>
-<div class="flow" aria-label="Centralized training data path">
+<div class="flow" role="group" aria-label="Centralized training data path">
   <div class="flow-parallel">
     <div class="flow-node">Hospital A Data</div>
     <div class="flow-node">Hospital B Data</div>
@@ -41,7 +41,7 @@ This approach breaks privacy in obvious ways. If I'm training a medical diagnosi
   <div class="flow-node is-bad"><b>Central Dataset</b><i>uploaded data</i></div>
   <div class="flow-node">Train Model</div>
 </div>
-<div class="flow" aria-label="Federated training update path">
+<div class="flow" role="group" aria-label="Federated training update path">
   <div class="flow-parallel">
     <div class="flow-node"><b>Hospital A Data</b><i>Local Model A</i></div>
     <div class="flow-node"><b>Hospital B Data</b><i>Local Model B</i></div>
@@ -253,7 +253,7 @@ pie title Training Round Time Breakdown (47 min total)
 
 ### Privacy Guarantees
 
-<div class="flow" aria-label="Granular-ball segmentation privacy path">
+<div class="flow" role="group" aria-label="Granular-ball segmentation privacy path">
   <div class="flow-node"><b>Raw Training Data</b><i>Individual examples</i></div>
   <div class="flow-node">Granular-Ball Segmentation</div>
   <div class="flow-parallel">
@@ -263,8 +263,8 @@ pie title Training Round Time Breakdown (47 min total)
   </div>
   <div class="flow-node is-gate">Variance &gt; threshold?</div>
   <div class="flow-branch">
-    <div class="flow-leg" data-branch="Yes"><div class="flow-node is-good"><b>Shared with aggregator</b><i>Aggregation Server</i></div></div>
-    <div class="flow-leg" data-branch="No"><div class="flow-node is-bad">Dropped — never leaves device</div></div>
+    <div class="flow-leg" data-branch="Yes" role="group" aria-label="Yes"><div class="flow-node is-good"><b>Shared with aggregator</b><i>Aggregation Server</i></div></div>
+    <div class="flow-leg" data-branch="No" role="group" aria-label="No"><div class="flow-node is-bad">Dropped — never leaves device</div></div>
   </div>
   <div class="flow-parallel">
     <div class="flow-node is-good"><b>Reconstruction Attack</b><i>Fails</i></div>

--- a/src/posts/2025-01-22-llm-security-alert-triage-local.md
+++ b/src/posts/2025-01-22-llm-security-alert-triage-local.md
@@ -48,7 +48,7 @@ names, internal network topology. Local LLM inference keeps all data in homelab.
 
 **Ollama architecture:**
 
-<div class="flow">
+<div class="flow" role="group" aria-label="Ollama alert triage architecture">
   <div class="flow-node"><b>Security Alerts</b><i>Wazuh / Suricata JSON</i></div>
   <div class="flow-node"><b>Alert Processor</b><i>Python prompt</i></div>
   <div class="flow-node"><b>Ollama Server</b><i>local LLM; NVIDIA GPU inference, 8GB VRAM</i></div>
@@ -222,7 +222,7 @@ Large Language Models benefit from context. Retrieval-Augmented Generation (RAG)
 
 **RAG architecture:**
 
-<div class="flow">
+<div class="flow" role="group" aria-label="RAG alert context pipeline">
   <div class="flow-node">New Alert</div>
   <div class="flow-node"><b>Vector DB</b><i>Chroma query; 30 days historical alert embeddings</i></div>
   <div class="flow-node"><b>Context Builder</b><i>similar alerts + MISP / OTX IOCs</i></div>

--- a/src/posts/2025-06-25-local-llm-deployment-privacy-first.md
+++ b/src/posts/2025-06-25-local-llm-deployment-privacy-first.md
@@ -21,11 +21,11 @@ I run local LLMs up to 34B parameters on my RTX 3090 (24GB VRAM), completely off
 ## Local LLM Architecture
 
 <figure class="arch-fig">
-<div class="arch is-stack" aria-label="Local LLM deployment architecture">
-  <section class="arch-tier" data-label="Hardware"><span class="arch-chip is-primary">GPU/TPU</span><span class="arch-chip">CPU</span><span class="arch-chip">Memory</span></section>
-  <section class="arch-tier" data-label="Model Layer"><span class="arch-chip">Model Files</span><span class="arch-chip">Weights</span><span class="arch-chip">Configuration</span></section>
-  <section class="arch-tier" data-label="Inference"><span class="arch-chip is-primary">Inference Engine</span><span class="arch-chip">Token Cache</span><span class="arch-chip">Batch Processing</span></section>
-  <section class="arch-tier" data-label="Interface"><span class="arch-chip is-primary">REST API</span><span class="arch-chip">Web UI</span><span class="arch-chip">CLI Tool</span></section>
+<div class="arch is-stack" role="group" aria-label="Local LLM deployment architecture">
+  <section class="arch-tier" data-label="Hardware" role="group" aria-label="Hardware"><span class="arch-chip is-primary">GPU/TPU</span><span class="arch-chip">CPU</span><span class="arch-chip">Memory</span></section>
+  <section class="arch-tier" data-label="Model Layer" role="group" aria-label="Model Layer"><span class="arch-chip">Model Files</span><span class="arch-chip">Weights</span><span class="arch-chip">Configuration</span></section>
+  <section class="arch-tier" data-label="Inference" role="group" aria-label="Inference"><span class="arch-chip is-primary">Inference Engine</span><span class="arch-chip">Token Cache</span><span class="arch-chip">Batch Processing</span></section>
+  <section class="arch-tier" data-label="Interface" role="group" aria-label="Interface"><span class="arch-chip is-primary">REST API</span><span class="arch-chip">Web UI</span><span class="arch-chip">CLI Tool</span></section>
 </div>
 <figcaption>Hardware and model files feed the inference engine, which exposes batch output through local API, web, and CLI interfaces.</figcaption>
 </figure>

--- a/src/posts/2025-07-01-ebpf-security-monitoring-practical-guide.md
+++ b/src/posts/2025-07-01-ebpf-security-monitoring-practical-guide.md
@@ -28,10 +28,10 @@ Imagine having X-ray vision into your kernel, seeing every system call, network 
 ⚠️ **Warning:** The following diagrams and examples demonstrate security monitoring concepts for educational purposes. eBPF programs require kernel privileges and should only be deployed in controlled environments with proper authorization.
 
 <figure class="arch-fig">
-<div class="arch is-stack" aria-label="eBPF security monitoring architecture">
-  <section class="arch-tier" data-label="Attack Surface"><span class="arch-chip">Process Execution</span><span class="arch-chip">Network Connections</span><span class="arch-chip">File Operations</span><span class="arch-chip">Privilege Changes</span></section>
-  <section class="arch-tier" data-label="Kernel Space"><span class="arch-chip">Kernel Probes</span><span class="arch-chip is-primary">eBPF VM</span><span class="arch-chip">BPF Maps</span><span class="arch-chip is-guard">BPF Verifier</span></section>
-  <section class="arch-tier" data-label="User Space"><span class="arch-chip">BPF Loader</span><span class="arch-chip">Event Monitor</span><span class="arch-chip is-primary">AI/ML Analysis</span><span class="arch-chip is-primary">SIEM Integration</span></section>
+<div class="arch is-stack" role="group" aria-label="eBPF security monitoring architecture">
+  <section class="arch-tier" data-label="Attack Surface" role="group" aria-label="Attack Surface"><span class="arch-chip">Process Execution</span><span class="arch-chip">Network Connections</span><span class="arch-chip">File Operations</span><span class="arch-chip">Privilege Changes</span></section>
+  <section class="arch-tier" data-label="Kernel Space" role="group" aria-label="Kernel Space"><span class="arch-chip">Kernel Probes</span><span class="arch-chip is-primary">eBPF VM</span><span class="arch-chip">BPF Maps</span><span class="arch-chip is-guard">BPF Verifier</span></section>
+  <section class="arch-tier" data-label="User Space" role="group" aria-label="User Space"><span class="arch-chip">BPF Loader</span><span class="arch-chip">Event Monitor</span><span class="arch-chip is-primary">AI/ML Analysis</span><span class="arch-chip is-primary">SIEM Integration</span></section>
 </div>
 <figcaption>Kernel probes collect activity, the verifier gates safe eBPF execution, and user-space monitors poll maps for analysis and SIEM delivery.</figcaption>
 </figure>
@@ -43,7 +43,7 @@ Let me share a story from my research lab. I once set up a honeypot with traditi
 With eBPF monitoring on an identical honeypot, the same attack was detected in 1.3 seconds. Here's what makes the difference:
 
 <figure>
-<div class="flow" aria-label="Traditional monitoring latency path">
+<div class="flow" role="group" aria-label="Traditional monitoring latency path">
   <div class="flow-parallel">
     <div class="flow-node"><b>Application Logs</b><i>Delayed</i></div>
     <div class="flow-node"><b>System Logs</b><i>Can be tampered</i></div>
@@ -52,7 +52,7 @@ With eBPF monitoring on an identical honeypot, the same attack was detected in 1
   <div class="flow-node">SIEM Aggregation</div>
   <div class="flow-node is-bad"><b>Alert Generation</b><i>Minutes to hours</i></div>
 </div>
-<div class="flow" aria-label="eBPF monitoring latency path">
+<div class="flow" role="group" aria-label="eBPF monitoring latency path">
   <div class="flow-node"><b>Kernel Events</b><i>Nanoseconds</i></div>
   <div class="flow-node"><b>Real-time Processing</b><i>Microseconds</i></div>
   <div class="flow-node"><b>In-kernel Filtering</b><i>Milliseconds</i></div>

--- a/src/posts/2025-07-15-vulnerability-management-scale-open-source.md
+++ b/src/posts/2025-07-15-vulnerability-management-scale-open-source.md
@@ -41,11 +41,11 @@ Open source vulnerability management can match enterprise capabilities at zero l
 Modern vulnerability management requires defense-in-depth strategies. Learn more about [implementing zero-trust architecture](/posts/2024-07-09-zero-trust-architecture-implementation) to complement vulnerability scanning with access controls.
 
 <figure class="arch-fig">
-<div class="arch is-stack" aria-label="Open source vulnerability management pipeline architecture">
-  <section class="arch-tier" data-label="Data Collection"><span class="arch-chip">NVD Database</span><span class="arch-chip">CVE/MITRE</span><span class="arch-chip">GitHub Advisory</span><span class="arch-chip">OSV Database</span></section>
-  <section class="arch-tier" data-label="Processing Pipeline"><span class="arch-chip is-primary">Data Collector</span><span class="arch-chip">CVE Parser</span><span class="arch-chip">Data Enricher</span><span class="arch-chip is-warn">Risk Scorer</span></section>
-  <section class="arch-tier" data-label="Storage &amp; Analysis"><span class="arch-chip">PostgreSQL</span><span class="arch-chip">Redis Cache</span><span class="arch-chip">ML Analysis</span></section>
-  <section class="arch-tier" data-label="Output"><span class="arch-chip">REST API</span><span class="arch-chip">Dashboard</span><span class="arch-chip is-bad">Alert System</span></section>
+<div class="arch is-stack" role="group" aria-label="Open source vulnerability management pipeline architecture">
+  <section class="arch-tier" data-label="Data Collection" role="group" aria-label="Data Collection"><span class="arch-chip">NVD Database</span><span class="arch-chip">CVE/MITRE</span><span class="arch-chip">GitHub Advisory</span><span class="arch-chip">OSV Database</span></section>
+  <section class="arch-tier" data-label="Processing Pipeline" role="group" aria-label="Processing Pipeline"><span class="arch-chip is-primary">Data Collector</span><span class="arch-chip">CVE Parser</span><span class="arch-chip">Data Enricher</span><span class="arch-chip is-warn">Risk Scorer</span></section>
+  <section class="arch-tier" data-label="Storage &amp; Analysis" role="group" aria-label="Storage &amp; Analysis"><span class="arch-chip">PostgreSQL</span><span class="arch-chip">Redis Cache</span><span class="arch-chip">ML Analysis</span></section>
+  <section class="arch-tier" data-label="Output" role="group" aria-label="Output"><span class="arch-chip">REST API</span><span class="arch-chip">Dashboard</span><span class="arch-chip is-bad">Alert System</span></section>
 </div>
 <figcaption>Advisory feeds move through collection, parsing, enrichment, and scoring before storage-backed analysis drives APIs, dashboards, and alerts.</figcaption>
 </figure>

--- a/src/posts/2025-07-22-supercharging-claude-cli-with-standards.md
+++ b/src/posts/2025-07-22-supercharging-claude-cli-with-standards.md
@@ -109,7 +109,7 @@ git commit -m "Add user auth"
 
 The standards system works through a context-aware loading pipeline that detects what you are working on and serves relevant standards:
 
-<div class="flow">
+<div class="flow" role="group" aria-label="Standards context loading pipeline">
   <div class="flow-node"><b>Developer Input</b><i>'I'm building a secure API'</i></div>
   <div class="flow-node">Context Detection</div>
   <div class="flow-node"><b>Parse Project Signals</b><i>files, imports, config</i></div>
@@ -321,7 +321,7 @@ curl -O [https://raw.githubusercontent.com/williamzujkowski/standards/master/doc
 
 The following diagram shows the evolution of CLAUDE.md and the standards system over six months:
 
-<div class="flow">
+<div class="flow" role="group" aria-label="Standards system evolution">
   <div class="flow-node is-bad"><b>v1.0</b><i>120 lines, Python only; 87 violations found, 4.5 hrs to fix</i></div>
   <div class="flow-node"><b>v2.0</b><i>~800 lines, multi-language; 312 flagged, 88% false positives</i></div>
   <div class="flow-node is-good"><b>v3.0</b><i>2,847 lines, full enforcement; FP rate: 4%, 12s validation</i></div>

--- a/src/posts/2025-07-29-building-mcp-standards-server.md
+++ b/src/posts/2025-07-29-building-mcp-standards-server.md
@@ -127,7 +127,7 @@ I may have overdone it.
 
 The architecture grew from a simple pipe to a multi-layered system across four versions:
 
-<div class="flow" aria-label="MCP standards server architecture evolution">
+<div class="flow" role="group" aria-label="MCP standards server architecture evolution">
   <div class="flow-node"><b>Version 1: Simple</b><i>stdio in/out, load standards, return to Claude; 200 lines</i></div>
   <div class="flow-node"><b>Version 2: + Redis</b><i>stdio, Redis L1/L2 cache, load standards, return; 1,200 lines</i></div>
   <div class="flow-node"><b>Version 3: + Vector Search</b><i>stdio, Redis cache, ChromaDB vector search, standards; 3,800 lines</i></div>
@@ -183,10 +183,10 @@ mcp-standards validate src/ --language auto
 The following diagram shows how the MCP server registers and exposes tools to the LLM client:
 
 <figure class="arch-fig">
-<div class="arch is-stack" aria-label="MCP standards server tool exposure architecture">
-  <section class="arch-tier" data-label="Client"><span class="arch-chip is-primary">Claude CLI / Desktop LLM</span><span class="arch-chip">tools/list</span><span class="arch-chip">tools/call</span></section>
-  <section class="arch-tier" data-label="Transport Layer"><span class="arch-chip">stdio (local)</span><span class="arch-chip">HTTP/SSE (remote)</span></section>
-  <section class="arch-tier" data-label="MCP Standards Server"><span class="arch-chip is-primary">Tool Registry</span><span class="arch-chip"><b>get_standard</b><i>retrieve by name</i></span><span class="arch-chip"><b>search_standards</b><i>semantic + keyword</i></span><span class="arch-chip"><b>validate_code</b><i>multi-language lint</i></span><span class="arch-chip"><b>check_compliance</b><i>NIST 800-53r5</i></span><span class="arch-chip"><b>list_standards</b><i>discovery</i></span></section>
+<div class="arch is-stack" role="group" aria-label="MCP standards server tool exposure architecture">
+  <section class="arch-tier" data-label="Client" role="group" aria-label="Client"><span class="arch-chip is-primary">Claude CLI / Desktop LLM</span><span class="arch-chip">tools/list</span><span class="arch-chip">tools/call</span></section>
+  <section class="arch-tier" data-label="Transport Layer" role="group" aria-label="Transport Layer"><span class="arch-chip">stdio (local)</span><span class="arch-chip">HTTP/SSE (remote)</span></section>
+  <section class="arch-tier" data-label="MCP Standards Server" role="group" aria-label="MCP Standards Server"><span class="arch-chip is-primary">Tool Registry</span><span class="arch-chip"><b>get_standard</b><i>retrieve by name</i></span><span class="arch-chip"><b>search_standards</b><i>semantic + keyword</i></span><span class="arch-chip"><b>validate_code</b><i>multi-language lint</i></span><span class="arch-chip"><b>check_compliance</b><i>NIST 800-53r5</i></span><span class="arch-chip"><b>list_standards</b><i>discovery</i></span></section>
 </div>
 <figcaption>The client discovers and calls tools through the transport layer; the server registry owns the exposed standards operations.</figcaption>
 </figure>
@@ -214,21 +214,21 @@ standard = get_standard("react-patterns", format="compressed")
 ## The Struggles (Learning Moments)
 
 <figure class="arch-fig">
-<div class="flow" aria-label="Redis L1 and L2 cache lookup path">
+<div class="flow" role="group" aria-label="Redis L1 and L2 cache lookup path">
   <div class="flow-node">Incoming Request</div>
   <div class="flow-node is-gate"><b>L1 Cache</b><i>in-memory</i></div>
   <div class="flow-branch">
-    <div class="flow-leg" data-branch="Hit"><div class="flow-node is-good">Return Cached</div></div>
-    <div class="flow-leg" data-branch="Miss"><div class="flow-node"><b>L2 Cache</b><i>Redis</i></div></div>
+    <div class="flow-leg" data-branch="Hit" role="group" aria-label="Hit"><div class="flow-node is-good">Return Cached</div></div>
+    <div class="flow-leg" data-branch="Miss" role="group" aria-label="Miss"><div class="flow-node"><b>L2 Cache</b><i>Redis</i></div></div>
   </div>
   <div class="flow-node is-gate">L2 Result</div>
   <div class="flow-branch">
-    <div class="flow-leg" data-branch="Hit"><div class="flow-node is-good"><b>Promote to L1</b><i>return cached</i></div></div>
-    <div class="flow-leg" data-branch="Miss"><div class="flow-node"><b>Load from Disk</b><i>store in L1 + L2 with 30-min TTL</i></div></div>
+    <div class="flow-leg" data-branch="Hit" role="group" aria-label="Hit"><div class="flow-node is-good"><b>Promote to L1</b><i>return cached</i></div></div>
+    <div class="flow-leg" data-branch="Miss" role="group" aria-label="Miss"><div class="flow-node"><b>Load from Disk</b><i>store in L1 + L2 with 30-min TTL</i></div></div>
   </div>
 </div>
-<div class="arch" aria-label="Redis cache eviction policy">
-  <section class="arch-tier" data-label="Eviction Policy"><span class="arch-chip is-guard">30-min TTL expiry</span><span class="arch-chip is-guard">LRU when maxmemory hits 64MB</span><span class="arch-chip is-guard">Manual invalidation on standards update</span></section>
+<div class="arch" role="group" aria-label="Redis cache eviction policy">
+  <section class="arch-tier" data-label="Eviction Policy" role="group" aria-label="Eviction Policy"><span class="arch-chip is-guard">30-min TTL expiry</span><span class="arch-chip is-guard">LRU when maxmemory hits 64MB</span><span class="arch-chip is-guard">Manual invalidation on standards update</span></section>
 </div>
 <figcaption>The cache path handles request lookup, while the policy view shows the independent eviction controls.</figcaption>
 </figure>

--- a/src/posts/2025-08-07-supercharging-development-claude-flow.md
+++ b/src/posts/2025-08-07-supercharging-development-claude-flow.md
@@ -48,10 +48,10 @@ Claude-Flow supports multiple swarm topologies, each optimized for different sce
 ## System Architecture Overview
 
 <figure class="arch-fig">
-<div class="arch is-stack" aria-label="Claude-Flow swarm architecture">
-  <section class="arch-tier" data-label="Swarm Topologies"><span class="arch-chip">Mesh - P2P Collaboration</span><span class="arch-chip">Hierarchical - Queen/Worker</span><span class="arch-chip">Ring - Sequential Pipeline</span><span class="arch-chip">Star - Centralized Control</span></section>
-  <section class="arch-tier" data-label="Core Agents"><span class="arch-chip is-primary">🎭 Orchestrator</span><span class="arch-chip">🔍 Researcher</span><span class="arch-chip">🏗️ Architect</span><span class="arch-chip">💻 Coder</span><span class="arch-chip">🧪 Tester</span></section>
-  <section class="arch-tier" data-label="Intelligence Layer"><span class="arch-chip is-guard">💾 Persistent Memory</span><span class="arch-chip is-guard">🧠 Neural Training</span><span class="arch-chip is-guard">🔄 Pattern Recognition</span></section>
+<div class="arch is-stack" role="group" aria-label="Claude-Flow swarm architecture">
+  <section class="arch-tier" data-label="Swarm Topologies" role="group" aria-label="Swarm Topologies"><span class="arch-chip">Mesh - P2P Collaboration</span><span class="arch-chip">Hierarchical - Queen/Worker</span><span class="arch-chip">Ring - Sequential Pipeline</span><span class="arch-chip">Star - Centralized Control</span></section>
+  <section class="arch-tier" data-label="Core Agents" role="group" aria-label="Core Agents"><span class="arch-chip is-primary">🎭 Orchestrator</span><span class="arch-chip">🔍 Researcher</span><span class="arch-chip">🏗️ Architect</span><span class="arch-chip">💻 Coder</span><span class="arch-chip">🧪 Tester</span></section>
+  <section class="arch-tier" data-label="Intelligence Layer" role="group" aria-label="Intelligence Layer"><span class="arch-chip is-guard">💾 Persistent Memory</span><span class="arch-chip is-guard">🧠 Neural Training</span><span class="arch-chip is-guard">🔄 Pattern Recognition</span></section>
 </div>
 <figcaption>Topology choices feed the orchestrator, which coordinates specialized agents and writes learning back into the intelligence layer.</figcaption>
 </figure>
@@ -104,7 +104,7 @@ Memory persistence adds overhead, and token costs scale with context size.
 
 ## SPARC Development Methodology
 
-<div class="flow">
+<div class="flow" role="group" aria-label="SPARC development methodology">
   <div class="flow-node"><b>📋 Specification</b><i>Define Requirements</i></div>
   <div class="flow-node"><b>🔢 Pseudocode</b><i>Design Algorithms</i></div>
   <div class="flow-node"><b>🏛️ Architecture</b><i>System Structure</i></div>

--- a/src/posts/2025-08-09-ai-cognitive-infrastructure.md
+++ b/src/posts/2025-08-09-ai-cognitive-infrastructure.md
@@ -26,14 +26,14 @@ According to [Giuseppe Riva's groundbreaking research](https://arxiv.org/abs/250
 ⚠️ **Warning:** These diagrams illustrate AI cognitive infrastructure concepts for educational analysis. Understanding these systems' influence requires critical evaluation and awareness of algorithmic mediation.
 
 <figure class="arch-fig">
-<div class="flow" aria-label="Traditional infrastructure enablement path">
+<div class="flow" role="group" aria-label="Traditional infrastructure enablement path">
   <div class="flow-parallel">
     <div class="flow-node"><b>Physical Roads</b><i>enable commerce</i></div>
     <div class="flow-node"><b>Electricity Grid</b><i>powers industry</i></div>
     <div class="flow-node"><b>Telecommunications</b><i>enable communication</i></div>
   </div>
 </div>
-<div class="flow" aria-label="Cognitive infrastructure mediation path">
+<div class="flow" role="group" aria-label="Cognitive infrastructure mediation path">
   <div class="flow-parallel">
     <div class="flow-node">AI Systems</div>
     <div class="flow-node">Machine Learning</div>
@@ -93,7 +93,7 @@ The concept of "epistemic agency" (your ability to determine what's true and rel
 
 ⚠️ **Warning:** This diagram demonstrates how AI systems influence information access and decision-making. Users should maintain awareness of algorithmic filtering and actively seek diverse information sources.
 
-<div class="flow" aria-label="AI-mediated information access path">
+<div class="flow" role="group" aria-label="AI-mediated information access path">
   <div class="flow-node">User Query/Interest</div>
   <div class="flow-node is-gate">AI Analysis</div>
   <div class="flow-parallel">
@@ -102,9 +102,9 @@ The concept of "epistemic agency" (your ability to determine what's true and rel
     <div class="flow-node"><b>Personalization</b><i>filter bubble / echo chamber</i></div>
   </div>
   <div class="flow-branch">
-    <div class="flow-leg" data-branch="Seen"><div class="flow-node is-good">User Decision</div></div>
-    <div class="flow-leg" data-branch="Filtered"><div class="flow-node is-bad"><b>Lost Possibilities</b><i>never seen or rarely seen</i></div></div>
-    <div class="flow-leg" data-branch="Reinforced"><div class="flow-node">Echo Chamber</div></div>
+    <div class="flow-leg" data-branch="Seen" role="group" aria-label="Seen"><div class="flow-node is-good">User Decision</div></div>
+    <div class="flow-leg" data-branch="Filtered" role="group" aria-label="Filtered"><div class="flow-node is-bad"><b>Lost Possibilities</b><i>never seen or rarely seen</i></div></div>
+    <div class="flow-leg" data-branch="Reinforced" role="group" aria-label="Reinforced"><div class="flow-node">Echo Chamber</div></div>
   </div>
 </div>
 

--- a/src/posts/2025-08-18-docker-lsm-security-hardening.md
+++ b/src/posts/2025-08-18-docker-lsm-security-hardening.md
@@ -37,15 +37,15 @@ FS privilege escalation
 
 **What I needed:** Defense-in-depth without K8s. Standalone Docker hardening using Linux Security Modules (LSM), seccomp, capabilities, and filesystem restrictions.
 
-<div class="flow" aria-label="Container syscall security checkpoints">
+<div class="flow" role="group" aria-label="Container syscall security checkpoints">
   <div class="flow-node"><b>Docker Container</b><i>application process in user space</i></div>
   <div class="flow-node"><b>Syscall Entry</b><i>open, mount, ptrace</i></div>
   <div class="flow-node is-gate">LSM Hooks</div>
   <div class="flow-node is-gate">Seccomp BPF</div>
   <div class="flow-node is-gate">Capability Check</div>
   <div class="flow-branch">
-    <div class="flow-leg" data-branch="Denied"><div class="flow-node is-bad"><b>EACCES / EPERM</b><i>operation blocked</i></div></div>
-    <div class="flow-leg" data-branch="Allowed"><div class="flow-node is-good">Execute Syscall</div></div>
+    <div class="flow-leg" data-branch="Denied" role="group" aria-label="Denied"><div class="flow-node is-bad"><b>EACCES / EPERM</b><i>operation blocked</i></div></div>
+    <div class="flow-leg" data-branch="Allowed" role="group" aria-label="Allowed"><div class="flow-node is-good">Execute Syscall</div></div>
   </div>
 </div>
 
@@ -94,7 +94,7 @@ I combine multiple isolation mechanisms for defense-in-depth. If attacker bypass
 
 **Security layers:**
 
-<div class="flow">
+<div class="flow" role="group" aria-label="Layered Docker security controls">
   <div class="flow-node">Docker Container</div>
   <div class="flow-node is-bad"><b>Attacker with RCE</b><i>try to escape</i></div>
   <div class="flow-node"><b>Layer 1: AppArmor Profile</b><i>file system access control</i></div>

--- a/src/posts/2025-08-25-network-traffic-analysis-suricata-homelab.md
+++ b/src/posts/2025-08-25-network-traffic-analysis-suricata-homelab.md
@@ -24,11 +24,11 @@ That's the case for Suricata in one line: you can't protect what you can't see. 
 ⚠️ **Warning:** Network traffic analysis must comply with privacy laws and organizational policies. Deploy only on networks you own or have explicit authorization to monitor.
 
 <figure class="arch-fig">
-<div class="arch is-stack" aria-label="Suricata traffic analysis architecture">
-  <section class="arch-tier" data-label="Traffic Collection"><span class="arch-chip">Port Mirroring</span><span class="arch-chip">Network TAP</span><span class="arch-chip">SPAN Port</span></section>
-  <section class="arch-tier" data-label="Rule Management"><span class="arch-chip is-guard">Emerging Threats</span><span class="arch-chip is-guard">Custom Rules</span><span class="arch-chip is-guard">ET Pro Rules</span><span class="arch-chip is-guard">Rule Updates</span></section>
-  <section class="arch-tier" data-label="Suricata Engine"><span class="arch-chip">Packet Capture</span><span class="arch-chip">Protocol Decoder</span><span class="arch-chip is-primary">Detection Engine</span><span class="arch-chip">Event Logger</span></section>
-  <section class="arch-tier" data-label="Analysis &amp; Response"><span class="arch-chip">EVE JSON Logs</span><span class="arch-chip">Filebeat Shipper</span><span class="arch-chip">Elasticsearch</span><span class="arch-chip">Kibana Dashboard</span><span class="arch-chip">Wazuh SIEM</span></section>
+<div class="arch is-stack" role="group" aria-label="Suricata traffic analysis architecture">
+  <section class="arch-tier" data-label="Traffic Collection" role="group" aria-label="Traffic Collection"><span class="arch-chip">Port Mirroring</span><span class="arch-chip">Network TAP</span><span class="arch-chip">SPAN Port</span></section>
+  <section class="arch-tier" data-label="Rule Management" role="group" aria-label="Rule Management"><span class="arch-chip is-guard">Emerging Threats</span><span class="arch-chip is-guard">Custom Rules</span><span class="arch-chip is-guard">ET Pro Rules</span><span class="arch-chip is-guard">Rule Updates</span></section>
+  <section class="arch-tier" data-label="Suricata Engine" role="group" aria-label="Suricata Engine"><span class="arch-chip">Packet Capture</span><span class="arch-chip">Protocol Decoder</span><span class="arch-chip is-primary">Detection Engine</span><span class="arch-chip">Event Logger</span></section>
+  <section class="arch-tier" data-label="Analysis &amp; Response" role="group" aria-label="Analysis &amp; Response"><span class="arch-chip">EVE JSON Logs</span><span class="arch-chip">Filebeat Shipper</span><span class="arch-chip">Elasticsearch</span><span class="arch-chip">Kibana Dashboard</span><span class="arch-chip">Wazuh SIEM</span></section>
 </div>
 <figcaption>Traffic collection feeds Suricata, rule sources shape detection, and EVE logs move into search, dashboards, and SIEM response.</figcaption>
 </figure>

--- a/src/posts/2025-09-01-self-hosted-bitwarden-migration-guide.md
+++ b/src/posts/2025-09-01-self-hosted-bitwarden-migration-guide.md
@@ -22,17 +22,17 @@ tags:
 ## Self-Hosted Password Management Architecture
 
 <figure class="arch-fig">
-<div class="arch is-stack" aria-label="Self-hosted Bitwarden serving architecture">
-  <section class="arch-tier" data-label="Client Access"><span class="arch-chip">Web Vault</span><span class="arch-chip">Mobile Apps</span><span class="arch-chip">Desktop Apps</span><span class="arch-chip">Browser Extensions</span></section>
-  <section class="arch-tier" data-label="Ingress Protection"><span class="arch-chip is-guard">Firewall Rules</span><span class="arch-chip is-guard">TLS 1.3</span><span class="arch-chip is-guard">Fail2ban</span><span class="arch-chip is-guard">ModSecurity WAF</span></section>
-  <section class="arch-tier" data-label="Application Edge"><span class="arch-chip">Nginx Reverse Proxy</span></section>
-  <section class="arch-tier" data-label="Vault Service"><span class="arch-chip is-primary">Vaultwarden</span></section>
-  <section class="arch-tier" data-label="Data Store"><span class="arch-chip"><b>SQLite / PostgreSQL</b><i>encrypted at rest</i></span></section>
+<div class="arch is-stack" role="group" aria-label="Self-hosted Bitwarden serving architecture">
+  <section class="arch-tier" data-label="Client Access" role="group" aria-label="Client Access"><span class="arch-chip">Web Vault</span><span class="arch-chip">Mobile Apps</span><span class="arch-chip">Desktop Apps</span><span class="arch-chip">Browser Extensions</span></section>
+  <section class="arch-tier" data-label="Ingress Protection" role="group" aria-label="Ingress Protection"><span class="arch-chip is-guard">Firewall Rules</span><span class="arch-chip is-guard">TLS 1.3</span><span class="arch-chip is-guard">Fail2ban</span><span class="arch-chip is-guard">ModSecurity WAF</span></section>
+  <section class="arch-tier" data-label="Application Edge" role="group" aria-label="Application Edge"><span class="arch-chip">Nginx Reverse Proxy</span></section>
+  <section class="arch-tier" data-label="Vault Service" role="group" aria-label="Vault Service"><span class="arch-chip is-primary">Vaultwarden</span></section>
+  <section class="arch-tier" data-label="Data Store" role="group" aria-label="Data Store"><span class="arch-chip"><b>SQLite / PostgreSQL</b><i>encrypted at rest</i></span></section>
 </div>
 <figcaption>Clients enter through the protected edge; Vaultwarden sits behind Nginx and writes to a private database. Backups (below) run downstream of the data store.</figcaption>
 </figure>
 
-<div class="flow" aria-label="Bitwarden backup and recovery path">
+<div class="flow" role="group" aria-label="Bitwarden backup and recovery path">
   <div class="flow-node">Database</div>
   <div class="flow-node">Local Backups</div>
   <div class="flow-node is-gate">Encrypted Storage</div>

--- a/src/posts/2025-09-08-zero-trust-vlan-segmentation-homelab.md
+++ b/src/posts/2025-09-08-zero-trust-vlan-segmentation-homelab.md
@@ -23,14 +23,14 @@ All because I put it on the same network as my trusted devices. That camera is n
 ## Zero Trust Network Architecture
 
 <figure class="arch-fig">
-<div class="arch" aria-label="Zero trust VLAN segmentation zones">
-  <section class="arch-tier" data-label="Internet Edge"><span class="arch-chip">WAN Connection</span><span class="arch-chip is-primary">Dream Machine Pro</span></section>
-  <section class="arch-tier" data-label="Management VLAN 10"><span class="arch-chip is-guard">Admin Devices</span><span class="arch-chip">Proxmox Host</span><span class="arch-chip">Network Switches</span></section>
-  <section class="arch-tier" data-label="Trusted VLAN 20"><span class="arch-chip">Workstations</span><span class="arch-chip">Laptops</span><span class="arch-chip">Personal Phones</span></section>
-  <section class="arch-tier" data-label="Server VLAN 30"><span class="arch-chip">Web Servers</span><span class="arch-chip">Databases</span><span class="arch-chip">Applications</span></section>
-  <section class="arch-tier" data-label="IoT VLAN 40"><span class="arch-chip is-warn">IP Cameras</span><span class="arch-chip is-warn">Smart Devices</span><span class="arch-chip is-warn">IoT Sensors</span></section>
-  <section class="arch-tier" data-label="Guest VLAN 50"><span class="arch-chip is-bad">Guest Devices</span></section>
-  <section class="arch-tier" data-label="Security Services"><span class="arch-chip is-guard">Firewall Rules</span><span class="arch-chip is-guard">Suricata IDS</span><span class="arch-chip is-guard">Pi-hole DNS</span></section>
+<div class="arch" role="group" aria-label="Zero trust VLAN segmentation zones">
+  <section class="arch-tier" data-label="Internet Edge" role="group" aria-label="Internet Edge"><span class="arch-chip">WAN Connection</span><span class="arch-chip is-primary">Dream Machine Pro</span></section>
+  <section class="arch-tier" data-label="Management VLAN 10" role="group" aria-label="Management VLAN 10"><span class="arch-chip is-guard">Admin Devices</span><span class="arch-chip">Proxmox Host</span><span class="arch-chip">Network Switches</span></section>
+  <section class="arch-tier" data-label="Trusted VLAN 20" role="group" aria-label="Trusted VLAN 20"><span class="arch-chip">Workstations</span><span class="arch-chip">Laptops</span><span class="arch-chip">Personal Phones</span></section>
+  <section class="arch-tier" data-label="Server VLAN 30" role="group" aria-label="Server VLAN 30"><span class="arch-chip">Web Servers</span><span class="arch-chip">Databases</span><span class="arch-chip">Applications</span></section>
+  <section class="arch-tier" data-label="IoT VLAN 40" role="group" aria-label="IoT VLAN 40"><span class="arch-chip is-warn">IP Cameras</span><span class="arch-chip is-warn">Smart Devices</span><span class="arch-chip is-warn">IoT Sensors</span></section>
+  <section class="arch-tier" data-label="Guest VLAN 50" role="group" aria-label="Guest VLAN 50"><span class="arch-chip is-bad">Guest Devices</span></section>
+  <section class="arch-tier" data-label="Security Services" role="group" aria-label="Security Services"><span class="arch-chip is-guard">Firewall Rules</span><span class="arch-chip is-guard">Suricata IDS</span><span class="arch-chip is-guard">Pi-hole DNS</span></section>
 </div>
 <figcaption>The firewall mediates traffic between peer VLAN zones, with IDS and DNS controls attached as shared security services.</figcaption>
 </figure>

--- a/src/posts/2025-09-20-iot-security-homelab-owasp.md
+++ b/src/posts/2025-09-20-iot-security-homelab-owasp.md
@@ -34,12 +34,12 @@ Before diving into vulnerabilities, let's set up a proper isolated environment. 
 Here's my home lab IoT security setup using VLANs and a dedicated analysis subnet. I moved all IoT devices to a separate VLAN (192.168.50.0/24) with firewall rules blocking LAN access. My Nest thermostat immediately stopped working until I allowed specific port 443 traffic to Google servers. The **trade-off**: security versus convenience. You gain isolation **but** lose easy device-to-device communication. For a complete approach to this architecture, see my guide on [building a security-focused homelab](/posts/2025-04-24-building-secure-homelab-adventure).
 
 <figure class="arch-fig">
-<div class="arch" aria-label="IoT security lab network zones">
-  <section class="arch-tier" data-label="Firewall"><span class="arch-chip is-primary">pfSense/OPNsense</span></section>
-  <section class="arch-tier" data-label="Main Network VLAN 10"><span class="arch-chip">Main Network</span></section>
-  <section class="arch-tier" data-label="IoT Production VLAN 20"><span class="arch-chip is-guard">Isolated</span></section>
-  <section class="arch-tier" data-label="IoT Testing VLAN 666"><span class="arch-chip is-bad">No Internet</span><span class="arch-chip">IoTGoat Device</span><span class="arch-chip">Packet Capture</span></section>
-  <section class="arch-tier" data-label="Analysis VM VLAN 30"><span class="arch-chip is-guard">Monitor Only</span><span class="arch-chip">Burp Suite</span><span class="arch-chip">Wireshark</span><span class="arch-chip">MQTT Explorer</span></section>
+<div class="arch" role="group" aria-label="IoT security lab network zones">
+  <section class="arch-tier" data-label="Firewall" role="group" aria-label="Firewall"><span class="arch-chip is-primary">pfSense/OPNsense</span></section>
+  <section class="arch-tier" data-label="Main Network VLAN 10" role="group" aria-label="Main Network VLAN 10"><span class="arch-chip">Main Network</span></section>
+  <section class="arch-tier" data-label="IoT Production VLAN 20" role="group" aria-label="IoT Production VLAN 20"><span class="arch-chip is-guard">Isolated</span></section>
+  <section class="arch-tier" data-label="IoT Testing VLAN 666" role="group" aria-label="IoT Testing VLAN 666"><span class="arch-chip is-bad">No Internet</span><span class="arch-chip">IoTGoat Device</span><span class="arch-chip">Packet Capture</span></section>
+  <section class="arch-tier" data-label="Analysis VM VLAN 30" role="group" aria-label="Analysis VM VLAN 30"><span class="arch-chip is-guard">Monitor Only</span><span class="arch-chip">Burp Suite</span><span class="arch-chip">Wireshark</span><span class="arch-chip">MQTT Explorer</span></section>
 </div>
 <figcaption>The firewall separates the main network, production IoT, vulnerable testing devices, and analysis tooling into peer zones.</figcaption>
 </figure>

--- a/src/posts/2025-09-20-vulnerability-prioritization-epss-kev.md
+++ b/src/posts/2025-09-20-vulnerability-prioritization-epss-kev.md
@@ -73,7 +73,7 @@ Let me walk through creating a practical system that combines these data sources
 
 ⚠️ **Warning:** This architecture integrates multiple external APIs (NVD, EPSS, CISA KEV). Implement proper authentication, rate limiting, and error handling for production deployments.
 
-<div class="flow" aria-label="Vulnerability prioritization data pipeline">
+<div class="flow" role="group" aria-label="Vulnerability prioritization data pipeline">
   <div class="flow-parallel">
     <div class="flow-node"><b>NVD API</b><i>CVE details</i></div>
     <div class="flow-node"><b>EPSS API</b><i>probability scores</i></div>

--- a/src/posts/2025-09-29-proxmox-high-availability-homelab.md
+++ b/src/posts/2025-09-29-proxmox-high-availability-homelab.md
@@ -24,12 +24,12 @@ This incident became a driving force behind [building a security-focused homelab
 ## High Availability Architecture
 
 <figure class="arch-fig">
-<div class="arch" aria-label="Proxmox high availability homelab architecture">
-  <section class="arch-tier" data-label="Cluster Nodes"><span class="arch-chip"><b>Proxmox Node 1</b><i>Dell R910</i></span><span class="arch-chip"><b>Proxmox Node 2</b><i>Dell R730</i></span><span class="arch-chip"><b>Proxmox Node 3</b><i>Custom Build</i></span></section>
-  <section class="arch-tier" data-label="Shared Storage"><span class="arch-chip is-primary"><b>Ceph Cluster</b><i>distributed storage</i></span></section>
-  <section class="arch-tier" data-label="Network Infrastructure"><span class="arch-chip"><b>10Gb Switch</b><i>primary</i></span><span class="arch-chip"><b>1Gb Switch</b><i>management</i></span></section>
-  <section class="arch-tier" data-label="HA Services"><span class="arch-chip is-guard"><b>Corosync</b><i>cluster communication</i></span><span class="arch-chip is-primary"><b>PVE HA Manager</b><i>failover orchestration</i></span><span class="arch-chip is-bad"><b>Fencing Agent</b><i>split-brain prevention</i></span></section>
-  <section class="arch-tier" data-label="VMs with HA"><span class="arch-chip">Pi-hole DNS</span><span class="arch-chip">Bitwarden</span><span class="arch-chip">Wazuh SIEM</span><span class="arch-chip">Web Services</span></section>
+<div class="arch" role="group" aria-label="Proxmox high availability homelab architecture">
+  <section class="arch-tier" data-label="Cluster Nodes" role="group" aria-label="Cluster Nodes"><span class="arch-chip"><b>Proxmox Node 1</b><i>Dell R910</i></span><span class="arch-chip"><b>Proxmox Node 2</b><i>Dell R730</i></span><span class="arch-chip"><b>Proxmox Node 3</b><i>Custom Build</i></span></section>
+  <section class="arch-tier" data-label="Shared Storage" role="group" aria-label="Shared Storage"><span class="arch-chip is-primary"><b>Ceph Cluster</b><i>distributed storage</i></span></section>
+  <section class="arch-tier" data-label="Network Infrastructure" role="group" aria-label="Network Infrastructure"><span class="arch-chip"><b>10Gb Switch</b><i>primary</i></span><span class="arch-chip"><b>1Gb Switch</b><i>management</i></span></section>
+  <section class="arch-tier" data-label="HA Services" role="group" aria-label="HA Services"><span class="arch-chip is-guard"><b>Corosync</b><i>cluster communication</i></span><span class="arch-chip is-primary"><b>PVE HA Manager</b><i>failover orchestration</i></span><span class="arch-chip is-bad"><b>Fencing Agent</b><i>split-brain prevention</i></span></section>
+  <section class="arch-tier" data-label="VMs with HA" role="group" aria-label="VMs with HA"><span class="arch-chip">Pi-hole DNS</span><span class="arch-chip">Bitwarden</span><span class="arch-chip">Wazuh SIEM</span><span class="arch-chip">Web Services</span></section>
 </div>
 <figcaption>Cluster nodes share storage and network fabric while HA services coordinate failover for the protected VMs.</figcaption>
 </figure>

--- a/src/posts/2025-10-06-automated-security-scanning-pipeline.md
+++ b/src/posts/2025-10-06-automated-security-scanning-pipeline.md
@@ -25,7 +25,7 @@ I built an automated security pipeline that scans every commit with Grype, OSV-S
 
 ⚠️ **Warning:** Security scanning pipelines must be configured with appropriate policies and approval gates. Automated remediation should include review processes for production environments.
 
-<div class="flow" aria-label="Automated security scanning pipeline">
+<div class="flow" role="group" aria-label="Automated security scanning pipeline">
   <div class="flow-parallel">
     <div class="flow-node">Git Push</div>
     <div class="flow-node">Pull Request</div>
@@ -47,8 +47,8 @@ I built an automated security pipeline that scans every commit with Grype, OSV-S
   </div>
   <div class="flow-node is-gate">Quality Gates</div>
   <div class="flow-branch">
-    <div class="flow-leg" data-branch="Critical"><div class="flow-node is-bad">Block on Critical</div></div>
-    <div class="flow-leg" data-branch="Review"><div class="flow-node">Manual Review</div></div>
+    <div class="flow-leg" data-branch="Critical" role="group" aria-label="Critical"><div class="flow-node is-bad">Block on Critical</div></div>
+    <div class="flow-leg" data-branch="Review" role="group" aria-label="Review"><div class="flow-node">Manual Review</div></div>
   </div>
 </div>
 
@@ -84,7 +84,7 @@ I installed all three scanners on my Ubuntu 22.04 homelab server. The process to
 
 The pipeline orchestrates three scanners in parallel with a final quality gate:
 
-<div class="flow">
+<div class="flow" role="group" aria-label="GitHub Actions security scanning pipeline">
   <div class="flow-node">Git Push / PR</div>
   <div class="flow-node is-gate">Trigger Pipeline</div>
   <div class="flow-parallel">
@@ -95,8 +95,8 @@ The pipeline orchestrates three scanners in parallel with a final quality gate:
   <div class="flow-node">Upload SARIF</div>
   <div class="flow-node is-gate">Security Gate</div>
   <div class="flow-branch">
-    <div class="flow-leg" data-branch="Pass"><div class="flow-node is-good">Deploy</div></div>
-    <div class="flow-leg" data-branch="Critical"><div class="flow-node is-bad">Block &amp; Alert</div></div>
+    <div class="flow-leg" data-branch="Pass" role="group" aria-label="Pass"><div class="flow-node is-good">Deploy</div></div>
+    <div class="flow-leg" data-branch="Critical" role="group" aria-label="Critical"><div class="flow-node is-bad">Block &amp; Alert</div></div>
   </div>
 </div>
 

--- a/src/posts/2025-10-13-embodied-ai-robots-physical-world.md
+++ b/src/posts/2025-10-13-embodied-ai-robots-physical-world.md
@@ -33,12 +33,12 @@ That gap is closing. VLA models combine three capabilities:
 - **Action**: Generating physical control signals for robotic systems
 
 <figure class="arch-fig">
-<div class="flow" aria-label="Traditional AI agent path">
+<div class="flow" role="group" aria-label="Traditional AI agent path">
   <div class="flow-node">Text Input</div>
   <div class="flow-node">Language Model</div>
   <div class="flow-node">Text Output</div>
 </div>
-<div class="flow" aria-label="Vision-Language-Action model path">
+<div class="flow" role="group" aria-label="Vision-Language-Action model path">
   <div class="flow-parallel">
     <div class="flow-node">Visual Input</div>
     <div class="flow-node">Language Input</div>
@@ -139,11 +139,11 @@ Formal safety frameworks for robotics exist, but most VLA deployments lack rigor
 ⚠️ **Warning:** Embodied AI systems that interact with the physical world require extensive safety testing. Physical robotics experiments must follow proper safety protocols and risk assessments.
 
 <figure class="arch-fig">
-<div class="arch is-stack" aria-label="Embodied AI safety layers">
-  <section class="arch-tier" data-label="Model"><span class="arch-chip is-primary">VLA Model</span></section>
-  <section class="arch-tier" data-label="Runtime Guards"><span class="arch-chip is-guard">Action Filter</span><span class="arch-chip is-guard">Collision Detection</span><span class="arch-chip is-guard">Force Limits</span><span class="arch-chip is-warn">Safety Monitor</span></section>
-  <section class="arch-tier" data-label="Stop Controls"><span class="arch-chip is-bad">Emergency Stop</span><span class="arch-chip is-guard">Human Supervisor</span></section>
-  <section class="arch-tier" data-label="Actuator"><span class="arch-chip">Physical Robot</span></section>
+<div class="arch is-stack" role="group" aria-label="Embodied AI safety layers">
+  <section class="arch-tier" data-label="Model" role="group" aria-label="Model"><span class="arch-chip is-primary">VLA Model</span></section>
+  <section class="arch-tier" data-label="Runtime Guards" role="group" aria-label="Runtime Guards"><span class="arch-chip is-guard">Action Filter</span><span class="arch-chip is-guard">Collision Detection</span><span class="arch-chip is-guard">Force Limits</span><span class="arch-chip is-warn">Safety Monitor</span></section>
+  <section class="arch-tier" data-label="Stop Controls" role="group" aria-label="Stop Controls"><span class="arch-chip is-bad">Emergency Stop</span><span class="arch-chip is-guard">Human Supervisor</span></section>
+  <section class="arch-tier" data-label="Actuator" role="group" aria-label="Actuator"><span class="arch-chip">Physical Robot</span></section>
 </div>
 <figcaption>Model output passes through runtime guards and stop controls before it can move the physical robot.</figcaption>
 </figure>

--- a/src/posts/2025-10-17-progressive-context-loading-llm-workflows.md
+++ b/src/posts/2025-10-17-progressive-context-loading-llm-workflows.md
@@ -150,7 +150,7 @@ The design goal: preserve critical context, discard irrelevant information, and 
 
 Task flow:
 
-<div class="flow" aria-label="Dynamic context assembly workflow">
+<div class="flow" role="group" aria-label="Dynamic context assembly workflow">
   <div class="flow-node">Task Arrives</div>
   <div class="flow-node is-gate">Parse File Types</div>
   <div class="flow-node">Query Product Matrix</div>
@@ -158,9 +158,9 @@ Task flow:
   <div class="flow-node is-good"><b>Load Primary Skills</b><i>2K tokens</i></div>
   <div class="flow-node is-gate">Task Complete?</div>
   <div class="flow-branch">
-    <div class="flow-leg" data-branch="Yes"><div class="flow-node is-good">Return Result</div></div>
-    <div class="flow-leg" data-branch="Need Context"><div class="flow-node"><b>Load Dependencies</b><i>+3K tokens, then re-check task</i></div></div>
-    <div class="flow-leg" data-branch="No Context"><div class="flow-node">Request Clarification</div></div>
+    <div class="flow-leg" data-branch="Yes" role="group" aria-label="Yes"><div class="flow-node is-good">Return Result</div></div>
+    <div class="flow-leg" data-branch="Need Context" role="group" aria-label="Need Context"><div class="flow-node"><b>Load Dependencies</b><i>+3K tokens, then re-check task</i></div></div>
+    <div class="flow-leg" data-branch="No Context" role="group" aria-label="No Context"><div class="flow-node">Request Clarification</div></div>
   </div>
 </div>
 

--- a/src/posts/2025-10-29-post-quantum-cryptography-homelab.md
+++ b/src/posts/2025-10-29-post-quantum-cryptography-homelab.md
@@ -37,7 +37,7 @@ According to RAND Corporation's analysis,[^rand-analysis] if your data needs to 
 The math is simple and it's called [Mosca's Theorem](https://globalriskinstitute.org/publication/2023-quantum-threat-timeline-report/): If **X** (how long your data must stay secret) + **Y** (how long it takes to migrate) > **Z** (when quantum computers arrive), you're already behind schedule.
 
 <figure class="arch-fig">
-<div class="flow" aria-label="Mosca theorem migration timing test">
+<div class="flow" role="group" aria-label="Mosca theorem migration timing test">
   <div class="flow-parallel">
     <div class="flow-node"><b>X: Data Secrecy Requirement</b><i>10-30 years</i></div>
     <div class="flow-node"><b>Y: Migration Time Needed</b><i>5-15 years</i></div>
@@ -46,11 +46,11 @@ The math is simple and it's called [Mosca's Theorem](https://globalriskinstitute
   <div class="flow-node">X + Y</div>
   <div class="flow-node is-gate">X + Y &gt; Z?</div>
   <div class="flow-branch">
-    <div class="flow-leg" data-branch="Yes"><div class="flow-node is-bad"><b>Already Behind</b><i>schedule</i></div></div>
-    <div class="flow-leg" data-branch="No"><div class="flow-node is-good"><b>Time Remaining</b><i>to migrate</i></div></div>
+    <div class="flow-leg" data-branch="Yes" role="group" aria-label="Yes"><div class="flow-node is-bad"><b>Already Behind</b><i>schedule</i></div></div>
+    <div class="flow-leg" data-branch="No" role="group" aria-label="No"><div class="flow-node is-good"><b>Time Remaining</b><i>to migrate</i></div></div>
   </div>
 </div>
-<div class="flow" aria-label="Store Now Decrypt Later attack path">
+<div class="flow" role="group" aria-label="Store Now Decrypt Later attack path">
   <div class="flow-node"><b>Adversary Captures Encrypted Traffic</b><i>today</i></div>
   <div class="flow-node"><b>Stores Until Quantum Computer</b><i>available</i></div>
   <div class="flow-node is-bad">Decrypts Historical Traffic</div>
@@ -65,11 +65,11 @@ For my homelab, that meant my encrypted backups, my self-hosted Bitwarden vault 
 The following diagram compares the three NIST-standardized post-quantum algorithms and their roles:
 
 <figure class="arch-fig">
-<div class="arch is-stack" aria-label="NIST post-quantum cryptography standards">
-  <section class="arch-tier" data-label="Standards"><span class="arch-chip is-primary"><b>NIST PQC Standards</b><i>August 2024</i></span></section>
-  <section class="arch-tier" data-label="Algorithms"><span class="arch-chip"><b>ML-KEM (FIPS 203)</b><i>key encapsulation</i></span><span class="arch-chip"><b>ML-DSA (FIPS 204)</b><i>digital signatures</i></span><span class="arch-chip"><b>SLH-DSA (FIPS 205)</b><i>hash-based signatures</i></span></section>
-  <section class="arch-tier" data-label="Uses"><span class="arch-chip"><b>ML-KEM</b><i>replaces ECDH / X25519; TLS handshakes; 800-1568 byte keys</i></span><span class="arch-chip"><b>ML-DSA</b><i>replaces RSA / ECDSA; certificates and code signing; 2420-4595 byte signatures</i></span><span class="arch-chip"><b>SLH-DSA</b><i>backup for ML-DSA; long-term archival; hash functions only</i></span></section>
-  <section class="arch-tier" data-label="Math Basis"><span class="arch-chip is-guard"><b>Lattice-Based Math</b><i>Learning With Errors</i></span><span class="arch-chip is-guard"><b>Hash Functions</b><i>different math basis</i></span></section>
+<div class="arch is-stack" role="group" aria-label="NIST post-quantum cryptography standards">
+  <section class="arch-tier" data-label="Standards" role="group" aria-label="Standards"><span class="arch-chip is-primary"><b>NIST PQC Standards</b><i>August 2024</i></span></section>
+  <section class="arch-tier" data-label="Algorithms" role="group" aria-label="Algorithms"><span class="arch-chip"><b>ML-KEM (FIPS 203)</b><i>key encapsulation</i></span><span class="arch-chip"><b>ML-DSA (FIPS 204)</b><i>digital signatures</i></span><span class="arch-chip"><b>SLH-DSA (FIPS 205)</b><i>hash-based signatures</i></span></section>
+  <section class="arch-tier" data-label="Uses" role="group" aria-label="Uses"><span class="arch-chip"><b>ML-KEM</b><i>replaces ECDH / X25519; TLS handshakes; 800-1568 byte keys</i></span><span class="arch-chip"><b>ML-DSA</b><i>replaces RSA / ECDSA; certificates and code signing; 2420-4595 byte signatures</i></span><span class="arch-chip"><b>SLH-DSA</b><i>backup for ML-DSA; long-term archival; hash functions only</i></span></section>
+  <section class="arch-tier" data-label="Math Basis" role="group" aria-label="Math Basis"><span class="arch-chip is-guard"><b>Lattice-Based Math</b><i>Learning With Errors</i></span><span class="arch-chip is-guard"><b>Hash Functions</b><i>different math basis</i></span></section>
 </div>
 <figcaption>ML-KEM and ML-DSA rely on lattice-based assumptions; SLH-DSA provides a hash-based signature fallback.</figcaption>
 </figure>
@@ -632,7 +632,7 @@ My personal risk tolerance says these trade-offs are acceptable for homelab expe
 
 The migration strategy follows four phases, prioritizing services by their exposure to Store Now, Decrypt Later attacks:
 
-<div class="flow" aria-label="Post-quantum cryptography homelab migration phases">
+<div class="flow" role="group" aria-label="Post-quantum cryptography homelab migration phases">
   <div class="flow-node"><b>Phase 1: Test</b><i>Weekend 1; isolated Ubuntu 24.04 VM, Caddy 2.10, verify x25519_kyber768 handshake</i></div>
   <div class="flow-node"><b>Phase 2: Certificates</b><i>Weekend 1; classical certs, PQC key exchange with ML-KEM-768, future ML-DSA certs in 2026-2027</i></div>
   <div class="flow-node is-gate"><b>Phase 3: Rollout</b><i>Weekend 2</i></div>

--- a/src/posts/2025-10-29-privacy-first-ai-lab-local-llms.md
+++ b/src/posts/2025-10-29-privacy-first-ai-lab-local-llms.md
@@ -34,10 +34,10 @@ But privacy isn't just about where the compute happens. It's about the entire st
 After that wake-up call, I rebuilt my thinking around three distinct threat layers:
 
 <figure class="arch-fig">
-<div class="arch is-stack" aria-label="Local LLM privacy threat model layers">
-  <section class="arch-tier" data-label="Network Layer"><span class="arch-chip is-guard">Endpoint Access Control</span><span class="arch-chip is-guard">Telemetry Monitoring</span><span class="arch-chip is-guard">Network Boundary Rules</span></section>
-  <section class="arch-tier" data-label="Storage Layer"><span class="arch-chip is-guard">Prompt / Response Encryption</span><span class="arch-chip is-guard">Docker Volume Protection</span><span class="arch-chip is-guard">Model File Integrity</span></section>
-  <section class="arch-tier" data-label="Inference Layer"><span class="arch-chip is-primary">GPU Memory Isolation</span><span class="arch-chip is-primary">KV Cache Protection</span><span class="arch-chip is-primary">Process Sandboxing</span></section>
+<div class="arch is-stack" role="group" aria-label="Local LLM privacy threat model layers">
+  <section class="arch-tier" data-label="Network Layer" role="group" aria-label="Network Layer"><span class="arch-chip is-guard">Endpoint Access Control</span><span class="arch-chip is-guard">Telemetry Monitoring</span><span class="arch-chip is-guard">Network Boundary Rules</span></section>
+  <section class="arch-tier" data-label="Storage Layer" role="group" aria-label="Storage Layer"><span class="arch-chip is-guard">Prompt / Response Encryption</span><span class="arch-chip is-guard">Docker Volume Protection</span><span class="arch-chip is-guard">Model File Integrity</span></section>
+  <section class="arch-tier" data-label="Inference Layer" role="group" aria-label="Inference Layer"><span class="arch-chip is-primary">GPU Memory Isolation</span><span class="arch-chip is-primary">KV Cache Protection</span><span class="arch-chip is-primary">Process Sandboxing</span></section>
 </div>
 <figcaption>The model is only private when controls hold at the network, storage, and inference layers.</figcaption>
 </figure>
@@ -80,7 +80,7 @@ I started verifying model checksums obsessively after reading this.
 
 ## Local LLM Tools: The Privacy Reality Check
 
-<div class="flow">
+<div class="flow" role="group" aria-label="Local LLM inference path">
   <div class="flow-node">User Prompt</div>
   <div class="flow-node">System Prompt + Filters</div>
   <div class="flow-node">Tokenizer</div>
@@ -204,11 +204,11 @@ Maybe in 3-5 years this'll be viable for homelab use. For now, it's research-onl
 Here's how I actually locked things down. This took about 6 hours to configure properly, but it's the foundation of everything else.
 
 <figure class="arch-fig">
-<div class="arch" aria-label="AI lab VLAN zones">
-  <section class="arch-tier" data-label="VLAN 1 - Main Network"><span class="arch-chip">Laptop / Desktop</span></section>
-  <section class="arch-tier" data-label="VLAN 10 - DMZ"><span class="arch-chip is-bad">IoT Devices</span></section>
-  <section class="arch-tier" data-label="VLAN 20 - AI Services"><span class="arch-chip">Proxmox Host</span><span class="arch-chip">Ubuntu VM + RTX 3090</span><span class="arch-chip is-primary">Ollama / LM Studio</span></section>
-  <section class="arch-tier" data-label="VLAN 30 - Monitoring"><span class="arch-chip is-guard">Wazuh SIEM</span><span class="arch-chip is-guard">Prometheus</span></section>
+<div class="arch" role="group" aria-label="AI lab VLAN zones">
+  <section class="arch-tier" data-label="VLAN 1 - Main Network" role="group" aria-label="VLAN 1 - Main Network"><span class="arch-chip">Laptop / Desktop</span></section>
+  <section class="arch-tier" data-label="VLAN 10 - DMZ" role="group" aria-label="VLAN 10 - DMZ"><span class="arch-chip is-bad">IoT Devices</span></section>
+  <section class="arch-tier" data-label="VLAN 20 - AI Services" role="group" aria-label="VLAN 20 - AI Services"><span class="arch-chip">Proxmox Host</span><span class="arch-chip">Ubuntu VM + RTX 3090</span><span class="arch-chip is-primary">Ollama / LM Studio</span></section>
+  <section class="arch-tier" data-label="VLAN 30 - Monitoring" role="group" aria-label="VLAN 30 - Monitoring"><span class="arch-chip is-guard">Wazuh SIEM</span><span class="arch-chip is-guard">Prometheus</span></section>
 </div>
 <figcaption>VLAN 20 accepts main-network access only over VPN, exports metrics to monitoring, and blocks DMZ and internet paths by policy.</figcaption>
 </figure>
@@ -309,16 +309,16 @@ Running everything locally means I'm limited to models that fit in 24GB VRAM ful
 
 I use a separate Claude subscription for this blog writing. None of my sensitive homelab data ever touches cloud APIs.
 
-<div class="flow" aria-label="Local versus cloud LLM routing decision">
+<div class="flow" role="group" aria-label="Local versus cloud LLM routing decision">
   <div class="flow-node is-gate">What data are you processing?</div>
   <div class="flow-branch">
-    <div class="flow-leg" data-branch="Sensitive / Regulated"><div class="flow-node is-good"><b>Local Processing</b><i>GPU hardware or CPU-only inference</i></div></div>
-    <div class="flow-leg" data-branch="Public / Non-sensitive"><div class="flow-node"><b>Cloud Processing</b><i>Cloud API or managed service</i></div></div>
+    <div class="flow-leg" data-branch="Sensitive / Regulated" role="group" aria-label="Sensitive / Regulated"><div class="flow-node is-good"><b>Local Processing</b><i>GPU hardware or CPU-only inference</i></div></div>
+    <div class="flow-leg" data-branch="Public / Non-sensitive" role="group" aria-label="Public / Non-sensitive"><div class="flow-node"><b>Cloud Processing</b><i>Cloud API or managed service</i></div></div>
   </div>
   <div class="flow-node is-gate">Match budget and capability needs</div>
   <div class="flow-branch">
-    <div class="flow-leg" data-branch="Local"><div class="flow-node is-good"><b>Harden</b><i>VLAN + encryption + DP + monitoring</i></div></div>
-    <div class="flow-leg" data-branch="Cloud"><div class="flow-node"><b>Choose service</b><i>405B+ API or general managed use</i></div></div>
+    <div class="flow-leg" data-branch="Local" role="group" aria-label="Local"><div class="flow-node is-good"><b>Harden</b><i>VLAN + encryption + DP + monitoring</i></div></div>
+    <div class="flow-leg" data-branch="Cloud" role="group" aria-label="Cloud"><div class="flow-node"><b>Choose service</b><i>405B+ API or general managed use</i></div></div>
   </div>
   <div class="flow-node is-good">Production Ready</div>
 </div>

--- a/src/posts/2025-11-05-siem-homelab-wazuh-graylog-comparison.md
+++ b/src/posts/2025-11-05-siem-homelab-wazuh-graylog-comparison.md
@@ -37,21 +37,21 @@ Both use agent-based collection, centralized storage, and web UI. Architectures 
 
 **Wazuh architecture:**
 
-<div class="flow" aria-label="Wazuh log collection architecture">
+<div class="flow" role="group" aria-label="Wazuh log collection architecture">
   <div class="flow-parallel">
     <div class="flow-node"><b>Wazuh Agent</b><i>Host 1 logs</i></div>
     <div class="flow-node"><b>Wazuh Agent</b><i>Host 2 logs</i></div>
   </div>
   <div class="flow-node">Wazuh Manager</div>
   <div class="flow-branch">
-    <div class="flow-leg" data-branch="Index"><div class="flow-node"><b>Wazuh Indexer</b><i>OpenSearch</i></div></div>
-    <div class="flow-leg" data-branch="Alerts"><div class="flow-node"><b>Wazuh Dashboard</b><i>queries indexer</i></div></div>
+    <div class="flow-leg" data-branch="Index" role="group" aria-label="Index"><div class="flow-node"><b>Wazuh Indexer</b><i>OpenSearch</i></div></div>
+    <div class="flow-leg" data-branch="Alerts" role="group" aria-label="Alerts"><div class="flow-node"><b>Wazuh Dashboard</b><i>queries indexer</i></div></div>
   </div>
 </div>
 
 **Graylog architecture:**
 
-<div class="flow" aria-label="Graylog log collection architecture">
+<div class="flow" role="group" aria-label="Graylog log collection architecture">
   <div class="flow-parallel">
     <div class="flow-node"><b>Filebeat</b><i>Host 1 syslog</i></div>
     <div class="flow-node"><b>Filebeat</b><i>Host 2 syslog</i></div>
@@ -338,11 +338,11 @@ Some teams run Wazuh + Graylog together. Wazuh handles threat detection, Graylog
 **Hybrid architecture:**
 
 <figure class="arch-fig">
-<div class="arch" aria-label="Hybrid Wazuh and Graylog deployment">
-  <section class="arch-tier" data-label="Inputs"><span class="arch-chip">Homelab Hosts</span></section>
-  <section class="arch-tier" data-label="Security Path"><span class="arch-chip is-primary">Wazuh Manager</span><span class="arch-chip">Alert Dashboard</span></section>
-  <section class="arch-tier" data-label="Application Path"><span class="arch-chip is-primary">Graylog Server</span><span class="arch-chip">Investigation UI</span></section>
-  <section class="arch-tier" data-label="Integration"><span class="arch-chip is-guard">Forward Wazuh Alerts to Graylog</span><span class="arch-chip is-guard">Enrich Graylog Events in Wazuh</span></section>
+<div class="arch" role="group" aria-label="Hybrid Wazuh and Graylog deployment">
+  <section class="arch-tier" data-label="Inputs" role="group" aria-label="Inputs"><span class="arch-chip">Homelab Hosts</span></section>
+  <section class="arch-tier" data-label="Security Path" role="group" aria-label="Security Path"><span class="arch-chip is-primary">Wazuh Manager</span><span class="arch-chip">Alert Dashboard</span></section>
+  <section class="arch-tier" data-label="Application Path" role="group" aria-label="Application Path"><span class="arch-chip is-primary">Graylog Server</span><span class="arch-chip">Investigation UI</span></section>
+  <section class="arch-tier" data-label="Integration" role="group" aria-label="Integration"><span class="arch-chip is-guard">Forward Wazuh Alerts to Graylog</span><span class="arch-chip is-guard">Enrich Graylog Events in Wazuh</span></section>
 </div>
 <figcaption>Security logs flow to Wazuh, application logs flow to Graylog, and the two systems exchange alerts for unified investigation.</figcaption>
 </figure>

--- a/src/posts/2025-11-12-quantum-error-correction-willow-breakthrough.md
+++ b/src/posts/2025-11-12-quantum-error-correction-willow-breakthrough.md
@@ -22,10 +22,10 @@ Here's the catch that almost doomed the field: traditional error correction make
 The theoretical solution has been known since the 1990s: surface codes and logical qubits. Instead of using individual physical qubits for computation, you use groups of physical qubits to create one "logical qubit" protected by quantum error correction. The math said this should work below a critical error threshold around 1%.
 
 <figure class="arch-fig">
-<div class="arch is-stack" aria-label="Surface code error correction path">
-  <section class="arch-tier" data-label="Surface Code Layout"><span class="arch-chip is-primary"><b>D</b><i>Data Qubit</i></span><span class="arch-chip is-guard"><b>S</b><i>Syndrome Ancilla</i></span><span class="arch-chip is-primary"><b>D</b><i>Data Qubit</i></span><span class="arch-chip is-guard"><b>S</b><i>Syndrome Ancilla</i></span><span class="arch-chip is-primary"><b>D</b><i>Data Qubit</i></span></section>
-  <section class="arch-tier" data-label="Error Correction"><span class="arch-chip is-guard">Syndrome Measurement</span><span class="arch-chip is-guard">Decoding</span></section>
-  <section class="arch-tier" data-label="Logical Qubit"><span class="arch-chip is-primary">1 Logical Qubit</span></section>
+<div class="arch is-stack" role="group" aria-label="Surface code error correction path">
+  <section class="arch-tier" data-label="Surface Code Layout" role="group" aria-label="Surface Code Layout"><span class="arch-chip is-primary"><b>D</b><i>Data Qubit</i></span><span class="arch-chip is-guard"><b>S</b><i>Syndrome Ancilla</i></span><span class="arch-chip is-primary"><b>D</b><i>Data Qubit</i></span><span class="arch-chip is-guard"><b>S</b><i>Syndrome Ancilla</i></span><span class="arch-chip is-primary"><b>D</b><i>Data Qubit</i></span></section>
+  <section class="arch-tier" data-label="Error Correction" role="group" aria-label="Error Correction"><span class="arch-chip is-guard">Syndrome Measurement</span><span class="arch-chip is-guard">Decoding</span></section>
+  <section class="arch-tier" data-label="Logical Qubit" role="group" aria-label="Logical Qubit"><span class="arch-chip is-primary">1 Logical Qubit</span></section>
 </div>
 <figcaption>Physical data qubits and syndrome ancillas form a surface-code layout that decodes into one protected logical qubit.</figcaption>
 </figure>
@@ -38,7 +38,7 @@ Google's Willow chip finally cracked the code. They built logical qubits using s
 
 **The breakthrough:** As they increased from 3x3 to 5x5 to 7x7, the logical error rate decreased exponentially. Adding more physical qubits made the logical qubit more reliable, not less.
 
-<div class="flow">
+<div class="flow" role="group" aria-label="Willow logical qubit scaling">
   <div class="flow-node is-bad"><b>3x3 Array</b><i>9 Physical Qubits; Higher Error Rate</i></div>
   <div class="flow-node"><b>5x5 Array</b><i>25 Physical Qubits; Lower Error Rate</i></div>
   <div class="flow-node is-good"><b>7x7 Array</b><i>49 Physical Qubits; Lowest Error Rate</i></div>
@@ -56,7 +56,7 @@ The paper (["Quantum error correction below the surface code threshold"](https:/
 
 ## Why This Changes Everything
 
-<div class="flow">
+<div class="flow" role="group" aria-label="Quantum computing stack dependencies">
   <div class="flow-node"><b>Applications</b><i>Drug Discovery, Crypto, AI, Climate</i></div>
   <div class="flow-node"><b>Quantum Algorithms</b><i>Shor's, Grover's, VQE</i></div>
   <div class="flow-node"><b>Logical Qubits</b><i>Error-Corrected Computation</i></div>

--- a/src/posts/2025-11-19-promsketch-prometheus-optimization.md
+++ b/src/posts/2025-11-19-promsketch-prometheus-optimization.md
@@ -46,14 +46,14 @@ PromSketch sits between Grafana and Prometheus as a caching proxy. It uses proba
 
 **Architecture:**
 
-<div class="flow" aria-label="PromSketch query optimization path">
+<div class="flow" role="group" aria-label="PromSketch query optimization path">
   <div class="flow-node">Grafana Dashboard</div>
   <div class="flow-node">PromSketch Proxy</div>
   <div class="flow-node">Query Optimizer</div>
   <div class="flow-node is-gate">Sketch-eligible?</div>
   <div class="flow-branch">
-    <div class="flow-leg" data-branch="Yes"><div class="flow-node is-good"><b>Sketch Cache</b><i>approximation</i></div></div>
-    <div class="flow-leg" data-branch="No"><div class="flow-node"><b>Prometheus</b><i>exact data</i></div></div>
+    <div class="flow-leg" data-branch="Yes" role="group" aria-label="Yes"><div class="flow-node is-good"><b>Sketch Cache</b><i>approximation</i></div></div>
+    <div class="flow-leg" data-branch="No" role="group" aria-label="No"><div class="flow-node"><b>Prometheus</b><i>exact data</i></div></div>
   </div>
   <div class="flow-node is-good">Fast Result</div>
   <div class="flow-node"><b>Background Sketch Builder</b><i>Prometheus updates cache</i></div>

--- a/src/posts/2025-11-23-nodeshield-runtime-sbom-enforcement.md
+++ b/src/posts/2025-11-23-nodeshield-runtime-sbom-enforcement.md
@@ -51,16 +51,16 @@ NodeShield uses V8 engine hooks to intercept `require()` calls. When a module tr
 
 **Architecture:**
 
-<div class="flow" aria-label="NodeShield runtime enforcement path">
+<div class="flow" role="group" aria-label="NodeShield runtime enforcement path">
   <div class="flow-node">Node.js App</div>
   <div class="flow-node">NodeShield Hook</div>
   <div class="flow-node is-gate">Check CBOM Policy</div>
   <div class="flow-branch">
-    <div class="flow-leg" data-branch="Authorized"><div class="flow-node is-good">Load Module</div></div>
-    <div class="flow-leg" data-branch="Unauthorized"><div class="flow-node is-bad">Block + Log</div></div>
+    <div class="flow-leg" data-branch="Authorized" role="group" aria-label="Authorized"><div class="flow-node is-good">Load Module</div></div>
+    <div class="flow-leg" data-branch="Unauthorized" role="group" aria-label="Unauthorized"><div class="flow-node is-bad">Block + Log</div></div>
   </div>
 </div>
-<div class="flow" aria-label="NodeShield policy generation path">
+<div class="flow" role="group" aria-label="NodeShield policy generation path">
   <div class="flow-node">Static Outliner</div>
   <div class="flow-node">Static SBOM</div>
   <div class="flow-node is-good">CBOM Policy</div>

--- a/src/posts/2025-12-10-homelab-security-dashboard-grafana-prometheus.md
+++ b/src/posts/2025-12-10-homelab-security-dashboard-grafana-prometheus.md
@@ -47,10 +47,10 @@ With proper dashboards? Real-time alerts caught similar attempts in under 2 minu
 - **Custom exporters**: Security-specific metrics
 
 <figure class="arch-fig">
-<div class="arch is-stack" aria-label="Homelab security dashboard architecture">
-  <section class="arch-tier" data-label="Data Sources"><span class="arch-chip">Node Exporter</span><span class="arch-chip">SSH Monitor</span><span class="arch-chip">Firewall Exporter</span><span class="arch-chip">Blackbox Exporter</span><span class="arch-chip">Threat Intel Feed</span></section>
-  <section class="arch-tier" data-label="Core Stack"><span class="arch-chip is-primary"><b>Prometheus</b><i>TSDB, 90-day retention</i></span><span class="arch-chip is-guard">Alertmanager</span></section>
-  <section class="arch-tier" data-label="Outputs"><span class="arch-chip is-primary">Grafana Dashboards</span><span class="arch-chip is-bad">Immediate Notify</span><span class="arch-chip is-warn">Hourly Summary</span></section>
+<div class="arch is-stack" role="group" aria-label="Homelab security dashboard architecture">
+  <section class="arch-tier" data-label="Data Sources" role="group" aria-label="Data Sources"><span class="arch-chip">Node Exporter</span><span class="arch-chip">SSH Monitor</span><span class="arch-chip">Firewall Exporter</span><span class="arch-chip">Blackbox Exporter</span><span class="arch-chip">Threat Intel Feed</span></section>
+  <section class="arch-tier" data-label="Core Stack" role="group" aria-label="Core Stack"><span class="arch-chip is-primary"><b>Prometheus</b><i>TSDB, 90-day retention</i></span><span class="arch-chip is-guard">Alertmanager</span></section>
+  <section class="arch-tier" data-label="Outputs" role="group" aria-label="Outputs"><span class="arch-chip is-primary">Grafana Dashboards</span><span class="arch-chip is-bad">Immediate Notify</span><span class="arch-chip is-warn">Hourly Summary</span></section>
 </div>
 <figcaption>Exporters feed Prometheus; Prometheus drives Grafana queries and Alertmanager notification paths.</figcaption>
 </figure>
@@ -332,17 +332,17 @@ groups:
 
 ### Alert Fatigue Prevention
 
-<div class="flow" aria-label="Security alert routing and deduplication">
+<div class="flow" role="group" aria-label="Security alert routing and deduplication">
   <div class="flow-node">Security Event</div>
   <div class="flow-node">Prometheus Evaluates Rules</div>
   <div class="flow-node is-gate">Exceeds Threshold?</div>
   <div class="flow-branch">
-    <div class="flow-leg" data-branch="No"><div class="flow-node">Log Only - Info</div></div>
-    <div class="flow-leg" data-branch="Yes"><div class="flow-node is-gate">Severity?</div></div>
+    <div class="flow-leg" data-branch="No" role="group" aria-label="No"><div class="flow-node">Log Only - Info</div></div>
+    <div class="flow-leg" data-branch="Yes" role="group" aria-label="Yes"><div class="flow-node is-gate">Severity?</div></div>
   </div>
   <div class="flow-branch">
-    <div class="flow-leg" data-branch="Critical"><div class="flow-node is-bad"><b>Immediate Notification</b><i>webhook, respond now</i></div></div>
-    <div class="flow-leg" data-branch="Warning"><div class="flow-node"><b>Hourly Summary Batch</b><i>investigate within 4h</i></div></div>
+    <div class="flow-leg" data-branch="Critical" role="group" aria-label="Critical"><div class="flow-node is-bad"><b>Immediate Notification</b><i>webhook, respond now</i></div></div>
+    <div class="flow-leg" data-branch="Warning" role="group" aria-label="Warning"><div class="flow-node"><b>Hourly Summary Batch</b><i>investigate within 4h</i></div></div>
   </div>
   <div class="flow-node"><b>Alertmanager Groups</b><i>by alertname, 5m intervals</i></div>
   <div class="flow-node">Deduplicate - 12h repeat interval</div>
@@ -505,7 +505,7 @@ def geolocate_ip(ip_address):
 
 ### Correlation Dashboard
 
-<div class="flow" aria-label="Security signal correlation workflow">
+<div class="flow" role="group" aria-label="Security signal correlation workflow">
   <div class="flow-parallel">
     <div class="flow-node">SSH Failed Logins</div>
     <div class="flow-node">Port Scans</div>
@@ -514,9 +514,9 @@ def geolocate_ip(ip_address):
   </div>
   <div class="flow-node is-gate"><b>Correlation Engine</b><i>PromQL join on source_ip</i></div>
   <div class="flow-branch">
-    <div class="flow-leg" data-branch="1 signal"><div class="flow-node">Opportunistic Scan</div></div>
-    <div class="flow-leg" data-branch="2 signals"><div class="flow-node">Targeted Probe</div></div>
-    <div class="flow-leg" data-branch="3+ signals"><div class="flow-node is-bad">Active Compromise</div></div>
+    <div class="flow-leg" data-branch="1 signal" role="group" aria-label="1 signal"><div class="flow-node">Opportunistic Scan</div></div>
+    <div class="flow-leg" data-branch="2 signals" role="group" aria-label="2 signals"><div class="flow-node">Targeted Probe</div></div>
+    <div class="flow-leg" data-branch="3+ signals" role="group" aria-label="3+ signals"><div class="flow-node is-bad">Active Compromise</div></div>
   </div>
 </div>
 

--- a/src/posts/2025-12-17-docker-container-hardening-homelab.md
+++ b/src/posts/2025-12-17-docker-container-hardening-homelab.md
@@ -28,7 +28,7 @@ Container security isn't binary. You can't just "enable security" and assume you
 - **Network segmentation** contains lateral movement
 - **Resource limits** stop resource exhaustion attacks
 
-<div class="flow">
+<div class="flow" role="group" aria-label="Container defense-in-depth layers">
   <div class="flow-node is-bad">Attacker</div>
   <div class="flow-node"><b>Layer 1: Minimal Base Images</b><i>reduced attack surface</i></div>
   <div class="flow-node"><b>Layer 2: User Namespaces</b><i>no real root privileges</i></div>
@@ -273,10 +273,10 @@ docker run \
 ## Layer 7: Network Segmentation
 
 <figure class="arch-fig">
-<div class="arch" aria-label="Docker frontend and backend network zones">
-  <section class="arch-tier" data-label="Internet Edge"><span class="arch-chip">Internet</span><span class="arch-chip">Load Balancer</span></section>
-  <section class="arch-tier" data-label="frontend-network - 172.20.1.0/24"><span class="arch-chip">Nginx Reverse Proxy</span><span class="arch-chip is-primary">Web Application</span></section>
-  <section class="arch-tier" data-label="backend-network - 172.20.2.0/24 (internal)"><span class="arch-chip is-primary">API Server</span><span class="arch-chip is-guard">PostgreSQL</span><span class="arch-chip is-guard">Redis</span></section>
+<div class="arch" role="group" aria-label="Docker frontend and backend network zones">
+  <section class="arch-tier" data-label="Internet Edge" role="group" aria-label="Internet Edge"><span class="arch-chip">Internet</span><span class="arch-chip">Load Balancer</span></section>
+  <section class="arch-tier" data-label="frontend-network - 172.20.1.0/24" role="group" aria-label="frontend-network - 172.20.1.0/24"><span class="arch-chip">Nginx Reverse Proxy</span><span class="arch-chip is-primary">Web Application</span></section>
+  <section class="arch-tier" data-label="backend-network - 172.20.2.0/24 (internal)" role="group" aria-label="backend-network - 172.20.2.0/24 (internal)"><span class="arch-chip is-primary">API Server</span><span class="arch-chip is-guard">PostgreSQL</span><span class="arch-chip is-guard">Redis</span></section>
 </div>
 <figcaption>The frontend can reach the API on port 8080; direct Nginx-to-database and internet-to-backend paths stay blocked.</figcaption>
 </figure>
@@ -340,7 +340,7 @@ docker run \
 
 ## Implementation Strategy
 
-<div class="flow">
+<div class="flow" role="group" aria-label="Container hardening rollout plan">
   <div class="flow-node"><b>Week 1</b><i>Base Images + Resource Limits; Low disruption</i></div>
   <div class="flow-node"><b>Week 2</b><i>User Namespaces</i></div>
   <div class="flow-node"><b>Week 3</b><i>Cap Drop + Read-Only FS; Medium disruption</i></div>

--- a/src/posts/2025-12-24-private-cloud-homelab-proxmox-security.md
+++ b/src/posts/2025-12-24-private-cloud-homelab-proxmox-security.md
@@ -36,10 +36,10 @@ My setup runs on a single Dell R910:
 This single node handles 30+ VMs and containers comfortably. With 256GB RAM, careful resource allocation is key, but it's more than sufficient for a full-featured homelab. Uptime averages 99.7% - better than some cloud providers I've used.
 
 <figure class="arch-fig">
-<div class="arch" aria-label="Private cloud physical architecture">
-  <section class="arch-tier" data-label="Dell R910"><span class="arch-chip is-primary"><b>Proxmox VE Host</b><i>4x Xeon E7540, 256GB RAM</i></span><span class="arch-chip">30+ VMs</span><span class="arch-chip">LXC Containers</span><span class="arch-chip">ZFS Pool - OS + VM Storage</span><span class="arch-chip">12TB HDD - Bulk Storage</span></section>
-  <section class="arch-tier" data-label="Network - Ubiquiti"><span class="arch-chip is-guard">UDM Pro - Firewall / Router</span><span class="arch-chip">UniFi Switch 24 PoE</span></section>
-  <section class="arch-tier" data-label="Storage Server"><span class="arch-chip is-primary"><b>TrueNAS Core</b><i>~30TB usable, RAIDZ2</i></span></section>
+<div class="arch" role="group" aria-label="Private cloud physical architecture">
+  <section class="arch-tier" data-label="Dell R910" role="group" aria-label="Dell R910"><span class="arch-chip is-primary"><b>Proxmox VE Host</b><i>4x Xeon E7540, 256GB RAM</i></span><span class="arch-chip">30+ VMs</span><span class="arch-chip">LXC Containers</span><span class="arch-chip">ZFS Pool - OS + VM Storage</span><span class="arch-chip">12TB HDD - Bulk Storage</span></section>
+  <section class="arch-tier" data-label="Network - Ubiquiti" role="group" aria-label="Network - Ubiquiti"><span class="arch-chip is-guard">UDM Pro - Firewall / Router</span><span class="arch-chip">UniFi Switch 24 PoE</span></section>
+  <section class="arch-tier" data-label="Storage Server" role="group" aria-label="Storage Server"><span class="arch-chip is-primary"><b>TrueNAS Core</b><i>~30TB usable, RAIDZ2</i></span></section>
 </div>
 <figcaption>Proxmox manages compute locally, connects to Ubiquiti for management and VM traffic, and uses TrueNAS over 10GbE iSCSI for shared storage.</figcaption>
 </figure>
@@ -61,10 +61,10 @@ Proxmox supports multiple storage backends. I tested five configurations over 12
 **Winner:** ZFS over iSCSI. My TrueNAS Core server provides ~30TB usable storage (from 40TB raw) with RAIDZ2 protection. Proxmox sees it as shared block storage, perfect for VM disks and backups.
 
 <figure class="arch-fig">
-<div class="arch" aria-label="Proxmox storage architecture">
-  <section class="arch-tier" data-label="Proxmox Host"><span class="arch-chip is-primary">Proxmox VE</span></section>
-  <section class="arch-tier" data-label="Local Storage"><span class="arch-chip"><b>ZFS Pool</b><i>VM disks, fast</i></span><span class="arch-chip"><b>12TB HDD</b><i>bulk / ISOs</i></span></section>
-  <section class="arch-tier" data-label="Network Storage"><span class="arch-chip is-primary">TrueNAS Core</span><span class="arch-chip is-guard"><b>RAIDZ2 Pool</b><i>40TB raw to 30TB usable</i></span></section>
+<div class="arch" role="group" aria-label="Proxmox storage architecture">
+  <section class="arch-tier" data-label="Proxmox Host" role="group" aria-label="Proxmox Host"><span class="arch-chip is-primary">Proxmox VE</span></section>
+  <section class="arch-tier" data-label="Local Storage" role="group" aria-label="Local Storage"><span class="arch-chip"><b>ZFS Pool</b><i>VM disks, fast</i></span><span class="arch-chip"><b>12TB HDD</b><i>bulk / ISOs</i></span></section>
+  <section class="arch-tier" data-label="Network Storage" role="group" aria-label="Network Storage"><span class="arch-chip is-primary">TrueNAS Core</span><span class="arch-chip is-guard"><b>RAIDZ2 Pool</b><i>40TB raw to 30TB usable</i></span></section>
 </div>
 <figcaption>Proxmox uses local disks directly and reaches the TrueNAS RAIDZ2 pool over 10GbE iSCSI.</figcaption>
 </figure>
@@ -103,13 +103,13 @@ I implemented five VLANs using my Ubiquiti Dream Machine Pro and UniFi Switch 24
 Each VLAN has specific firewall rules enforced by the Dream Machine Pro. Cross-VLAN communication requires explicit allow rules. The UniFi ecosystem makes this manageable through a single interface.
 
 <figure class="arch-fig">
-<div class="arch" aria-label="Private cloud VLAN segmentation">
-  <section class="arch-tier" data-label="Edge"><span class="arch-chip">Internet</span><span class="arch-chip is-guard"><b>UDM Pro</b><i>firewall / router</i></span></section>
-  <section class="arch-tier" data-label="VLAN 10 - Management - 192.168.10.0/24"><span class="arch-chip is-primary">Proxmox Host</span><span class="arch-chip">TrueNAS</span><span class="arch-chip is-guard">Bastion Host</span></section>
-  <section class="arch-tier" data-label="VLAN 20 - Services - 192.168.20.0/24"><span class="arch-chip">GitLab CE</span><span class="arch-chip">BookStack</span><span class="arch-chip">Jellyfin</span></section>
-  <section class="arch-tier" data-label="VLAN 30 - IoT - 192.168.30.0/24"><span class="arch-chip">Home Assistant</span><span class="arch-chip is-warn">Smart Devices</span></section>
-  <section class="arch-tier" data-label="VLAN 40 - Guest - 192.168.40.0/24"><span class="arch-chip is-guard">Guest Devices - Internet Only</span></section>
-  <section class="arch-tier" data-label="VLAN 50 - Lab - 192.168.50.0/24"><span class="arch-chip"><b>K3s Cluster</b><i>3x Pi 5 + 1x Pi 4</i></span></section>
+<div class="arch" role="group" aria-label="Private cloud VLAN segmentation">
+  <section class="arch-tier" data-label="Edge" role="group" aria-label="Edge"><span class="arch-chip">Internet</span><span class="arch-chip is-guard"><b>UDM Pro</b><i>firewall / router</i></span></section>
+  <section class="arch-tier" data-label="VLAN 10 - Management - 192.168.10.0/24" role="group" aria-label="VLAN 10 - Management - 192.168.10.0/24"><span class="arch-chip is-primary">Proxmox Host</span><span class="arch-chip">TrueNAS</span><span class="arch-chip is-guard">Bastion Host</span></section>
+  <section class="arch-tier" data-label="VLAN 20 - Services - 192.168.20.0/24" role="group" aria-label="VLAN 20 - Services - 192.168.20.0/24"><span class="arch-chip">GitLab CE</span><span class="arch-chip">BookStack</span><span class="arch-chip">Jellyfin</span></section>
+  <section class="arch-tier" data-label="VLAN 30 - IoT - 192.168.30.0/24" role="group" aria-label="VLAN 30 - IoT - 192.168.30.0/24"><span class="arch-chip">Home Assistant</span><span class="arch-chip is-warn">Smart Devices</span></section>
+  <section class="arch-tier" data-label="VLAN 40 - Guest - 192.168.40.0/24" role="group" aria-label="VLAN 40 - Guest - 192.168.40.0/24"><span class="arch-chip is-guard">Guest Devices - Internet Only</span></section>
+  <section class="arch-tier" data-label="VLAN 50 - Lab - 192.168.50.0/24" role="group" aria-label="VLAN 50 - Lab - 192.168.50.0/24"><span class="arch-chip"><b>K3s Cluster</b><i>3x Pi 5 + 1x Pi 4</i></span></section>
 </div>
 <figcaption>The UDM Pro routes each VLAN; Home Assistant bridges only to approved services, and bastion SSH is the management entry point.</figcaption>
 </figure>
@@ -200,11 +200,11 @@ Backups are boring until you need them. I learned this during a storage controll
 **Tier 3 - Offsite replication:** Restic backups to Backblaze B2. Critical data encrypted and synced daily, full backups weekly. 90-day retention with versioning.
 
 <figure class="arch-fig">
-<div class="arch is-stack" aria-label="Three-tier Proxmox backup strategy">
-  <section class="arch-tier" data-label="Source"><span class="arch-chip is-primary">VMs &amp; Containers</span></section>
-  <section class="arch-tier" data-label="Tier 1 - Local"><span class="arch-chip"><b>ZFS Snapshots</b><i>every hour, 48h retention</i></span></section>
-  <section class="arch-tier" data-label="Tier 2 - On-Site"><span class="arch-chip">Weekly Full Backup</span><span class="arch-chip">Daily Incrementals</span><span class="arch-chip is-guard"><b>TrueNAS RAIDZ2</b><i>30-day retention</i></span></section>
-  <section class="arch-tier" data-label="Tier 3 - Offsite"><span class="arch-chip is-guard">Restic Encrypted</span><span class="arch-chip is-primary"><b>Backblaze B2</b><i>90-day retention</i></span></section>
+<div class="arch is-stack" role="group" aria-label="Three-tier Proxmox backup strategy">
+  <section class="arch-tier" data-label="Source" role="group" aria-label="Source"><span class="arch-chip is-primary">VMs &amp; Containers</span></section>
+  <section class="arch-tier" data-label="Tier 1 - Local" role="group" aria-label="Tier 1 - Local"><span class="arch-chip"><b>ZFS Snapshots</b><i>every hour, 48h retention</i></span></section>
+  <section class="arch-tier" data-label="Tier 2 - On-Site" role="group" aria-label="Tier 2 - On-Site"><span class="arch-chip">Weekly Full Backup</span><span class="arch-chip">Daily Incrementals</span><span class="arch-chip is-guard"><b>TrueNAS RAIDZ2</b><i>30-day retention</i></span></section>
+  <section class="arch-tier" data-label="Tier 3 - Offsite" role="group" aria-label="Tier 3 - Offsite"><span class="arch-chip is-guard">Restic Encrypted</span><span class="arch-chip is-primary"><b>Backblaze B2</b><i>90-day retention</i></span></section>
 </div>
 <figcaption>Local snapshots handle fast rollback, on-site backups cover VM recovery, and encrypted Restic syncs critical data offsite.</figcaption>
 </figure>

--- a/src/posts/2026-01-15-routellm-contextual-bandits-model-router-research.md
+++ b/src/posts/2026-01-15-routellm-contextual-bandits-model-router-research.md
@@ -102,7 +102,7 @@ Not every paper I read was useful. A few approaches I tried and discarded:
 
 ## The Full Pipeline
 
-<div class="flow" aria-label="RouteLLM contextual bandit routing pipeline">
+<div class="flow" role="group" aria-label="RouteLLM contextual bandit routing pipeline">
   <div class="flow-node">Task Input</div>
   <div class="flow-node">Budget Router</div>
   <div class="flow-node">Zero Router</div>

--- a/src/posts/2026-01-28-consensus-voting-ai-models-multi-agent.md
+++ b/src/posts/2026-01-28-consensus-voting-ai-models-multi-agent.md
@@ -39,7 +39,7 @@ These findings led to two design decisions: role-based agent assignment with rou
 
 ## How Consensus Voting Works
 
-<div class="flow" aria-label="Consensus voting decision workflow">
+<div class="flow" role="group" aria-label="Consensus voting decision workflow">
   <div class="flow-node">Proposal Text</div>
   <div class="flow-node">Round-Robin Model Assignment</div>
   <div class="flow-parallel">
@@ -52,8 +52,8 @@ These findings led to two design decisions: role-based agent assignment with rou
   <div class="flow-node">Vote Aggregation</div>
   <div class="flow-node is-gate">Strategy Threshold</div>
   <div class="flow-branch">
-    <div class="flow-leg" data-branch="Met"><div class="flow-node is-good">APPROVED</div></div>
-    <div class="flow-leg" data-branch="Not Met"><div class="flow-node is-bad">REJECTED</div></div>
+    <div class="flow-leg" data-branch="Met" role="group" aria-label="Met"><div class="flow-node is-good">APPROVED</div></div>
+    <div class="flow-leg" data-branch="Not Met" role="group" aria-label="Not Met"><div class="flow-node is-bad">REJECTED</div></div>
   </div>
 </div>
 

--- a/src/posts/2026-02-09-building-nexus-agents-multi-model-orchestration.md
+++ b/src/posts/2026-02-09-building-nexus-agents-multi-model-orchestration.md
@@ -36,11 +36,11 @@ MCP gave me a standard interface that any compatible client could use. Claude Co
 An [STPA safety analysis of MCP](https://arxiv.org/abs/2601.08012) later validated some of my security concerns about the protocol. More on that below.
 
 <figure class="arch-fig">
-<div class="arch is-stack" aria-label="Nexus-Agents MCP orchestration architecture">
-  <section class="arch-tier" data-label="MCP Clients"><span class="arch-chip">Claude Code</span><span class="arch-chip">Cursor</span><span class="arch-chip">Windsurf</span></section>
-  <section class="arch-tier" data-label="Nexus-Agents MCP Server"><span class="arch-chip is-primary"><b>MCP Protocol Layer</b><i>25 tools</i></span><span class="arch-chip">Orchestrator</span><span class="arch-chip">CompositeRouter - 5-Stage Pipeline</span><span class="arch-chip">Consensus Engine</span><span class="arch-chip">Graph Workflows</span><span class="arch-chip">Plugin Pipeline</span></section>
-  <section class="arch-tier" data-label="CLI Adapters"><span class="arch-chip">Claude Adapter</span><span class="arch-chip">Gemini Adapter</span><span class="arch-chip">Codex Adapter</span><span class="arch-chip">OpenCode Adapter</span></section>
-  <section class="arch-tier" data-label="AI Models"><span class="arch-chip is-primary">Claude Opus / Sonnet</span><span class="arch-chip is-primary">Gemini Pro / Flash</span><span class="arch-chip is-primary">Codex</span></section>
+<div class="arch is-stack" role="group" aria-label="Nexus-Agents MCP orchestration architecture">
+  <section class="arch-tier" data-label="MCP Clients" role="group" aria-label="MCP Clients"><span class="arch-chip">Claude Code</span><span class="arch-chip">Cursor</span><span class="arch-chip">Windsurf</span></section>
+  <section class="arch-tier" data-label="Nexus-Agents MCP Server" role="group" aria-label="Nexus-Agents MCP Server"><span class="arch-chip is-primary"><b>MCP Protocol Layer</b><i>25 tools</i></span><span class="arch-chip">Orchestrator</span><span class="arch-chip">CompositeRouter - 5-Stage Pipeline</span><span class="arch-chip">Consensus Engine</span><span class="arch-chip">Graph Workflows</span><span class="arch-chip">Plugin Pipeline</span></section>
+  <section class="arch-tier" data-label="CLI Adapters" role="group" aria-label="CLI Adapters"><span class="arch-chip">Claude Adapter</span><span class="arch-chip">Gemini Adapter</span><span class="arch-chip">Codex Adapter</span><span class="arch-chip">OpenCode Adapter</span></section>
+  <section class="arch-tier" data-label="AI Models" role="group" aria-label="AI Models"><span class="arch-chip is-primary">Claude Opus / Sonnet</span><span class="arch-chip is-primary">Gemini Pro / Flash</span><span class="arch-chip is-primary">Codex</span></section>
 </div>
 <figcaption>MCP clients enter through the server, the orchestrator selects routing, consensus, workflow, or plugin tools, and adapters call the underlying models.</figcaption>
 </figure>
@@ -77,7 +77,7 @@ Picking the right model for a task isn't simple. I built a five-stage routing pi
 
 The entire pipeline runs in under 10ms. I was surprised how fast TOPSIS is when you're only ranking 6-8 models. The routing decision is nearly free compared to actual model inference. I wrote a [deeper dive on the routing research](/posts/2026-01-15-routellm-contextual-bandits-model-router-research/) separately, including the approaches that didn't work.
 
-<div class="flow" aria-label="Nexus-Agents five-stage routing pipeline">
+<div class="flow" role="group" aria-label="Nexus-Agents five-stage routing pipeline">
   <div class="flow-node">Incoming Task</div>
   <div class="flow-node"><b>1. Budget</b><i>Router</i></div>
   <div class="flow-node"><b>2. Zero</b><i>Router</i></div>

--- a/src/posts/2026-07-19-oklch-terminal-themes.md
+++ b/src/posts/2026-07-19-oklch-terminal-themes.md
@@ -67,7 +67,7 @@ The dataset also tags each theme with plain WCAG contrast ratios. `classify.ts` 
 
 For each curated theme, the script derives a dozen CSS tokens — muted text, borders, code background, accent, accent-hover — by mixing the theme's foreground and background in OKLCH space, with shortest-arc hue interpolation so a blend never takes the scenic route around the color wheel. Every derived token gets checked against the same floors as the source data. If a mixed color can't clear its floor, the script raises and the build fails. That's the actual payoff of all of this: not that OKLCH computes contrast for you (plain luminance math does that, color-space agnostic), but that colors nobody hand-picked stay predictable enough to gate a build on.
 
-<div class="flow">
+<div class="flow" role="group" aria-label="OKLCH theme build pipeline">
   <div class="flow-node"><b>12 upstream repos</b><i>sources.json, pinned SHAs</i></div>
   <div class="flow-node">fetch-upstream.ts</div>
   <div class="flow-node"><b>build.ts</b><i>hex to OKLCH (culori)</i></div>


### PR DESCRIPTION
A consensus QA/a11y/vestigial review of the shipped diagram system (3 sonnet dimensions, adversarially verified) surfaced 7 confirmed defects that `axe` CI can't catch. All addressed here.

## a11y (screen readers)
- **`role="group"` on all 96 `.flow`/`.arch` roots** — a bare `<div>` is `role=generic`, which per the AccName spec *silently discards* `aria-label`. Every diagram's label was invisible to AT. (spec- and build-verified)
- **Tier/branch structure**: mirrored 126 `.arch-tier` `data-label`s and 67 `.flow-leg` `data-branch`es into `role="group"` + `aria-label` (the CSS `::before` label is visual-only and unreliably announced).
- **Backfilled `aria-label`** on the 17 `.flow` diagrams that had none.

## vestigial CSS
- Deleted the dead `.flow-parallel .flow-node::before/::after {content:none}` cancel-rule (never matched — those nodes aren't direct `.flow` children).
- Deleted the `.arch-fig figcaption` override; the canonical `figcaption` rule now applies (consistency).

## Docs
- `docs/content-visuals.md` contracts + examples and the `blog-visuals` skill now require `role="group"` + `aria-label`, so future posts are accessible by default.

## Deferred
- Richer list/parallel-vs-sequential semantics → #422 (bigger semantic choice; axe already passes).

Verified: a11y attrs present in dist, `pnpm build` green, 13px floor clean, format gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)