### PR TITLE
fix(content): replace 43 CSP-blocked gist embeds with clean links (#424)

### DIFF
--- a/src/posts/2025-02-10-automating-home-network-security.md
+++ b/src/posts/2025-02-10-automating-home-network-security.md
@@ -32,7 +32,7 @@ pip install collections email ipaddress nmap requests smtplib sqlite3 subprocess
 
 Or create a `requirements.txt` file with these dependencies:
 
-<script src="https://gist.github.com/williamzujkowski/7bb056a1b487f9fc2e4a61f9a76ab8a4.js"></script>
+🔖 [Home network security automation requirements file ↗](https://gist.github.com/williamzujkowski/7bb056a1b487f9fc2e4a61f9a76ab8a4)
 Managing home network security is like being a one-person SOC (Security Operations Center). You've got multiple devices, various family members with different tech literacy levels, and new threats emerging daily. Manual security management doesn't scale. Especially when you're also trying to be present for bedtime stories.
 
 After running my [home network](/posts/2025-04-24-building-secure-homelab-adventure) with 25+ connected devices (including IoT gadgets, family laptops, and that inevitable "smart" toaster), I've developed Python scripts and automation workflows that maintain security without sacrificing family time.
@@ -55,7 +55,7 @@ That's when I realized we needed automation – not just for security, but for m
 
 Here's the script that saves my sanity (runs hourly, alerts immediately):
 
-<script src="https://gist.github.com/williamzujkowski/2abad62ff98d044d09102ae06ecf3b0f.js"></script>
+🔖 [Automated home network device discovery script ↗](https://gist.github.com/williamzujkowski/2abad62ff98d044d09102ae06ecf3b0f)
 
 ## DNS Monitoring and Ad Blocking
 
@@ -65,31 +65,31 @@ One of the most effective security measures is controlling DNS. I use Pi-hole fo
 
 This script monitors DNS logs for suspicious patterns:
 
-<script src="https://gist.github.com/williamzujkowski/6c7c754be164e75b84f6b9e601753531.js"></script>
+🔖 [Suspicious DNS query monitoring script ↗](https://gist.github.com/williamzujkowski/6c7c754be164e75b84f6b9e601753531)
 
 ## Automated Vulnerability Scanning
 
 Keeping devices patched is crucial. This script runs weekly to identify vulnerable services:
 
-<script src="https://gist.github.com/williamzujkowski/e3e41c782e4099a06a6ac1f482cd3119.js"></script>
+🔖 [Automated vulnerability scanning script ↗](https://gist.github.com/williamzujkowski/e3e41c782e4099a06a6ac1f482cd3119)
 
 ## Smart Firewall Rules Management
 
 Static firewall rules don't adapt to changing threats. Here's how I automate rule updates:
 
-<script src="https://gist.github.com/williamzujkowski/6af94c70d3afd57829d26c12940d1cb1.js"></script>
+🔖 [Smart firewall rule automation script ↗](https://gist.github.com/williamzujkowski/6af94c70d3afd57829d26c12940d1cb1)
 
 ## Notification System
 
 All this automation is useless if you don't know what's happening. Here's my notification system:
 
-<script src="https://gist.github.com/williamzujkowski/f025bd03e6d265b8aa9fdb8d73df9740.js"></script>
+🔖 [Home network security notification system ↗](https://gist.github.com/williamzujkowski/f025bd03e6d265b8aa9fdb8d73df9740)
 
 ## Putting It All Together
 
 The real power comes from orchestrating these scripts. Here's my master automation script:
 
-<script src="https://gist.github.com/williamzujkowski/9cc496653878271d7045108bead98a65.js"></script>
+🔖 [Master home network security automation script ↗](https://gist.github.com/williamzujkowski/9cc496653878271d7045108bead98a65)
 
 ## Lessons Learned
 

--- a/src/posts/2025-04-10-securing-personal-ai-experiments.md
+++ b/src/posts/2025-04-10-securing-personal-ai-experiments.md
@@ -57,13 +57,13 @@ My first rule: AI experiments run in isolation.
 
 This approach adds operational complexity, trading convenience for security. But isolation prevents one compromised experiment from cascading across your network — and a compromised experiment with 24GB of VRAM and no rate limit is not something you want loose.
 
-<script src="https://gist.github.com/williamzujkowski/d8ad8f2e7cb5431e0def2c94283d4ce5.js"></script>
+🔖 [Secure AI sandbox isolation setup ↗](https://gist.github.com/williamzujkowski/d8ad8f2e7cb5431e0def2c94283d4ce5)
 
 ### Network Segmentation for AI Workloads
 
 AI experiments get their own VLAN with strict firewall rules:
 
-<script src="https://gist.github.com/williamzujkowski/6eaf1ebe4f96aad330fc23fc5b57c671.js"></script>
+🔖 [AI workload VLAN segmentation rules ↗](https://gist.github.com/williamzujkowski/6eaf1ebe4f96aad330fc23fc5b57c671)
 
 ## Securing Local LLM Deployments
 
@@ -71,19 +71,19 @@ Running LLMs locally (like LLaMA or Mistral) requires special consideration:
 
 ### Safe Model Loading
 
-<script src="https://gist.github.com/williamzujkowski/139b291b7ab1aaf8188ae9d66370a018.js"></script>
+🔖 [Safe local LLM model loading workflow ↗](https://gist.github.com/williamzujkowski/139b291b7ab1aaf8188ae9d66370a018)
 
 ### Prompt Injection Protection
 
 When building AI applications, protecting against prompt injection is crucial:
 
-<script src="https://gist.github.com/williamzujkowski/5c97f26a169c386e822ffe9a77e48507.js"></script>
+🔖 [Prompt injection protection examples ↗](https://gist.github.com/williamzujkowski/5c97f26a169c386e822ffe9a77e48507)
 
 ## Monitoring AI Resource Usage
 
 AI workloads can consume significant resources. Here's how I monitor them:
 
-<script src="https://gist.github.com/williamzujkowski/328c43577820c92437ed40c58e276ae8.js"></script>
+🔖 [AI resource usage monitoring scripts ↗](https://gist.github.com/williamzujkowski/328c43577820c92437ed40c58e276ae8)
 
 ## Data Privacy in AI Experiments
 
@@ -91,13 +91,13 @@ AI workloads can consume significant resources. Here's how I monitor them:
 
 When experimenting with AI, especially when using family photos or documents:
 
-<script src="https://gist.github.com/williamzujkowski/271230bd22778b63d2645fb63570b3bf.js"></script>
+🔖 [AI experiment data leakage prevention workflow ↗](https://gist.github.com/williamzujkowski/271230bd22778b63d2645fb63570b3bf)
 
 ### Secure API Key Management
 
 For cloud AI services, proper API key management is essential:
 
-<script src="https://gist.github.com/williamzujkowski/9321cf345abbe8ae554d4d106645a0db.js"></script>
+🔖 [Secure AI API key management examples ↗](https://gist.github.com/williamzujkowski/9321cf345abbe8ae554d4d106645a0db)
 
 ## Family-Safe AI Guidelines
 
@@ -105,7 +105,7 @@ When kids want to experiment with AI, additional safeguards are needed:
 
 ### Content Filtering for AI Outputs
 
-<script src="https://gist.github.com/williamzujkowski/cda8c25a0a3b3596aa38207ad76769a8.js"></script>
+🔖 [Family-safe AI output filtering examples ↗](https://gist.github.com/williamzujkowski/cda8c25a0a3b3596aa38207ad76769a8)
 
 ## Lessons Learned
 

--- a/src/posts/2025-07-08-implementing-dns-over-https-home-networks.md
+++ b/src/posts/2025-07-08-implementing-dns-over-https-home-networks.md
@@ -91,7 +91,7 @@ Select provider or enter custom: [https://dns.google/dns-query](https://dns.goog
 
 For system-wide protection, I use `cloudflared`:
 
-<script src="https://gist.github.com/williamzujkowski/9ca841f8bdea7bced7c797ee2cfa5597.js"></script>
+🔖 [System-wide DoH setup with cloudflared ↗](https://gist.github.com/williamzujkowski/9ca841f8bdea7bced7c797ee2cfa5597)
 
 ### Windows DoH Setup
 
@@ -161,7 +161,7 @@ sudo systemctl enable dnsdist && sudo systemctl start dnsdist
 
 ### Verify DoH is Working
 
-<script src="https://gist.github.com/williamzujkowski/82e4d29a006b6fc5b20b881760d6deb9.js"></script>
+🔖 [DNS-over-HTTPS validation and monitoring tools ↗](https://gist.github.com/williamzujkowski/82e4d29a006b6fc5b20b881760d6deb9)
 
 ### Performance Monitoring
 
@@ -195,7 +195,7 @@ Provider Comparison:
 
 Ensure all DNS queries use DoH:
 
-<script src="https://gist.github.com/williamzujkowski/48bd7c6e1d18e0d12cfcad67ff4a644c.js"></script>
+🔖 [DNS-over-HTTPS bypass prevention rules ↗](https://gist.github.com/williamzujkowski/48bd7c6e1d18e0d12cfcad67ff4a644c)
 
 ### 3. Certificate Pinning
 
@@ -203,7 +203,7 @@ For self-hosted DoH, implement certificate pinning (see Python script in the sec
 
 ## Troubleshooting Common Issues
 
-<script src="https://gist.github.com/williamzujkowski/365d9b3a0dc812e93ec8177e5bf84922.js"></script>
+🔖 [DNS-over-HTTPS troubleshooting configurations ↗](https://gist.github.com/williamzujkowski/365d9b3a0dc812e93ec8177e5bf84922)
 
 ### 1. Slow Initial Queries
 
@@ -219,7 +219,7 @@ Some corporate networks block DoH. See the corporate network detection script in
 
 ## Advanced Configurations
 
-<script src="https://gist.github.com/williamzujkowski/8749d27f31c0c222e79033fc978069bd.js"></script>
+🔖 [Advanced DNS-over-HTTPS routing configurations ↗](https://gist.github.com/williamzujkowski/8749d27f31c0c222e79033fc978069bd)
 
 ### Load Balancing Multiple DoH Providers
 

--- a/src/posts/2025-08-07-supercharging-development-claude-flow.md
+++ b/src/posts/2025-08-07-supercharging-development-claude-flow.md
@@ -58,7 +58,7 @@ Claude-Flow supports multiple swarm topologies, each optimized for different sce
 
 **Swarm Initialization & Agent Spawning Examples:**
 
-<script src="https://gist.github.com/williamzujkowski/2e8e787541c00d8650d83f6b9c53d03a.js"></script>
+🔖 [Claude-Flow swarm initialization and agent spawning examples ↗](https://gist.github.com/williamzujkowski/2e8e787541c00d8650d83f6b9c53d03a)
 
 [View complete examples on GitHub Gist](https://gist.github.com/williamzujkowski/2e8e787541c00d8650d83f6b9c53d03a)
 
@@ -85,7 +85,7 @@ The swarm delivered:
 
 Claude-Flow provides advanced features for learning patterns, preserving context, and optimizing workflows:
 
-<script src="https://gist.github.com/williamzujkowski/be7284a8615d02d17a7de1140b07938b.js"></script>
+🔖 [Claude-Flow neural training, memory, and performance examples ↗](https://gist.github.com/williamzujkowski/be7284a8615d02d17a7de1140b07938b)
 
 [View complete examples on GitHub Gist](https://gist.github.com/williamzujkowski/be7284a8615d02d17a7de1140b07938b)
 
@@ -141,7 +141,7 @@ Real measurements from production use:
 
 **Production-Ready Workflows:**
 
-<script src="https://gist.github.com/williamzujkowski/d7c84bb665d58245f9041d951873ed53.js"></script>
+🔖 [Claude-Flow production-ready workflow patterns ↗](https://gist.github.com/williamzujkowski/d7c84bb665d58245f9041d951873ed53)
 
 [View complete patterns on GitHub Gist](https://gist.github.com/williamzujkowski/d7c84bb665d58245f9041d951873ed53)
 
@@ -152,7 +152,7 @@ But it can over-optimize without clear completion criteria.
 
 **Installation & Configuration:**
 
-<script src="https://gist.github.com/williamzujkowski/325ab7edde18fdd562a8d8797eed466e.js"></script>
+🔖 [Claude-Flow installation and configuration guide ↗](https://gist.github.com/williamzujkowski/325ab7edde18fdd562a8d8797eed466e)
 
 [View installation guide on GitHub Gist](https://gist.github.com/williamzujkowski/325ab7edde18fdd562a8d8797eed466e)
 

--- a/src/posts/2025-08-25-network-traffic-analysis-suricata-homelab.md
+++ b/src/posts/2025-08-25-network-traffic-analysis-suricata-homelab.md
@@ -71,7 +71,7 @@ I run Suricata on my Dell R910 with:
 
 ### Installing Suricata
 
-<script src="https://gist.github.com/williamzujkowski/ac871dd21758d0f1f44986c4ee6e21e7.js"></script>
+🔖 [Suricata installation and configuration script ↗](https://gist.github.com/williamzujkowski/ac871dd21758d0f1f44986c4ee6e21e7)
 
 ## Writing Custom Suricata Rules
 
@@ -89,15 +89,15 @@ action protocol source_ip source_port -> dest_ip dest_port (rule options)
 
 One particularly valuable use case is detecting suspicious IoT device behavior — the kind that got this whole project started. After working through [lessons from OWASP IoTGoat on IoT security](/posts/2025-09-20-iot-security-homelab-owasp), I developed custom rules to catch the most common IoT attack patterns:
 
-<script src="https://gist.github.com/williamzujkowski/fdd48db6a837ca02c00c79f7c4fd6cde.js"></script>
+🔖 [Custom Suricata IoT detection rules ↗](https://gist.github.com/williamzujkowski/fdd48db6a837ca02c00c79f7c4fd6cde)
 
 ## Testing and Validation
 
-<script src="https://gist.github.com/williamzujkowski/55bec7428ee6cb7ba25a59a6aabca57d.js"></script>
+🔖 [Suricata testing and validation workflow ↗](https://gist.github.com/williamzujkowski/55bec7428ee6cb7ba25a59a6aabca57d)
 
 ## Integration with SIEM
 
-<script src="https://gist.github.com/williamzujkowski/4f6b12b16ec06c596b3baefe837ecf95.js"></script>
+🔖 [Suricata SIEM integration configuration ↗](https://gist.github.com/williamzujkowski/4f6b12b16ec06c596b3baefe837ecf95)
 
 ## Visualization with Kibana
 
@@ -110,15 +110,15 @@ sudo filebeat setup --dashboards -E output.elasticsearch.hosts=["10.0.1.5:9200"]
 
 Custom visualization queries:
 
-<script src="https://gist.github.com/williamzujkowski/35c585bdda7f328093d18b40c29ccb22.js"></script>
+🔖 [Kibana visualization queries for Suricata ↗](https://gist.github.com/williamzujkowski/35c585bdda7f328093d18b40c29ccb22)
 
 ## Advanced Detection Techniques
 
-<script src="https://gist.github.com/williamzujkowski/a6630cefcbe03030515d0b3310251b7a.js"></script>
+🔖 [Advanced Suricata detection techniques ↗](https://gist.github.com/williamzujkowski/a6630cefcbe03030515d0b3310251b7a)
 
 ## Operational Best Practices
 
-<script src="https://gist.github.com/williamzujkowski/d370286436bb31c998340c63afe8e501.js"></script>
+🔖 [Suricata operational best practices ↗](https://gist.github.com/williamzujkowski/d370286436bb31c998340c63afe8e501)
 
 ## Rule Update Security (CRITICAL)
 

--- a/src/posts/2025-09-01-self-hosted-bitwarden-migration-guide.md
+++ b/src/posts/2025-09-01-self-hosted-bitwarden-migration-guide.md
@@ -81,17 +81,17 @@ I run Vaultwarden for resource efficiency and deployment simplicity. My Proxmox 
 
 ### Docker Compose Deployment
 
-<script src="https://gist.github.com/williamzujkowski/dc0728c2908e4689896f35bec5f3855a.js"></script>
+🔖 [Vaultwarden Docker Compose deployment ↗](https://gist.github.com/williamzujkowski/dc0728c2908e4689896f35bec5f3855a)
 
 ### Deploy the Stack
 
-<script src="https://gist.github.com/williamzujkowski/b8cb1cd1d6ff8f64425f02ec912a6d1a.js"></script>
+🔖 [Vaultwarden stack deployment commands ↗](https://gist.github.com/williamzujkowski/b8cb1cd1d6ff8f64425f02ec912a6d1a)
 
 ## Reverse Proxy Configuration
 
 ### Nginx with TLS
 
-<script src="https://gist.github.com/williamzujkowski/f11619209152dd8cf3ed558335ac7a3f.js"></script>
+🔖 [Vaultwarden Nginx TLS reverse proxy configuration ↗](https://gist.github.com/williamzujkowski/f11619209152dd8cf3ed558335ac7a3f)
 
 ## Security Hardening
 
@@ -99,7 +99,7 @@ I run Vaultwarden for resource efficiency and deployment simplicity. My Proxmox 
 
 Protect against brute-force attacks:
 
-<script src="https://gist.github.com/williamzujkowski/28d9a26bcff2a02c2d0aabbaf570b409.js"></script>
+🔖 [Vaultwarden Fail2ban configuration ↗](https://gist.github.com/williamzujkowski/28d9a26bcff2a02c2d0aabbaf570b409)
 
 Restart Fail2ban:
 
@@ -112,7 +112,7 @@ sudo fail2ban-client status vaultwarden
 
 For complete firewall configuration and network segmentation strategies:
 
-<script src="https://gist.github.com/williamzujkowski/0549ee4b142ddff4d684e8ec21fb0317.js"></script>
+🔖 [Vaultwarden firewall and network segmentation rules ↗](https://gist.github.com/williamzujkowski/0549ee4b142ddff4d684e8ec21fb0317)
 
 ### Two-Factor Authentication
 
@@ -427,7 +427,7 @@ shred -vfz -n 10 lastpass-export.csv
 
 ### Automated Database Backups
 
-<script src="https://gist.github.com/williamzujkowski/f007271e97105ae16de1d28a2cfbe9d7.js"></script>
+🔖 [Automated Vaultwarden database backup script ↗](https://gist.github.com/williamzujkowski/f007271e97105ae16de1d28a2cfbe9d7)
 
 Schedule with cron:
 
@@ -438,7 +438,7 @@ Schedule with cron:
 
 ### Testing Backup Restoration
 
-<script src="https://gist.github.com/williamzujkowski/327bbe4806d93f947478373788a4ede5.js"></script>
+🔖 [Vaultwarden backup restoration test workflow ↗](https://gist.github.com/williamzujkowski/327bbe4806d93f947478373788a4ede5)
 
 **Test your backups regularly!** A backup you haven't tested is just wishful thinking.
 
@@ -448,7 +448,7 @@ Continuous monitoring is critical for self-hosted infrastructure. Learn more abo
 
 ### Health Check Script
 
-<script src="https://gist.github.com/williamzujkowski/b5fd9b8c6991a5e43587cb78f30ff344.js"></script>
+🔖 [Vaultwarden health check script ↗](https://gist.github.com/williamzujkowski/b5fd9b8c6991a5e43587cb78f30ff344)
 
 ### Prometheus Metrics
 
@@ -493,7 +493,7 @@ Export metrics for monitoring:
 
 ### CLI Client
 
-<script src="https://gist.github.com/williamzujkowski/4b8fc96deb050dd4376e396d71044031.js"></script>
+🔖 [Bitwarden CLI client setup commands ↗](https://gist.github.com/williamzujkowski/4b8fc96deb050dd4376e396d71044031)
 
 ## Disaster Recovery Plan
 

--- a/src/posts/2025-09-20-iot-security-homelab-owasp.md
+++ b/src/posts/2025-09-20-iot-security-homelab-owasp.md
@@ -48,7 +48,7 @@ Here's my home lab IoT security setup using VLANs and a dedicated analysis subne
 
 These tools catch the common IoT vulnerability classes well. For additional automation approaches, check out my post on [automating home network security with Python](/posts/2025-02-10-automating-home-network-security). The complete lab setup script includes tool installation, IoTGoat deployment, and firmware analysis commands:
 
-<script src="https://gist.github.com/williamzujkowski/680213bdd6d4a52ef369d1f2801cb9b4.js"></script>
+🔖 [IoTGoat lab setup and firmware analysis script ↗](https://gist.github.com/williamzujkowski/680213bdd6d4a52ef369d1f2801cb9b4)
 
 ## Deploying OWASP IoTGoat
 
@@ -66,7 +66,7 @@ I ran a password audit on my 23 IoT devices. Eight were still using default cred
 
 Here's a toolkit for testing IoT vulnerabilities including default credentials, MQTT discovery, and command injection:
 
-<script src="https://gist.github.com/williamzujkowski/8d96ac97bbb24da06b9b381c4b46b441.js"></script>
+🔖 [IoT vulnerability testing toolkit ↗](https://gist.github.com/williamzujkowski/8d96ac97bbb24da06b9b381c4b46b441)
 
 ### 2. Insecure MQTT Communications
 
@@ -171,7 +171,7 @@ The **trade-off** between usability and security is constant in IoT. Manufacture
 
 Here's a practical monitoring setup I use in my home lab for real-time packet analysis and anomaly detection. This complements the network traffic analysis techniques I cover in my [Suricata lab guide](/posts/2025-08-25-network-traffic-analysis-suricata-homelab):
 
-<script src="https://gist.github.com/williamzujkowski/369cedae8893df3807bc6fb66870c8e8.js"></script>
+🔖 [IoT packet analysis and anomaly detection setup ↗](https://gist.github.com/williamzujkowski/369cedae8893df3807bc6fb66870c8e8)
 
 ## Lessons Learned
 


### PR DESCRIPTION
Fixes the user-facing part of #424: **43 gist `<script>` embeds across 7 posts were blocked by the CSP** (gist.github.com isn't allowlisted) and rendered as nothing for readers.

Approved fix: replace each broken embed with a clean styled link — `🔖 [description ↗](https://gist.github.com/…)` — mirroring the convention already used in other posts (e.g. the scan-pipeline post).

## Why links (not restore-embed or inline)
- Keeps long code out of the post body (the original reason for using gists) — most of these gists are medium/long
- CSP-safe, no external script/tracking, no layout shift, theme-consistent
- Removes 43 raw `<script>` tags from post content (also shrinks the #424 XSS surface)

## Verification
- 43/43 converted; **0 remaining `<script src="gist.github.com">`** across the 7 posts
- Labels sourced from `gists/gist-mapping.json` descriptions (all descriptive, none generic/ID-only); all point at the gist page URL, not `.js`
- `pnpm build` green

Remaining #424 items (CSP `unsafe-inline`/sanitization, clickjacking) stay tracked there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)