### PR TITLE
a11y: announce parallel fan-outs + branches in .flow diagrams (#422)

### DIFF
--- a/docs/content-visuals.md
+++ b/docs/content-visuals.md
@@ -25,10 +25,10 @@ Class contract:
 <div class="flow" role="group" aria-label="Short diagram purpose">
   <div class="flow-node">Step</div>
   <div class="flow-node is-gate">Decision / gate</div>
-  <div class="flow-parallel">
+  <div class="flow-parallel" role="group" aria-label="Runs in parallel">
     <div class="flow-node">Parallel step</div>
   </div>
-  <div class="flow-branch">
+  <div class="flow-branch" role="group" aria-label="Branch outcomes">
     <div class="flow-leg" data-branch="Pass" role="group" aria-label="Pass">
       <div class="flow-node is-good">Good result</div>
     </div>
@@ -55,14 +55,14 @@ Copy-paste example:
 <div class="flow" role="group" aria-label="Security scanning pipeline">
   <div class="flow-node">Git Push / PR</div>
   <div class="flow-node is-gate">Trigger Pipeline</div>
-  <div class="flow-parallel">
+  <div class="flow-parallel" role="group" aria-label="Runs in parallel">
     <div class="flow-node"><b>OSV</b><i>dependency scan</i></div>
     <div class="flow-node"><b>Grype</b><i>container scan</i></div>
     <div class="flow-node"><b>Trivy</b><i>filesystem scan</i></div>
   </div>
   <div class="flow-node">Upload SARIF</div>
   <div class="flow-node is-gate">Security Gate</div>
-  <div class="flow-branch">
+  <div class="flow-branch" role="group" aria-label="Branch outcomes">
     <div class="flow-leg" data-branch="Pass" role="group" aria-label="Pass"><div class="flow-node is-good">Deploy</div></div>
     <div class="flow-leg" data-branch="Critical" role="group" aria-label="Critical"><div class="flow-node is-bad">Block &amp; Alert</div></div>
   </div>

--- a/src/posts/2024-01-18-demystifying-cryptography-beginners-guide.md
+++ b/src/posts/2024-01-18-demystifying-cryptography-beginners-guide.md
@@ -233,12 +233,12 @@ If hashing creates fingerprints, digital signatures are like notarizing those fi
   <div class="flow-node">✍️ Digital Signature</div>
   <div class="flow-node">📦 Document + Signature</div>
   <div class="flow-node"><b>Receiver</b><i>split document and signature</i></div>
-  <div class="flow-parallel">
+  <div class="flow-parallel" role="group" aria-label="Runs in parallel">
     <div class="flow-node"><b>📄 Document</b><i>SHA-256 Hash, then Hash Digest</i></div>
     <div class="flow-node"><b>✍️ Signature</b><i>Decrypt with 🔓 Public Key, then Hash Digest</i></div>
   </div>
   <div class="flow-node is-gate">Match?</div>
-  <div class="flow-branch">
+  <div class="flow-branch" role="group" aria-label="Branch outcomes">
     <div class="flow-leg" data-branch="Yes" role="group" aria-label="Yes"><div class="flow-node is-good">✅ Authentic &amp; Unaltered</div></div>
     <div class="flow-leg" data-branch="No" role="group" aria-label="No"><div class="flow-node is-bad">❌ Tampered or Forged</div></div>
   </div>

--- a/src/posts/2024-01-30-python-vulnerability-scanner-automation.md
+++ b/src/posts/2024-01-30-python-vulnerability-scanner-automation.md
@@ -68,7 +68,7 @@ My scanner uses three components: package inventory, NVD query engine, and alert
   <div class="flow-node"><b>Version Matcher</b><i>vulnerable?</i></div>
   <div class="flow-node"><b>Severity Filter</b><i>Critical / High</i></div>
   <div class="flow-node">Alert Dispatcher</div>
-  <div class="flow-parallel">
+  <div class="flow-parallel" role="group" aria-label="Runs in parallel">
     <div class="flow-node"><b>Slack / Email</b><i>notify</i></div>
     <div class="flow-node"><b>Prometheus</b><i>metrics</i></div>
   </div>

--- a/src/posts/2024-07-16-sustainable-computing-carbon-footprint.md
+++ b/src/posts/2024-07-16-sustainable-computing-carbon-footprint.md
@@ -165,7 +165,7 @@ Choosing data center locations based on carbon intensity:
 The following diagram shows how carbon-aware workload scheduling interacts with renewable energy availability:
 
 <div class="flow" role="group" aria-label="Carbon-aware scheduling decision path">
-  <div class="flow-parallel">
+  <div class="flow-parallel" role="group" aria-label="Runs in parallel">
     <div class="flow-node"><b>Solar Generation</b><i>Peak: 11AM-3PM</i></div>
     <div class="flow-node"><b>Wind Generation</b><i>Peak: 2AM-6AM</i></div>
     <div class="flow-node"><b>Grid Electricity</b><i>Variable Carbon</i></div>
@@ -173,7 +173,7 @@ The following diagram shows how carbon-aware workload scheduling interacts with 
   <div class="flow-node"><b>Carbon Intensity API</b><i>WattTime</i></div>
   <div class="flow-node">Workload Queue</div>
   <div class="flow-node is-gate">Carbon Intensity Below Threshold?</div>
-  <div class="flow-branch">
+  <div class="flow-branch" role="group" aria-label="Branch outcomes">
     <div class="flow-leg" data-branch="Yes" role="group" aria-label="Yes"><div class="flow-node is-good"><b>Run Workload Now</b><i>Low Carbon</i></div></div>
     <div class="flow-leg" data-branch="No, deferrable" role="group" aria-label="No, deferrable"><div class="flow-node is-gate">Defer to Low-Carbon Window</div></div>
     <div class="flow-leg" data-branch="No, urgent" role="group" aria-label="No, urgent"><div class="flow-node">Migrate to Green Region</div></div>

--- a/src/posts/2024-08-02-quantum-computing-leap-forward.md
+++ b/src/posts/2024-08-02-quantum-computing-leap-forward.md
@@ -19,14 +19,14 @@ That learning experience taught me something critical. Quantum computing isn't j
 ## How It Works
 
 <div class="flow" role="group" aria-label="Two-qubit quantum circuit path">
-  <div class="flow-parallel">
+  <div class="flow-parallel" role="group" aria-label="Runs in parallel">
     <div class="flow-node">Qubit 0: Zero State</div>
     <div class="flow-node">Qubit 1: Zero State</div>
   </div>
   <div class="flow-node">Hadamard Gate</div>
   <div class="flow-node">CNOT Gate</div>
   <div class="flow-node is-gate">Measurement</div>
-  <div class="flow-parallel">
+  <div class="flow-parallel" role="group" aria-label="Runs in parallel">
     <div class="flow-node">Classical Bit 0</div>
     <div class="flow-node">Classical Bit 1</div>
   </div>

--- a/src/posts/2024-08-13-high-performance-computing.md
+++ b/src/posts/2024-08-13-high-performance-computing.md
@@ -305,14 +305,14 @@ The integration between quantum and classical HPC systems has evolved rapidly ov
 <div class="flow" role="group" aria-label="Quantum-classical hybrid solving path">
   <div class="flow-node">Problem Definition</div>
   <div class="flow-node"><b>Classical Preprocessor</b><i>Problem Decomposition</i></div>
-  <div class="flow-parallel">
+  <div class="flow-parallel" role="group" aria-label="Runs in parallel">
     <div class="flow-node"><b>Classical Solver</b><i>Standard Subproblems</i></div>
     <div class="flow-node"><b>Quantum Circuit Compiler</b><i>Quantum-Suitable Subproblems</i></div>
   </div>
   <div class="flow-node"><b>Quantum Processor</b><i>VQE / QAOA Execution</i></div>
   <div class="flow-node"><b>Error Mitigation</b><i>Zero-Noise Extrapolation</i></div>
   <div class="flow-node is-gate">Converged?</div>
-  <div class="flow-branch">
+  <div class="flow-branch" role="group" aria-label="Branch outcomes">
     <div class="flow-leg" data-branch="No" role="group" aria-label="No"><div class="flow-node is-gate"><b>Repeat Quantum Compile</b><i>run another iteration</i></div></div>
     <div class="flow-leg" data-branch="Yes" role="group" aria-label="Yes"><div class="flow-node is-good"><b>Result Aggregation</b><i>Final Solution</i></div></div>
   </div>

--- a/src/posts/2024-09-25-gvisor-container-sandboxing-security.md
+++ b/src/posts/2024-09-25-gvisor-container-sandboxing-security.md
@@ -350,19 +350,19 @@ docker run --rm --runtime=runsc alpine sh -c "echo 'exploit' | tee /proc/self/me
 <div class="flow" role="group" aria-label="Container runtime selection decision path">
   <div class="flow-node">New Workload</div>
   <div class="flow-node is-gate">Untrusted image?</div>
-  <div class="flow-branch">
+  <div class="flow-branch" role="group" aria-label="Branch outcomes">
     <div class="flow-leg" data-branch="Yes" role="group" aria-label="Yes"><div class="flow-node is-good">Use gVisor</div></div>
     <div class="flow-leg" data-branch="No" role="group" aria-label="No"><div class="flow-node is-gate">Internet-facing?</div></div>
   </div>
-  <div class="flow-branch">
+  <div class="flow-branch" role="group" aria-label="Branch outcomes">
     <div class="flow-leg" data-branch="Yes" role="group" aria-label="Yes"><div class="flow-node is-good">Use gVisor</div></div>
     <div class="flow-leg" data-branch="No" role="group" aria-label="No"><div class="flow-node is-gate">Needs native performance?</div></div>
   </div>
-  <div class="flow-branch">
+  <div class="flow-branch" role="group" aria-label="Branch outcomes">
     <div class="flow-leg" data-branch="Yes" role="group" aria-label="Yes"><div class="flow-node">Use runc</div></div>
     <div class="flow-leg" data-branch="No" role="group" aria-label="No"><div class="flow-node is-gate">Syscall-heavy?</div></div>
   </div>
-  <div class="flow-branch">
+  <div class="flow-branch" role="group" aria-label="Branch outcomes">
     <div class="flow-leg" data-branch="Yes" role="group" aria-label="Yes"><div class="flow-node">Use runc</div></div>
     <div class="flow-leg" data-branch="No" role="group" aria-label="No"><div class="flow-node"><b>Use runc</b><i>principle of least surprise</i></div></div>
   </div>

--- a/src/posts/2024-11-15-gpu-power-monitoring-homelab-ml.md
+++ b/src/posts/2024-11-15-gpu-power-monitoring-homelab-ml.md
@@ -63,12 +63,12 @@ I ran each test for at least 30 minutes to capture steady-state behavior. Repeat
   <section class="arch-tier" data-label="Observability" role="group" aria-label="Observability"><span class="arch-chip">Prometheus</span><span class="arch-chip">Grafana Dashboards</span><span class="arch-chip is-warn">Telegram Alerts</span></section>
 </div>
 <div class="flow" role="group" aria-label="GPU telemetry collection path">
-  <div class="flow-parallel">
+  <div class="flow-parallel" role="group" aria-label="Runs in parallel">
     <div class="flow-node"><b>Kill-A-Watt</b><i>total system watts</i></div>
     <div class="flow-node"><b>UPS</b><i>UPS metrics</i></div>
     <div class="flow-node"><b>RTX 3090</b><i>GPU telemetry</i></div>
   </div>
-  <div class="flow-parallel">
+  <div class="flow-parallel" role="group" aria-label="Runs in parallel">
     <div class="flow-node"><b>nvidia-smi</b><i>GPU power, temp, clock</i></div>
     <div class="flow-node">DCGM Exporter</div>
     <div class="flow-node"><b>Custom Python</b><i>timestamped CSV</i></div>
@@ -196,13 +196,13 @@ These safeguards probably seem obvious to DevOps professionals, but they weren't
   <div class="flow-node"><b>GPU Running</b><i>Batch Job</i></div>
   <div class="flow-node"><b>Prometheus</b><i>scrapes nvidia-smi every 2s</i></div>
   <div class="flow-node is-gate"><b>Grafana Alert Rule</b><i>Power &gt; 300W for &gt; 2 hours?</i></div>
-  <div class="flow-branch">
+  <div class="flow-branch" role="group" aria-label="Branch outcomes">
     <div class="flow-leg" data-branch="No" role="group" aria-label="No"><div class="flow-node">Continue Polling</div></div>
     <div class="flow-leg" data-branch="Yes" role="group" aria-label="Yes"><div class="flow-node is-gate">Telegram Notification</div></div>
   </div>
   <div class="flow-node">Owner Checks</div>
   <div class="flow-node is-gate">Legitimate workload?</div>
-  <div class="flow-branch">
+  <div class="flow-branch" role="group" aria-label="Branch outcomes">
     <div class="flow-leg" data-branch="Yes" role="group" aria-label="Yes"><div class="flow-node is-good">Snooze Alert</div></div>
     <div class="flow-leg" data-branch="No" role="group" aria-label="No"><div class="flow-node is-bad">Kill Runaway Job</div></div>
   </div>
@@ -211,7 +211,7 @@ These safeguards probably seem obvious to DevOps professionals, but they weren't
 <div class="flow" role="group" aria-label="GPU timeout abort path">
   <div class="flow-node"><b>GPU Running</b><i>also checked</i></div>
   <div class="flow-node is-gate">Job Timeout Exceeded?</div>
-  <div class="flow-branch">
+  <div class="flow-branch" role="group" aria-label="Branch outcomes">
     <div class="flow-leg" data-branch="Yes" role="group" aria-label="Yes"><div class="flow-node is-bad"><b>Auto-Abort Job</b><i>+ Checkpoint State</i></div></div>
     <div class="flow-leg" data-branch="No" role="group" aria-label="No"><div class="flow-node">Continue Running</div></div>
   </div>
@@ -252,18 +252,18 @@ For these micro-tasks, CPU is 4x more energy-efficient despite being slower. I'm
 <div class="flow" role="group" aria-label="Power-aware model routing decision path">
   <div class="flow-node">Incoming Query</div>
   <div class="flow-node is-gate">Token estimate?</div>
-  <div class="flow-branch">
+  <div class="flow-branch" role="group" aria-label="Branch outcomes">
     <div class="flow-leg" data-branch="&lt; 100 tokens" role="group" aria-label="&lt; 100 tokens"><div class="flow-node is-good"><b>Route to CPU</b><i>llama.cpp on i9-9900K; 95W / 2.3 tok/s</i></div></div>
     <div class="flow-leg" data-branch="100+ tokens" role="group" aria-label="100+ tokens"><div class="flow-node is-gate">Task complexity?</div></div>
   </div>
-  <div class="flow-branch">
+  <div class="flow-branch" role="group" aria-label="Branch outcomes">
     <div class="flow-leg" data-branch="Simple summarization, Q&amp;A" role="group" aria-label="Simple summarization, Q&amp;A"><div class="flow-node is-good"><b>Phi-3 Mini 3.8B</b><i>276W avg</i></div></div>
     <div class="flow-leg" data-branch="General chat, writing" role="group" aria-label="General chat, writing"><div class="flow-node"><b>Llama 3.1 8B</b><i>312W avg</i></div></div>
     <div class="flow-leg" data-branch="Complex code gen, analysis" role="group" aria-label="Complex code gen, analysis"><div class="flow-node is-bad"><b>Llama 3.1 70B Q4</b><i>347W avg</i></div></div>
   </div>
   <div class="flow-node">Return Response</div>
   <div class="flow-node is-gate">Idle &gt; 15 min?</div>
-  <div class="flow-branch">
+  <div class="flow-branch" role="group" aria-label="Branch outcomes">
     <div class="flow-leg" data-branch="Yes" role="group" aria-label="Yes"><div class="flow-node is-good"><b>Unload Model</b><i>Drop to 52W baseline</i></div></div>
     <div class="flow-leg" data-branch="No" role="group" aria-label="No"><div class="flow-node"><b>Keep Model Loaded</b><i>87W standby</i></div></div>
   </div>

--- a/src/posts/2025-01-12-privacy-preserving-federated-learning-homelab.md
+++ b/src/posts/2025-01-12-privacy-preserving-federated-learning-homelab.md
@@ -33,7 +33,7 @@ This approach breaks privacy in obvious ways. If I'm training a medical diagnosi
 
 <figure>
 <div class="flow" role="group" aria-label="Centralized training data path">
-  <div class="flow-parallel">
+  <div class="flow-parallel" role="group" aria-label="Runs in parallel">
     <div class="flow-node">Hospital A Data</div>
     <div class="flow-node">Hospital B Data</div>
     <div class="flow-node">Hospital C Data</div>
@@ -42,7 +42,7 @@ This approach breaks privacy in obvious ways. If I'm training a medical diagnosi
   <div class="flow-node">Train Model</div>
 </div>
 <div class="flow" role="group" aria-label="Federated training update path">
-  <div class="flow-parallel">
+  <div class="flow-parallel" role="group" aria-label="Runs in parallel">
     <div class="flow-node"><b>Hospital A Data</b><i>Local Model A</i></div>
     <div class="flow-node"><b>Hospital B Data</b><i>Local Model B</i></div>
     <div class="flow-node"><b>Hospital C Data</b><i>Local Model C</i></div>
@@ -256,17 +256,17 @@ pie title Training Round Time Breakdown (47 min total)
 <div class="flow" role="group" aria-label="Granular-ball segmentation privacy path">
   <div class="flow-node"><b>Raw Training Data</b><i>Individual examples</i></div>
   <div class="flow-node">Granular-Ball Segmentation</div>
-  <div class="flow-parallel">
+  <div class="flow-parallel" role="group" aria-label="Runs in parallel">
     <div class="flow-node"><b>Cluster 1</b><i>center, variance, radius</i></div>
     <div class="flow-node"><b>Cluster 2</b><i>center, variance, radius</i></div>
     <div class="flow-node"><b>Cluster N</b><i>center, variance, radius</i></div>
   </div>
   <div class="flow-node is-gate">Variance &gt; threshold?</div>
-  <div class="flow-branch">
+  <div class="flow-branch" role="group" aria-label="Branch outcomes">
     <div class="flow-leg" data-branch="Yes" role="group" aria-label="Yes"><div class="flow-node is-good"><b>Shared with aggregator</b><i>Aggregation Server</i></div></div>
     <div class="flow-leg" data-branch="No" role="group" aria-label="No"><div class="flow-node is-bad">Dropped — never leaves device</div></div>
   </div>
-  <div class="flow-parallel">
+  <div class="flow-parallel" role="group" aria-label="Runs in parallel">
     <div class="flow-node is-good"><b>Reconstruction Attack</b><i>Fails</i></div>
     <div class="flow-node is-good"><b>Gradient Inversion</b><i>Not applicable</i></div>
   </div>

--- a/src/posts/2025-01-22-llm-security-alert-triage-local.md
+++ b/src/posts/2025-01-22-llm-security-alert-triage-local.md
@@ -53,7 +53,7 @@ names, internal network topology. Local LLM inference keeps all data in homelab.
   <div class="flow-node"><b>Alert Processor</b><i>Python prompt</i></div>
   <div class="flow-node"><b>Ollama Server</b><i>local LLM; NVIDIA GPU inference, 8GB VRAM</i></div>
   <div class="flow-node"><b>SQLite</b><i>alert DB classification</i></div>
-  <div class="flow-parallel">
+  <div class="flow-parallel" role="group" aria-label="Runs in parallel">
     <div class="flow-node is-bad"><b>Slack Notification</b><i>high priority</i></div>
     <div class="flow-node"><b>Grafana Dashboard</b><i>all alerts</i></div>
   </div>

--- a/src/posts/2025-07-01-ebpf-security-monitoring-practical-guide.md
+++ b/src/posts/2025-07-01-ebpf-security-monitoring-practical-guide.md
@@ -44,7 +44,7 @@ With eBPF monitoring on an identical honeypot, the same attack was detected in 1
 
 <figure>
 <div class="flow" role="group" aria-label="Traditional monitoring latency path">
-  <div class="flow-parallel">
+  <div class="flow-parallel" role="group" aria-label="Runs in parallel">
     <div class="flow-node"><b>Application Logs</b><i>Delayed</i></div>
     <div class="flow-node"><b>System Logs</b><i>Can be tampered</i></div>
     <div class="flow-node"><b>Network Logs</b><i>After the fact</i></div>

--- a/src/posts/2025-07-22-supercharging-claude-cli-with-standards.md
+++ b/src/posts/2025-07-22-supercharging-claude-cli-with-standards.md
@@ -114,7 +114,7 @@ The standards system works through a context-aware loading pipeline that detects
   <div class="flow-node">Context Detection</div>
   <div class="flow-node"><b>Parse Project Signals</b><i>files, imports, config</i></div>
   <div class="flow-node is-gate">Standard Matching Engine</div>
-  <div class="flow-parallel">
+  <div class="flow-parallel" role="group" aria-label="Runs in parallel">
     <div class="flow-node"><b>CS:python</b><i>CS:api</i></div>
     <div class="flow-node"><b>SEC:auth</b><i>SEC:payments</i></div>
     <div class="flow-node">TS:integration</div>

--- a/src/posts/2025-07-29-building-mcp-standards-server.md
+++ b/src/posts/2025-07-29-building-mcp-standards-server.md
@@ -217,12 +217,12 @@ standard = get_standard("react-patterns", format="compressed")
 <div class="flow" role="group" aria-label="Redis L1 and L2 cache lookup path">
   <div class="flow-node">Incoming Request</div>
   <div class="flow-node is-gate"><b>L1 Cache</b><i>in-memory</i></div>
-  <div class="flow-branch">
+  <div class="flow-branch" role="group" aria-label="Branch outcomes">
     <div class="flow-leg" data-branch="Hit" role="group" aria-label="Hit"><div class="flow-node is-good">Return Cached</div></div>
     <div class="flow-leg" data-branch="Miss" role="group" aria-label="Miss"><div class="flow-node"><b>L2 Cache</b><i>Redis</i></div></div>
   </div>
   <div class="flow-node is-gate">L2 Result</div>
-  <div class="flow-branch">
+  <div class="flow-branch" role="group" aria-label="Branch outcomes">
     <div class="flow-leg" data-branch="Hit" role="group" aria-label="Hit"><div class="flow-node is-good"><b>Promote to L1</b><i>return cached</i></div></div>
     <div class="flow-leg" data-branch="Miss" role="group" aria-label="Miss"><div class="flow-node"><b>Load from Disk</b><i>store in L1 + L2 with 30-min TTL</i></div></div>
   </div>

--- a/src/posts/2025-08-09-ai-cognitive-infrastructure.md
+++ b/src/posts/2025-08-09-ai-cognitive-infrastructure.md
@@ -27,19 +27,19 @@ According to [Giuseppe Riva's groundbreaking research](https://arxiv.org/abs/250
 
 <figure class="arch-fig">
 <div class="flow" role="group" aria-label="Traditional infrastructure enablement path">
-  <div class="flow-parallel">
+  <div class="flow-parallel" role="group" aria-label="Runs in parallel">
     <div class="flow-node"><b>Physical Roads</b><i>enable commerce</i></div>
     <div class="flow-node"><b>Electricity Grid</b><i>powers industry</i></div>
     <div class="flow-node"><b>Telecommunications</b><i>enable communication</i></div>
   </div>
 </div>
 <div class="flow" role="group" aria-label="Cognitive infrastructure mediation path">
-  <div class="flow-parallel">
+  <div class="flow-parallel" role="group" aria-label="Runs in parallel">
     <div class="flow-node">AI Systems</div>
     <div class="flow-node">Machine Learning</div>
     <div class="flow-node">Natural Language Processing</div>
   </div>
-  <div class="flow-parallel">
+  <div class="flow-parallel" role="group" aria-label="Runs in parallel">
     <div class="flow-node">Memory</div>
     <div class="flow-node">Decision Making</div>
     <div class="flow-node">Analysis</div>
@@ -96,12 +96,12 @@ The concept of "epistemic agency" (your ability to determine what's true and rel
 <div class="flow" role="group" aria-label="AI-mediated information access path">
   <div class="flow-node">User Query/Interest</div>
   <div class="flow-node is-gate">AI Analysis</div>
-  <div class="flow-parallel">
+  <div class="flow-parallel" role="group" aria-label="Runs in parallel">
     <div class="flow-node"><b>Relevance Filtering</b><i>visible options / hidden options</i></div>
     <div class="flow-node"><b>Priority Ranking</b><i>first results / later results</i></div>
     <div class="flow-node"><b>Personalization</b><i>filter bubble / echo chamber</i></div>
   </div>
-  <div class="flow-branch">
+  <div class="flow-branch" role="group" aria-label="Branch outcomes">
     <div class="flow-leg" data-branch="Seen" role="group" aria-label="Seen"><div class="flow-node is-good">User Decision</div></div>
     <div class="flow-leg" data-branch="Filtered" role="group" aria-label="Filtered"><div class="flow-node is-bad"><b>Lost Possibilities</b><i>never seen or rarely seen</i></div></div>
     <div class="flow-leg" data-branch="Reinforced" role="group" aria-label="Reinforced"><div class="flow-node">Echo Chamber</div></div>

--- a/src/posts/2025-08-18-docker-lsm-security-hardening.md
+++ b/src/posts/2025-08-18-docker-lsm-security-hardening.md
@@ -43,7 +43,7 @@ FS privilege escalation
   <div class="flow-node is-gate">LSM Hooks</div>
   <div class="flow-node is-gate">Seccomp BPF</div>
   <div class="flow-node is-gate">Capability Check</div>
-  <div class="flow-branch">
+  <div class="flow-branch" role="group" aria-label="Branch outcomes">
     <div class="flow-leg" data-branch="Denied" role="group" aria-label="Denied"><div class="flow-node is-bad"><b>EACCES / EPERM</b><i>operation blocked</i></div></div>
     <div class="flow-leg" data-branch="Allowed" role="group" aria-label="Allowed"><div class="flow-node is-good">Execute Syscall</div></div>
   </div>

--- a/src/posts/2025-09-20-vulnerability-prioritization-epss-kev.md
+++ b/src/posts/2025-09-20-vulnerability-prioritization-epss-kev.md
@@ -74,13 +74,13 @@ Let me walk through creating a practical system that combines these data sources
 ⚠️ **Warning:** This architecture integrates multiple external APIs (NVD, EPSS, CISA KEV). Implement proper authentication, rate limiting, and error handling for production deployments.
 
 <div class="flow" role="group" aria-label="Vulnerability prioritization data pipeline">
-  <div class="flow-parallel">
+  <div class="flow-parallel" role="group" aria-label="Runs in parallel">
     <div class="flow-node"><b>NVD API</b><i>CVE details</i></div>
     <div class="flow-node"><b>EPSS API</b><i>probability scores</i></div>
     <div class="flow-node"><b>CISA KEV</b><i>active exploitation</i></div>
   </div>
   <div class="flow-node">Data Aggregator</div>
-  <div class="flow-parallel">
+  <div class="flow-parallel" role="group" aria-label="Runs in parallel">
     <div class="flow-node">Risk Calculator</div>
     <div class="flow-node"><b>Asset Inventory</b><i>criticality</i></div>
   </div>

--- a/src/posts/2025-10-06-automated-security-scanning-pipeline.md
+++ b/src/posts/2025-10-06-automated-security-scanning-pipeline.md
@@ -26,7 +26,7 @@ I built an automated security pipeline that scans every commit with Grype, OSV-S
 ⚠️ **Warning:** Security scanning pipelines must be configured with appropriate policies and approval gates. Automated remediation should include review processes for production environments.
 
 <div class="flow" role="group" aria-label="Automated security scanning pipeline">
-  <div class="flow-parallel">
+  <div class="flow-parallel" role="group" aria-label="Runs in parallel">
     <div class="flow-node">Git Push</div>
     <div class="flow-node">Pull Request</div>
   </div>
@@ -34,19 +34,19 @@ I built an automated security pipeline that scans every commit with Grype, OSV-S
   <div class="flow-node">Build Stage</div>
   <div class="flow-node">Test Stage</div>
   <div class="flow-node is-gate">Security Scan Stage</div>
-  <div class="flow-parallel">
+  <div class="flow-parallel" role="group" aria-label="Runs in parallel">
     <div class="flow-node"><b>Grype</b><i>container scanning</i></div>
     <div class="flow-node"><b>OSV-Scanner</b><i>dependency scanning</i></div>
     <div class="flow-node"><b>Trivy</b><i>multi-scanner</i></div>
   </div>
   <div class="flow-node">SARIF Reports</div>
-  <div class="flow-parallel">
+  <div class="flow-parallel" role="group" aria-label="Runs in parallel">
     <div class="flow-node">GitHub Security</div>
     <div class="flow-node">Slack Alerts</div>
     <div class="flow-node">Wazuh SIEM</div>
   </div>
   <div class="flow-node is-gate">Quality Gates</div>
-  <div class="flow-branch">
+  <div class="flow-branch" role="group" aria-label="Branch outcomes">
     <div class="flow-leg" data-branch="Critical" role="group" aria-label="Critical"><div class="flow-node is-bad">Block on Critical</div></div>
     <div class="flow-leg" data-branch="Review" role="group" aria-label="Review"><div class="flow-node">Manual Review</div></div>
   </div>
@@ -87,14 +87,14 @@ The pipeline orchestrates three scanners in parallel with a final quality gate:
 <div class="flow" role="group" aria-label="GitHub Actions security scanning pipeline">
   <div class="flow-node">Git Push / PR</div>
   <div class="flow-node is-gate">Trigger Pipeline</div>
-  <div class="flow-parallel">
+  <div class="flow-parallel" role="group" aria-label="Runs in parallel">
     <div class="flow-node"><b>OSV</b><i>dependency scan</i></div>
     <div class="flow-node"><b>Grype</b><i>container scan</i></div>
     <div class="flow-node"><b>Trivy</b><i>filesystem scan</i></div>
   </div>
   <div class="flow-node">Upload SARIF</div>
   <div class="flow-node is-gate">Security Gate</div>
-  <div class="flow-branch">
+  <div class="flow-branch" role="group" aria-label="Branch outcomes">
     <div class="flow-leg" data-branch="Pass" role="group" aria-label="Pass"><div class="flow-node is-good">Deploy</div></div>
     <div class="flow-leg" data-branch="Critical" role="group" aria-label="Critical"><div class="flow-node is-bad">Block &amp; Alert</div></div>
   </div>

--- a/src/posts/2025-10-13-embodied-ai-robots-physical-world.md
+++ b/src/posts/2025-10-13-embodied-ai-robots-physical-world.md
@@ -39,7 +39,7 @@ That gap is closing. VLA models combine three capabilities:
   <div class="flow-node">Text Output</div>
 </div>
 <div class="flow" role="group" aria-label="Vision-Language-Action model path">
-  <div class="flow-parallel">
+  <div class="flow-parallel" role="group" aria-label="Runs in parallel">
     <div class="flow-node">Visual Input</div>
     <div class="flow-node">Language Input</div>
   </div>

--- a/src/posts/2025-10-17-progressive-context-loading-llm-workflows.md
+++ b/src/posts/2025-10-17-progressive-context-loading-llm-workflows.md
@@ -157,7 +157,7 @@ Task flow:
   <div class="flow-node is-gate">Determine Skills</div>
   <div class="flow-node is-good"><b>Load Primary Skills</b><i>2K tokens</i></div>
   <div class="flow-node is-gate">Task Complete?</div>
-  <div class="flow-branch">
+  <div class="flow-branch" role="group" aria-label="Branch outcomes">
     <div class="flow-leg" data-branch="Yes" role="group" aria-label="Yes"><div class="flow-node is-good">Return Result</div></div>
     <div class="flow-leg" data-branch="Need Context" role="group" aria-label="Need Context"><div class="flow-node"><b>Load Dependencies</b><i>+3K tokens, then re-check task</i></div></div>
     <div class="flow-leg" data-branch="No Context" role="group" aria-label="No Context"><div class="flow-node">Request Clarification</div></div>

--- a/src/posts/2025-10-29-post-quantum-cryptography-homelab.md
+++ b/src/posts/2025-10-29-post-quantum-cryptography-homelab.md
@@ -38,14 +38,14 @@ The math is simple and it's called [Mosca's Theorem](https://globalriskinstitute
 
 <figure class="arch-fig">
 <div class="flow" role="group" aria-label="Mosca theorem migration timing test">
-  <div class="flow-parallel">
+  <div class="flow-parallel" role="group" aria-label="Runs in parallel">
     <div class="flow-node"><b>X: Data Secrecy Requirement</b><i>10-30 years</i></div>
     <div class="flow-node"><b>Y: Migration Time Needed</b><i>5-15 years</i></div>
     <div class="flow-node"><b>Z: Quantum Computer Arrival</b><i>2033-2040?</i></div>
   </div>
   <div class="flow-node">X + Y</div>
   <div class="flow-node is-gate">X + Y &gt; Z?</div>
-  <div class="flow-branch">
+  <div class="flow-branch" role="group" aria-label="Branch outcomes">
     <div class="flow-leg" data-branch="Yes" role="group" aria-label="Yes"><div class="flow-node is-bad"><b>Already Behind</b><i>schedule</i></div></div>
     <div class="flow-leg" data-branch="No" role="group" aria-label="No"><div class="flow-node is-good"><b>Time Remaining</b><i>to migrate</i></div></div>
   </div>
@@ -636,7 +636,7 @@ The migration strategy follows four phases, prioritizing services by their expos
   <div class="flow-node"><b>Phase 1: Test</b><i>Weekend 1; isolated Ubuntu 24.04 VM, Caddy 2.10, verify x25519_kyber768 handshake</i></div>
   <div class="flow-node"><b>Phase 2: Certificates</b><i>Weekend 1; classical certs, PQC key exchange with ML-KEM-768, future ML-DSA certs in 2026-2027</i></div>
   <div class="flow-node is-gate"><b>Phase 3: Rollout</b><i>Weekend 2</i></div>
-  <div class="flow-parallel">
+  <div class="flow-parallel" role="group" aria-label="Runs in parallel">
     <div class="flow-node is-bad"><b>High Priority</b><i>Bitwarden, TrueNAS, VPN</i></div>
     <div class="flow-node"><b>Medium Priority</b><i>Nextcloud, Wikis</i></div>
     <div class="flow-node is-good"><b>Lower Priority</b><i>Jellyfin, Grafana</i></div>

--- a/src/posts/2025-10-29-privacy-first-ai-lab-local-llms.md
+++ b/src/posts/2025-10-29-privacy-first-ai-lab-local-llms.md
@@ -311,12 +311,12 @@ I use a separate Claude subscription for this blog writing. None of my sensitive
 
 <div class="flow" role="group" aria-label="Local versus cloud LLM routing decision">
   <div class="flow-node is-gate">What data are you processing?</div>
-  <div class="flow-branch">
+  <div class="flow-branch" role="group" aria-label="Branch outcomes">
     <div class="flow-leg" data-branch="Sensitive / Regulated" role="group" aria-label="Sensitive / Regulated"><div class="flow-node is-good"><b>Local Processing</b><i>GPU hardware or CPU-only inference</i></div></div>
     <div class="flow-leg" data-branch="Public / Non-sensitive" role="group" aria-label="Public / Non-sensitive"><div class="flow-node"><b>Cloud Processing</b><i>Cloud API or managed service</i></div></div>
   </div>
   <div class="flow-node is-gate">Match budget and capability needs</div>
-  <div class="flow-branch">
+  <div class="flow-branch" role="group" aria-label="Branch outcomes">
     <div class="flow-leg" data-branch="Local" role="group" aria-label="Local"><div class="flow-node is-good"><b>Harden</b><i>VLAN + encryption + DP + monitoring</i></div></div>
     <div class="flow-leg" data-branch="Cloud" role="group" aria-label="Cloud"><div class="flow-node"><b>Choose service</b><i>405B+ API or general managed use</i></div></div>
   </div>

--- a/src/posts/2025-11-05-siem-homelab-wazuh-graylog-comparison.md
+++ b/src/posts/2025-11-05-siem-homelab-wazuh-graylog-comparison.md
@@ -38,12 +38,12 @@ Both use agent-based collection, centralized storage, and web UI. Architectures 
 **Wazuh architecture:**
 
 <div class="flow" role="group" aria-label="Wazuh log collection architecture">
-  <div class="flow-parallel">
+  <div class="flow-parallel" role="group" aria-label="Runs in parallel">
     <div class="flow-node"><b>Wazuh Agent</b><i>Host 1 logs</i></div>
     <div class="flow-node"><b>Wazuh Agent</b><i>Host 2 logs</i></div>
   </div>
   <div class="flow-node">Wazuh Manager</div>
-  <div class="flow-branch">
+  <div class="flow-branch" role="group" aria-label="Branch outcomes">
     <div class="flow-leg" data-branch="Index" role="group" aria-label="Index"><div class="flow-node"><b>Wazuh Indexer</b><i>OpenSearch</i></div></div>
     <div class="flow-leg" data-branch="Alerts" role="group" aria-label="Alerts"><div class="flow-node"><b>Wazuh Dashboard</b><i>queries indexer</i></div></div>
   </div>
@@ -52,12 +52,12 @@ Both use agent-based collection, centralized storage, and web UI. Architectures 
 **Graylog architecture:**
 
 <div class="flow" role="group" aria-label="Graylog log collection architecture">
-  <div class="flow-parallel">
+  <div class="flow-parallel" role="group" aria-label="Runs in parallel">
     <div class="flow-node"><b>Filebeat</b><i>Host 1 syslog</i></div>
     <div class="flow-node"><b>Filebeat</b><i>Host 2 syslog</i></div>
   </div>
   <div class="flow-node">Graylog Server</div>
-  <div class="flow-parallel">
+  <div class="flow-parallel" role="group" aria-label="Runs in parallel">
     <div class="flow-node"><b>MongoDB</b><i>store</i></div>
     <div class="flow-node"><b>Elasticsearch</b><i>index</i></div>
     <div class="flow-node"><b>Graylog Web</b><i>search</i></div>

--- a/src/posts/2025-11-19-promsketch-prometheus-optimization.md
+++ b/src/posts/2025-11-19-promsketch-prometheus-optimization.md
@@ -51,7 +51,7 @@ PromSketch sits between Grafana and Prometheus as a caching proxy. It uses proba
   <div class="flow-node">PromSketch Proxy</div>
   <div class="flow-node">Query Optimizer</div>
   <div class="flow-node is-gate">Sketch-eligible?</div>
-  <div class="flow-branch">
+  <div class="flow-branch" role="group" aria-label="Branch outcomes">
     <div class="flow-leg" data-branch="Yes" role="group" aria-label="Yes"><div class="flow-node is-good"><b>Sketch Cache</b><i>approximation</i></div></div>
     <div class="flow-leg" data-branch="No" role="group" aria-label="No"><div class="flow-node"><b>Prometheus</b><i>exact data</i></div></div>
   </div>

--- a/src/posts/2025-11-23-nodeshield-runtime-sbom-enforcement.md
+++ b/src/posts/2025-11-23-nodeshield-runtime-sbom-enforcement.md
@@ -55,7 +55,7 @@ NodeShield uses V8 engine hooks to intercept `require()` calls. When a module tr
   <div class="flow-node">Node.js App</div>
   <div class="flow-node">NodeShield Hook</div>
   <div class="flow-node is-gate">Check CBOM Policy</div>
-  <div class="flow-branch">
+  <div class="flow-branch" role="group" aria-label="Branch outcomes">
     <div class="flow-leg" data-branch="Authorized" role="group" aria-label="Authorized"><div class="flow-node is-good">Load Module</div></div>
     <div class="flow-leg" data-branch="Unauthorized" role="group" aria-label="Unauthorized"><div class="flow-node is-bad">Block + Log</div></div>
   </div>

--- a/src/posts/2025-12-10-homelab-security-dashboard-grafana-prometheus.md
+++ b/src/posts/2025-12-10-homelab-security-dashboard-grafana-prometheus.md
@@ -336,11 +336,11 @@ groups:
   <div class="flow-node">Security Event</div>
   <div class="flow-node">Prometheus Evaluates Rules</div>
   <div class="flow-node is-gate">Exceeds Threshold?</div>
-  <div class="flow-branch">
+  <div class="flow-branch" role="group" aria-label="Branch outcomes">
     <div class="flow-leg" data-branch="No" role="group" aria-label="No"><div class="flow-node">Log Only - Info</div></div>
     <div class="flow-leg" data-branch="Yes" role="group" aria-label="Yes"><div class="flow-node is-gate">Severity?</div></div>
   </div>
-  <div class="flow-branch">
+  <div class="flow-branch" role="group" aria-label="Branch outcomes">
     <div class="flow-leg" data-branch="Critical" role="group" aria-label="Critical"><div class="flow-node is-bad"><b>Immediate Notification</b><i>webhook, respond now</i></div></div>
     <div class="flow-leg" data-branch="Warning" role="group" aria-label="Warning"><div class="flow-node"><b>Hourly Summary Batch</b><i>investigate within 4h</i></div></div>
   </div>
@@ -506,14 +506,14 @@ def geolocate_ip(ip_address):
 ### Correlation Dashboard
 
 <div class="flow" role="group" aria-label="Security signal correlation workflow">
-  <div class="flow-parallel">
+  <div class="flow-parallel" role="group" aria-label="Runs in parallel">
     <div class="flow-node">SSH Failed Logins</div>
     <div class="flow-node">Port Scans</div>
     <div class="flow-node">DNS Anomalies</div>
     <div class="flow-node">Unusual Processes</div>
   </div>
   <div class="flow-node is-gate"><b>Correlation Engine</b><i>PromQL join on source_ip</i></div>
-  <div class="flow-branch">
+  <div class="flow-branch" role="group" aria-label="Branch outcomes">
     <div class="flow-leg" data-branch="1 signal" role="group" aria-label="1 signal"><div class="flow-node">Opportunistic Scan</div></div>
     <div class="flow-leg" data-branch="2 signals" role="group" aria-label="2 signals"><div class="flow-node">Targeted Probe</div></div>
     <div class="flow-leg" data-branch="3+ signals" role="group" aria-label="3+ signals"><div class="flow-node is-bad">Active Compromise</div></div>

--- a/src/posts/2026-01-28-consensus-voting-ai-models-multi-agent.md
+++ b/src/posts/2026-01-28-consensus-voting-ai-models-multi-agent.md
@@ -42,7 +42,7 @@ These findings led to two design decisions: role-based agent assignment with rou
 <div class="flow" role="group" aria-label="Consensus voting decision workflow">
   <div class="flow-node">Proposal Text</div>
   <div class="flow-node">Round-Robin Model Assignment</div>
-  <div class="flow-parallel">
+  <div class="flow-parallel" role="group" aria-label="Runs in parallel">
     <div class="flow-node">Architect</div>
     <div class="flow-node">Security Engineer</div>
     <div class="flow-node">DevEx Advocate</div>
@@ -51,7 +51,7 @@ These findings led to two design decisions: role-based agent assignment with rou
   </div>
   <div class="flow-node">Vote Aggregation</div>
   <div class="flow-node is-gate">Strategy Threshold</div>
-  <div class="flow-branch">
+  <div class="flow-branch" role="group" aria-label="Branch outcomes">
     <div class="flow-leg" data-branch="Met" role="group" aria-label="Met"><div class="flow-node is-good">APPROVED</div></div>
     <div class="flow-leg" data-branch="Not Met" role="group" aria-label="Not Met"><div class="flow-node is-bad">REJECTED</div></div>
   </div>


### PR DESCRIPTION
Addresses the actionable part of #422. Screen readers read `.flow-parallel` (concurrent) and `.flow-branch` (fork) the same as sequential steps. Added `role="group"` + `aria-label` ("Runs in parallel" / "Branch outcomes") to the **33 parallel + 31 branch** groups so the structure is announced. Additive — doesn't touch the root/leg naming already shipped. Guide + `blog-visuals` skill updated.

Skipped the `role=list`/`listitem` position-count idea from #422 (would conflict with the root `role=group` naming; low marginal value over the group boundaries now announced). Build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)