### PR TITLE
fix(citations): classify anti-bot HTTP codes as unverifiable, not broken (#391)

### DIFF
--- a/scripts/link-validation/link-validator.py
+++ b/scripts/link-validation/link-validator.py
@@ -161,6 +161,42 @@ class LinkValidator:
         if self.browser:
             await self.browser.close()
 
+    # Anti-bot / rate-limit HTTP codes: the resource still exists for a human
+    # reader, but CI can't verify it. IEEE Xplore answers automated checkers
+    # with 202 ("Accepted") or 418 ("I'm a teapot"); LinkedIn returns 999;
+    # generic rate limiting is 429. These must not inflate the broken count.
+    ANTIBOT_CODES = frozenset({202, 418, 429, 999})
+
+    @staticmethod
+    def classify_http_status(status_code: int, has_paywall: bool = False,
+                             is_redirect: bool = False):
+        """Map a final HTTP status to (status, issue_type). Pure -- no network.
+
+        Only genuinely-dead responses are 'broken': 404 and 5xx (plus ssl_error /
+        dns_error / timeout, which callers handle separately). 403/401/paywall
+        and the anti-bot/rate-limit codes in ANTIBOT_CODES are 'restricted'
+        (unverifiable, advisory) so the weekly citation report only alarms on
+        real breakage rather than on publisher bot challenges. See #366 / #391.
+        """
+        if status_code == 200:
+            if has_paywall:
+                return 'restricted', 'paywall'
+            if is_redirect:
+                return 'redirect', 'redirect'
+            return 'valid', None
+        if status_code == 404:
+            return 'broken', '404'
+        if status_code == 403:
+            return 'restricted', '403'
+        if status_code == 401:
+            return 'restricted', 'http_401'
+        # Checked before the >=500 branch because 999 would otherwise be swept up.
+        if status_code in LinkValidator.ANTIBOT_CODES:
+            return 'restricted', f'http_{status_code}'
+        if status_code >= 500:
+            return 'broken', f'{status_code}_error'
+        return 'broken', f'http_{status_code}'
+
     async def validate_batch(self, links: List[Dict]) -> List[ValidationResult]:
         """Validate a batch of links"""
         results = []
@@ -284,39 +320,11 @@ class LinkValidator:
                 title_match = re.search(r'<title>([^<]+)</title>', content, re.IGNORECASE)
                 page_title = title_match.group(1) if title_match else None
 
-                # Determine status and issue type
-                #
-                # 403/401/paywall are access-restricted responses (publisher WAF
-                # blocks, login walls) that a human reader can usually still see
-                # fine -- CI simply can't verify them. Classify those as
-                # 'restricted' (unverifiable, advisory) rather than 'broken'
-                # (genuinely dead) so the weekly report only alarms on real
-                # breakage: 404 / 5xx / ssl_error / dns_error / timeout.
-                if response.status == 200:
-                    if has_paywall:
-                        status = 'restricted'
-                        issue_type = 'paywall'
-                    elif is_redirect:
-                        status = 'redirect'
-                        issue_type = 'redirect'
-                    else:
-                        status = 'valid'
-                        issue_type = None
-                elif response.status == 404:
-                    status = 'broken'
-                    issue_type = '404'
-                elif response.status == 403:
-                    status = 'restricted'
-                    issue_type = '403'
-                elif response.status == 401:
-                    status = 'restricted'
-                    issue_type = 'http_401'
-                elif response.status >= 500:
-                    status = 'broken'
-                    issue_type = f'{response.status}_error'
-                else:
-                    status = 'broken'
-                    issue_type = f'http_{response.status}'
+                # Map the final HTTP status to a classification (see
+                # classify_http_status for the broken-vs-restricted taxonomy).
+                status, issue_type = self.classify_http_status(
+                    response.status, has_paywall=has_paywall, is_redirect=is_redirect
+                )
 
                 return ValidationResult(
                     url=url,

--- a/scripts/link-validation/tests/test_link_validator.py
+++ b/scripts/link-validation/tests/test_link_validator.py
@@ -1,0 +1,49 @@
+"""Regression tests for link-validator.py HTTP status classification.
+
+Locks in that anti-bot / rate-limit codes (202/418/429/999) are 'restricted'
+(unverifiable), NOT 'broken' -- only 404 and 5xx are broken. This is the
+validator the citation-validation workflow actually runs; IEEE Xplore's 202/418
+bot challenges were inflating the broken count (issue #391, extends #366).
+"""
+import pytest
+
+from conftest import load_script
+
+lv = load_script("link-validator.py")
+classify = lv.LinkValidator.classify_http_status
+
+
+@pytest.mark.parametrize("code,expected", [
+    (200, "valid"),
+    (404, "broken"),
+    (410, "broken"),   # falls through the <500 else -> broken
+    (403, "restricted"),
+    (401, "restricted"),
+    (202, "restricted"),   # IEEE anti-bot "Accepted" stall
+    (418, "restricted"),   # IEEE "I'm a teapot" anti-bot
+    (429, "restricted"),   # rate limited
+    (999, "restricted"),   # LinkedIn / non-standard anti-bot
+    (500, "broken"),
+    (503, "broken"),
+])
+def test_classify_http_status(code, expected):
+    assert classify(code)[0] == expected
+
+
+def test_antibot_codes_are_never_broken():
+    """The #391 false positives: bot challenges must not read as broken."""
+    for code in sorted(lv.LinkValidator.ANTIBOT_CODES):
+        status, issue_type = classify(code)
+        assert status == "restricted"
+        assert issue_type == f"http_{code}"
+
+
+def test_200_variants():
+    assert classify(200) == ("valid", None)
+    assert classify(200, has_paywall=True) == ("restricted", "paywall")
+    assert classify(200, is_redirect=True) == ("redirect", "redirect")
+
+
+def test_genuinely_dead_stays_broken():
+    assert classify(404)[0] == "broken"
+    assert classify(500)[0] == "broken"


### PR DESCRIPTION
Addresses the false positives in #391.

## Finding
The citation-validation workflow runs `link-validator.py`, whose classifier routed every unhandled status through an `else` → `broken`. That false-flagged publisher **anti-bot / rate-limit** responses as broken links. **13 of the 16 "broken" links in #391 are IEEE Xplore `202`/`418`** — IEEE returns those to automated checkers, but the pages exist fine for a human.

I spot-checked the flagged links:
- IEEE `202`/`418` (e.g. `document/8593885`) — bot-blocked, real records → **false positive**
- Nature `s42256-023-00673-3` reported `404` — actually a `303` redirect to `idp.nature.com/authorize` (article gated, not dead) → **false positive**
- `cyberthreatalliance.org/resources/` reported `202` — fully live page → **false positive**

## Fix
Reclassify `202/418/429/999` as `restricted` (unverifiable, advisory), matching #366's treatment of `403/401/paywall` and the sibling `simple-validator.py`'s soft-code taxonomy. Only genuinely-dead responses (`404` / `5xx` / ssl / dns / timeout) stay `broken`.

- Extracted the status→(status, issue_type) mapping out of the async `_validate_http` into a **pure** `LinkValidator.classify_http_status` (previously untestable) + an `ANTIBOT_CODES` constant.
- New `tests/test_link_validator.py` locks in the taxonomy. **57 pass** (`uv run pytest scripts/link-validation/tests/`).

## Effect
The next weekly citation run moves the IEEE/anti-bot links from the "broken" section to "access-restricted (unverifiable, likely valid)" — the report will only alarm on real breakage. No blog-post citations were changed, because they aren't actually broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)