### PR TITLE
posts: OSCAL agent-controls series (2 parts)

### DIFF
--- a/src/posts/2026-07-23-agent-controls-as-oscal.md
+++ b/src/posts/2026-07-23-agent-controls-as-oscal.md
@@ -1,0 +1,92 @@
+---
+title: "The Firewall Stays Put. The Agent Improvises."
+date: 2026-07-23
+description: "Rewriting security controls for probabilistic agents. Static control catalogs assume systems that do what they're told; AI agents don't — so here's how to express agent guardrails (tool allowlists, secret-egress denial, audit) as machine-checkable OSCAL component definitions."
+tags:
+- security
+- ai
+- oscal
+- compliance
+- ai-agents
+---
+
+Most writing about AI-agent risk is qualitative: prompt injection, excessive agency, tool misuse, the usual gallery. Separately, the compliance world has [OSCAL](https://pages.nist.gov/OSCAL/), a machine-readable format for expressing security controls. I haven't found the two connected in public writing. This is a post about what happens when you try — and about why the sharper question is which control *expressions* survive contact with a non-deterministic actor.
+
+I have reasons to care about this intersection. I'm an OSCAL Foundation member, and I authored a NIST SP 800-53 overlay for AI-agent behaviors. Control catalogs are already machine-readable; the part I keep circling is how to *use* that while building with LLMs — pulling the applicable controls as a checklist so the well-worn security angles get covered deliberately, alongside the new ones AI opens up, and documenting what a system actually enforces as CLI agents help build it. I've poked at this in the open — an early [standards repo](https://github.com/williamzujkowski/standards) and [an MCP server on top of it](/posts/2025-07-22-supercharging-claude-cli-with-standards), both experiments I've let go quiet rather than products. This post is the idea underneath them. I work most of this out in my own test environments first, where I have room to fail loudly and cheaply. The thinking generalizes to higher-stakes settings; the freedom to fail cheaply does not.
+
+## The problem with borrowing a control catalog
+
+A control catalog was written for systems that do what they're told. You configure a firewall; it stays configured. You set a permission; it holds. The system is boring, and boring is exactly what you want from a control.
+
+An agent is not boring. It holds delegated credentials, it improvises across trust boundaries, and it keeps its plan in the one place you can't trust — the model's output. So "the agent has a tool policy" isn't a control. It's a wish with YAML nearby. The control is the thing that says *no* before the tool runs, outside the model's path, and can prove it did with a failing test and an audit line.
+
+That gap changes four things about how a control has to be written.
+
+**Bind the capability.** A system control often asserts that a function or boundary *exists*. An agent control has to assert which action the agent may take — under which task, with which identity, against which destination, with which approval. "The agent has a tool policy" is weak. "The runtime denies every tool call that does not match the policy tuple `{tool, action, resource, destination, principal, task}`, before execution" survives contact with the agent.
+
+**Treat outputs as untrusted until mediated.** The model's plan is not the enforcement boundary. OWASP's [Excessive Agency](https://genai.owasp.org/llmrisk/llm062025-excessive-agency/) guidance is blunt about this: damaging actions follow unexpected, ambiguous, or manipulated model output, and the mitigation is complete mediation with a deterministic decision *outside* the model path.
+
+**Make delegated authority explicit.** Agents act *as* users, service accounts, workflows, or other agents. That's a confused-deputy problem waiting to happen. A durable control names whose authority is in use, how it's scoped, when it expires, and whether the downstream system enforces the same scope — not just the agent's runtime.
+
+**Make it testable.** For a non-deterministic actor, the evidence is executable: allowed tool set, blocked tool set, destination allowlist, a secret-egress detector, review gates, audit fields. It comes from negative tests and runtime traces, not from a policy document. "Trust me, the prompt says behave" is not a control.
+
+## The worked example, said plainly
+
+Here is one behavior. I built it as a small reference implementation in my test environment — the code is in [`oscal-agent-controls`](https://github.com/williamzujkowski/oscal-agent-controls) — so everything below actually runs. The agent may call only the tools listed in a committed `agent-policy.yaml`. A separate, tighter allowlist governs where a secret may go. Every decision is logged.
+
+I'll describe the OSCAL in Simplified Technical English on purpose — short sentences, one action each. It reads like a checklist because a control *is* a checklist.
+
+Model the agent as an OSCAL software component. Give the component one `control-implementation`. Set its `source` to the NIST SP 800-53 Rev 5 catalog. Add one `implemented-requirement` for **AC-6** (least privilege). Set the default tool decision to `deny`. Add a property that names the policy file. Add a property that names the check a pipeline must run.
+
+```json
+{
+  "control-id": "ac-6",
+  "description": "The runtime exposes only task-approved tools and denies all other tool calls before execution.",
+  "props": [
+    { "name": "agent-control", "ns": "https://example.local/ns/agent-controls", "value": "tool-allowlist" },
+    { "name": "default-decision", "ns": "https://example.local/ns/agent-controls", "value": "deny" },
+    { "name": "policy-file", "ns": "https://example.local/ns/agent-controls", "value": "agent-policy.yaml" },
+    { "name": "pipeline-assertion", "ns": "https://example.local/ns/agent-controls", "value": "all_tool_calls_subset_of_allowed_tools" }
+  ]
+}
+```
+
+Add a second requirement for **AC-4** (information flow enforcement): block any tool call that would transmit a detected secret to an unapproved destination. Add a third for **AU-12** (audit record generation): every requested, allowed, denied, and reviewed call writes a structured record. `CM-7` (least functionality) and `SI-4` (system monitoring) map onto the same behaviors, though this example doesn't verify them independently. *(The full component definition — synthetic namespaces, fake tool names throughout — lives in the repo; the `ac-6` slice above is the shape.)*
+
+The gate itself is a fixed decision cascade. The first check that fails denies, and nothing downstream re-opens the question:
+
+<div class="flow" role="group" aria-label="Reference-monitor decision cascade for one tool call">
+  <div class="flow-node">Agent tool call</div>
+  <div class="flow-node is-gate"><b>On the tool allowlist?</b><i>else deny: tool-not-allowlisted</i></div>
+  <div class="flow-node is-gate"><b>Action permitted for the tool?</b><i>else deny: action-not-permitted</i></div>
+  <div class="flow-node is-gate"><b>Destination permitted?</b><i>else deny: destination-not-permitted</i></div>
+  <div class="flow-node is-gate"><b>Secret bound off the egress allowlist?</b><i>if yes, deny: secret-egress-blocked</i></div>
+  <div class="flow-branch" role="group" aria-label="Final decision">
+    <div class="flow-leg" data-branch="all gates pass" role="group" aria-label="all gates pass"><div class="flow-node is-good"><b>ALLOW</b><i>matched-allow-rule</i></div></div>
+    <div class="flow-leg" data-branch="any gate fails" role="group" aria-label="any gate fails"><div class="flow-node is-bad"><b>DENY</b><i>deny by default</i></div></div>
+  </div>
+</div>
+
+Now the pipeline does the work the prose can't. It reads the component definition. It loads the policy file. It confirms `ac-6`, `ac-4`, and `au-12` are present. Then it runs the tests against the gate. An unlisted tool call is denied. An allowed tool used for an unpermitted action is denied. An allowed tool aimed at an unapproved destination is denied. And the interesting one: an allowed tool calling an *approved* destination is still denied when its payload carries a secret — because secret-egress is a separate, tighter allowlist than tool use, and it wins. Two legitimate calls are allowed. Every decision, allow or deny, writes an audit record with the required fields. The pipeline emits an OSCAL `assessment-results` file: nine findings, all pass.
+
+That last step is the whole point. The control is no longer a sentence someone hopes is true. It's an assertion something ran, against a real runtime, and recorded the answer — a machine-readable finding you can diff on the next commit:
+
+```json
+{
+  "title": "deny secret egress",
+  "description": "expected deny/secret-egress-blocked, got deny/secret-egress-blocked",
+  "target": {
+    "target-id": "ac-4",
+    "type": "objective-id",
+    "status": { "state": "pass", "reason": "satisfied" }
+  }
+}
+```
+
+## What actually changed
+
+Nothing in OSCAL needed inventing. The component-definition model already carries `props` for application-specific semantics and `links` for pointing at a policy schema. The 800-53 controls already exist. What changed is the *expression*: instead of documenting that a policy exists, the requirement names the deterministic decision, the enforcement default, the policy artifact, and the pipeline assertion that proves it. The control describes behavior a machine can check.
+
+This isn't a solved space. NIST's [COSAiS](https://csrc.nist.gov/projects/cosais) project is actively developing 800-53 overlays for single- and multi-agent AI systems — the standards bodies already see agents as different enough to need tailored treatment. There's adjacent [AI risk-management guidance](https://www.nist.gov/itl/ai-risk-management-framework) too, though it's prose, not machine-checkable — which is rather the point. What I haven't found is a clean, public component-definition idiom for agent *runtime* behavior: tool allowlists, secret-egress denial, and the harder cases past them — delegated-credential scope, human-approval gates. This post takes the first two; the rest are the same shape.
+
+To be clear about what this is and isn't: it's an idiom, not an authorization package. The example uses a fake policy namespace and synthetic tool names, and the control mapping is illustrative. But the shape holds. Agents make the difference between a control and a wish very concrete, because the agent will absolutely take the wish literally and then improvise. So write the control as something that can say no on its own — and keep the YAML for the part that proves it did.

--- a/src/posts/2026-07-30-prove-the-gate-not-the-agent.md
+++ b/src/posts/2026-07-30-prove-the-gate-not-the-agent.md
@@ -1,0 +1,106 @@
+---
+title: "You Can't Prove the Agent. Prove the Gate."
+date: 2026-07-30
+description: "Formal verification for AI-agent security. You can't prove a probabilistic model does the right thing — but the deterministic gate in front of it is small enough to prove outright. Dafny proofs, a Rego twin, and differential testing, following the method AWS used for Cedar."
+tags:
+- security
+- ai
+- formal-verification
+- ai-agents
+- oscal
+---
+
+The [last post](/posts/2026-07-23-agent-controls-as-oscal) built a gate for an AI agent and proved it *ran* — negative tests, an audit trail, a machine-readable finding you could diff on the next commit. That's a real improvement over a policy document nobody executes. It is also the weakest useful thing you can say about a security control: it passed the cases I thought to write.
+
+The cases you didn't think to write are where the incident lives. So here is the stronger claim, and this post is about earning it: not "the gate passed my tests" but "the gate cannot allow a call the policy doesn't permit" — checked for every possible input at once, by a machine that doesn't get bored or optimistic. You cannot make that claim about an LLM. You can make it about the thing standing in front of the LLM.
+
+## Why the gate is the part you can prove
+
+A formal proof needs something total, deterministic, and small. Feed it a function that terminates on every input, always returns an answer, and fits in your head, and an automated prover will chew through every case for you. Feed it something that samples from a distribution and you get a shrug.
+
+An agent is the second thing. Its behavior lives in a model's weights and a temperature setting; "prove the agent won't exfiltrate a secret" is not a request a prover can honor. The gate is the first thing. The reference monitor from the last post is a pure function: a tool call goes in, an `allow`/`deny` with a reason comes out, and nothing about the model's mood changes the answer. That is exactly the shape a prover likes.
+
+So point the proof at the gate. The agent is the interesting part, sure. But the gate is the part where "cannot" is an available word.
+
+## What a proof buys over a test
+
+A test picks an input and checks the output. Write four negative tests and you've checked four points in a space with billions of them. A proof quantifies over the whole space. "For *every* tool call and *every* policy, if nothing on the allowlist matches, the decision is deny" is one statement that stands in for every test you'd never finish writing.
+
+I modeled the gate in [Dafny](https://dafny.org/), which discharges proofs with an SMT solver. The decision function mirrors the Python monitor's logic for the synthetic policy — same order, same deny reasons — written in Simplified Technical English, because a decision procedure reads like one anyway. Check the tool, check the action, check the destination, check for a secret, then decide (one defensive branch trimmed for space):
+
+```dafny
+function Decide(call: ToolCall, policy: Policy): Decision
+{
+  match FindToolRule(call.tool, policy.allowedTools)
+  case NoRule => Deny("tool-not-allowlisted")
+  case Found(rule) =>
+    if !InString(call.action, rule.actions) then
+      Deny("action-not-permitted")
+    else if !ResourceOrDestinationPermitted(call, rule) then
+      Deny("destination-not-permitted")
+    else if HasSecret(call, policy) && !EgressAllowed(call, policy) then
+      Deny("secret-egress-blocked")
+    else
+      Allow("matched-allow-rule")
+}
+```
+
+Then the properties. These are not tests. Each one is a statement Dafny proves holds for all inputs, or the build fails:
+
+```dafny
+lemma DenyByDefault(call: ToolCall, policy: Policy)
+  ensures !MatchesSomeAllowRule(call, policy) ==> Decide(call, policy).Deny?
+
+lemma EgressDominance(call: ToolCall, policy: Policy)
+  ensures HasSecret(call, policy) && !EgressAllowed(call, policy)
+          ==> Decide(call, policy).Deny?
+
+lemma AllowRequiresRule(call: ToolCall, policy: Policy)
+  ensures Decide(call, policy).Allow? ==> MatchesSomeAllowRule(call, policy)
+```
+
+`DenyByDefault` says the gate fails closed: no matching rule, no allow. `EgressDominance` says a secret headed somewhere unapproved is denied even when the tool call is otherwise fine — the sharp point from the last post, now a theorem instead of a test. `AllowRequiresRule` says the gate never says yes by accident: every allow traces back to a rule someone wrote down. A fourth lemma proves the function is total, which Dafny mostly insists on anyway.
+
+The proof bodies are empty. That is the good outcome — it means the properties fall straight out of the definitions, and the solver needs no hand-holding to see it. When the body has to fill up with hints, that's usually the model telling you the property is more fragile than you thought.
+
+## The gap a proof leaves open
+
+Here is the part most "we formally verified it" claims skip. A proof of the model is a proof of the *model*. It says nothing about whether the model matches the code you actually ship. You can prove a beautiful theorem about a Dafny function and still deploy a Python one that disagrees with it in a corner you never lined up.
+
+This is a known problem with a known discipline, and the people who worked it out are worth copying. AWS built [Cedar](https://www.amazon.science/blog/how-we-built-cedar-with-automated-reasoning-and-differential-testing), their authorization language, with exactly this worry in mind. They modeled the engine in Dafny with mechanized proofs (the models have since moved to Lean — same method, different prover), then used *differential testing* to hammer the model and the production Rust engine with generated inputs — on the order of a hundred million tests a night — checking that the two always agree. That second step turned up real bugs the proofs alone couldn't, because the proofs were about the model and the bugs were in the gap between it and the shipping code.
+
+So the gate carries a miniature of the same idea. Three implementations of the same decision — the Python reference monitor, the Dafny model compiled to Python, and a [Rego](https://www.openpolicyagent.org/docs/latest/policy-language/) policy you could actually drop into [OPA](https://www.openpolicyagent.org/) as a deployable decision point — get fed the same enumerated corpus of synthetic tool calls. A harness asserts all three return the same decision *and* the same reason for every one.
+
+<figure class="arch-fig">
+<div class="arch is-stack" role="group" aria-label="Differential testing across three implementations of the gate">
+  <section class="arch-tier" data-label="One input" role="group" aria-label="One input"><span class="arch-chip"><b>432 synthetic tool calls</b><i>enumerated, not sampled</i></span></section>
+  <section class="arch-tier" data-label="Three implementations" role="group" aria-label="Three implementations"><span class="arch-chip is-primary"><b>Python monitor</b><i>the shipped gate</i></span><span class="arch-chip is-guard"><b>Dafny model</b><i>proved, compiled to Python</i></span><span class="arch-chip is-guard"><b>Rego policy</b><i>deployable in OPA</i></span></section>
+  <section class="arch-tier" data-label="Compared on" role="group" aria-label="Compared on"><span class="arch-chip">decision + reason, for every call</span></section>
+  <section class="arch-tier" data-label="Result" role="group" aria-label="Result"><span class="arch-chip is-guard"><b>All three agree</b><i>a disagreement is a bug</i></span></section>
+</div>
+<figcaption>Prove the model, then check the proof against the code you ship. The Dafny-proved decision, the deployable Rego policy, and the production Python monitor must return the same decision and the same reason for every call in the corpus.</figcaption>
+</figure>
+
+Run it, and the three columns line up:
+
+```text
+$ python verify/difftest/run.py
+decision,reason,count
+allow,matched-allow-rule,20
+deny,action-not-permitted,192
+deny,destination-not-permitted,56
+deny,secret-egress-blocked,20
+deny,tool-not-allowlisted,144
+checked 432 synthetic calls
+all engines agree
+```
+
+432 is not millions. This is a toy, and I want to be precise about what it demonstrates: the *method*, not an industrial guarantee. The proved model, the deployable policy, and the production code agree across every case the corpus covers, and the corpus is enumerated rather than sampled, so "every case" means something bounded and honest. Scaling from hundreds of enumerated cases to millions of generated ones — with generators that actually hit the corners, which is the part that earns its keep — is engineering, not a new idea. The [whole thing](https://github.com/williamzujkowski/oscal-agent-controls) verifies in CI on every push: `dafny verify`, `opa test`, and the differential run.
+
+## What this does and doesn't earn you
+
+A proven gate is not a safe agent. The agent will still improvise, still get prompt-injected, still try things you didn't anticipate — verification doesn't touch any of that. What it changes is the trust you place in the one component standing between the agent's improvisation and the blast radius. When the gate says deny, you now know it says deny for *every* call the allowlist doesn't cover, not just the ones your test suite remembered.
+
+Two honest limits. First, the proof is only as good as the model's fidelity to the real runtime; differential testing narrows that gap but three implementations can still share one wrong assumption, which is why the corpus and the model both deserve suspicion. Second, the gate proves enforcement, not detection — "if the payload matches a secret pattern, deny" is a theorem, but whether the pattern actually catches real secrets is a separate, unproven, and much messier problem.
+
+None of that diminishes the move. You take the messy, probabilistic, genuinely-hard part and you refuse to stake safety on proving it. You isolate a small deterministic gate, prove *that* outright, and check the proof against the code you ship. The agent improvises. The gate does not — and now you can prove it.


### PR DESCRIPTION
Publishes the two-part OSCAL agent-controls series.

**Posts**
- **2026-07-23 — The Firewall Stays Put. The Agent Improvises.** Expressing AI-agent runtime controls (tool allowlists, secret-egress denial, audit) as an OSCAL component-definition, proved by a pipeline that emits `assessment-results`. Includes a `.flow` gate decision-cascade diagram.
- **2026-07-30 — You Can't Prove the Agent. Prove the Gate.** Formally verifying the deterministic gate (Dafny proofs + Rego twin + differential testing), following AWS Cedar's method. Includes a `.arch` differential-testing triad diagram.

**Backing repo:** [`oscal-agent-controls`](https://github.com/williamzujkowski/oscal-agent-controls) — public, CI-green (pytest, `make verify`, `dafny verify` 15/0, `opa test` 7/7, differential test 432/agree).

**QA:** both passed the full pre-publish gate (overlap, citation factcheck, llm-tells, NDA, argument-shape) plus an independent adversarial review. All example data is synthetic; framing uses "test environment" (NDA-safe). Native diagrams verified through sanitize + design audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)