### PR TITLE
ci: cache Astro font downloads to stop transient jsdelivr build flakes (#408)

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -58,6 +58,13 @@ jobs:
         run: cd astro-site && pnpm install --frozen-lockfile
       - name: Install Playwright chromium
         run: cd astro-site && pnpm exec playwright install --with-deps chromium
+      - name: Cache Astro font downloads (issue #408 — avoid transient jsdelivr fetch)
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: astro-site/node_modules/.astro/fonts
+          key: astro-fonts-${{ hashFiles('astro-site/astro.config.mjs', 'astro-site/pnpm-lock.yaml') }}
+          restore-keys: |
+            astro-fonts-
       - name: Build site
         run: cd astro-site && pnpm build
       - name: Run full Playwright suite (smoke + a11y + theme-deck)

--- a/.github/workflows/compliance-monitor.yml
+++ b/.github/workflows/compliance-monitor.yml
@@ -42,6 +42,13 @@ jobs:
     - name: Install dependencies
       run: cd astro-site && pnpm install --frozen-lockfile
 
+    - name: Cache Astro font downloads (issue #408 — avoid transient jsdelivr fetch)
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      with:
+        path: astro-site/node_modules/.astro/fonts
+        key: astro-fonts-${{ hashFiles('astro-site/astro.config.mjs', 'astro-site/pnpm-lock.yaml') }}
+        restore-keys: |
+          astro-fonts-
     - name: Build site
       run: cd astro-site && pnpm run build
       continue-on-error: false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,13 @@ jobs:
       - name: Install Playwright Chromium
         run: cd astro-site && pnpm exec playwright install --with-deps chromium
 
+      - name: Cache Astro font downloads (issue #408 — avoid transient jsdelivr fetch)
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: astro-site/node_modules/.astro/fonts
+          key: astro-fonts-${{ hashFiles('astro-site/astro.config.mjs', 'astro-site/pnpm-lock.yaml') }}
+          restore-keys: |
+            astro-fonts-
       - name: Build site
         run: cd astro-site && pnpm build
         env:


### PR DESCRIPTION
Closes #408.

## Cause
Astro's Fonts API fetches woff2 from the **jsdelivr CDN at build time**. Since `pnpm install` recreates `node_modules` fresh each run, Astro's font cache (`node_modules/.astro/fonts`) never survives across CI runs — so **every** build re-fetches from the CDN, and a CDN blip reds any build-dependent job (axe/deploy/compliance) with a misleading `CannotFetchFontFile` (which reads as e.g. "axe failed", not a font issue). Reruns pass, confirming it's transient.

## Fix
Add an `actions/cache` step for `astro-site/node_modules/.astro/fonts`, keyed on the fonts config (`astro.config.mjs`) + lockfile, to the **three** workflows that actually run `astro build`: `a11y.yml`, `compliance-monitor.yml`, `deploy.yml`. After the first run, builds restore fonts from cache and never touch the CDN (except when the font config changes and the key rotates).

- `audits.yml` runs node audit scripts, not `astro build`, so it isn't affected.
- **Safe by construction:** `actions/cache` is non-fatal — a miss or cache-service error just falls back to today's fetch. This change can only help or no-op; it cannot break a build.
- Action SHA-pinned (`actions/cache@55cc834…` v6.1.0) per repo convention; all three YAMLs validated as parseable.

## Verification
This PR runs `a11y` and `compliance` (both build), exercising the new cache step live. `deploy.yml` runs on merge; its YAML is validated and the cache is non-fatal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)