### PR TITLE
docs(content): flag welcome.md as Eleventy-era, rebuilt on Astro (#426)

### DIFF
--- a/src/posts/welcome.md
+++ b/src/posts/welcome.md
@@ -1,13 +1,16 @@
 ---
 date: 2025-01-01
 author: William Zujkowski
-description: Build privacy-respecting sites with Eleventy—create fast, accessible static websites with zero tracking and excellent Core Web Vitals.
+description: How this site began — a privacy-first, zero-tracking static digital garden. Originally built with Eleventy; since rebuilt on Astro.
 tags:
 - web-development
 - eleventy
+- astro
 - open-source
 title: Building My Digital Garden with Eleventy
 ---
+> **Update (2026):** One of the first posts here, from when the site ran on [Eleventy](https://www.11ty.dev/). It's since been rebuilt on **[Astro](https://astro.build/)** — Svelte islands for the few interactive bits, hand-written CSS on the Remarque design system, still statically generated and hosted on GitHub Pages. The zero-tracking, privacy-first, fast-by-default philosophy below hasn't changed; only the build tool did. I've left the original text as a record of where it started.
+
 Welcome to my digital corner of the internet! After years of working in security engineering and incident response, I decided it was time to create a proper home for my thoughts, projects, and learnings. This site documents [my secure homelab journey](/posts/2025-04-24-building-secure-homelab-adventure/), development workflows, and technical experiments.
 
 ## The Journey to Eleventy


### PR DESCRIPTION
Part of #426. The intro post `welcome.md` describes building the site with **Eleventy**, but it's since been rebuilt on **Astro**. Rather than fabricate an 'I chose Astro' narrative (the Jan-2025 post was accurate at the time), added a dated **update note** clarifying the current stack + reframed the frontmatter description. Kept the historical body as a record. Also added the `astro` tag.

On the greek-preload item (also #426): checked the built `<head>` — no greek font file is preloaded; the greek subset is a separate unicode-range file that only downloads when a Greek glyph renders, so the 'preloaded everywhere' concern appears to be a non-issue. Leaving #426 open with that note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)