### PR TITLE
docs: add blog-deep-review to the QA pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,14 @@ The Layer-1 skills are author-local tooling in `~/.claude/skills/blog-*/`
 │     blog-llm-tells      → voice/prose LLM-tell scrub              │
 │     blog-nda-check      → contextual NDA-compliance               │
 │     blog-argument-shape → thesis + evidence + falsifiability      │
+│     blog-visuals        → zine doodle, diagram a11y, tokens       │
+│                                                                   │
+│   blog-deep-review (separate, deliberate, expensive):             │
+│     4 parallel adversarial reviewers — reason-to-exist,           │
+│     fact-check vs primary source, prose/structure, prior-art +    │
+│     fairness + ethics. For load-bearing posts and the back        │
+│     catalogue. The gate passes posts that are wrong; this is      │
+│     what finds them.                                              │
 └───────────────────────────────────────────────────────────────────┘
                             │ author commits
                             ▼
@@ -210,6 +218,8 @@ The Layer-1 skills are author-local tooling in `~/.claude/skills/blog-*/`
 | Citation link health (HTTP) | Layer 4 (`link-monitor.yml`) | Cheap, automated, scales |
 | Topic overlap with prior posts | Layer 1 (`blog-overlap`) | Author decides refinement vs new arg |
 | Thesis / evidence / falsifiability | Layer 1 (`blog-argument-shape`) | Author-time editorial judgment |
+| Visual coverage, diagram a11y, design tokens | Layer 1 (`blog-visuals`) | The prose audits all pass on a wall of text |
+| Unanswered objections, uncited prior art, self-flattering arithmetic, claims that outlived their evidence | Layer 1 (`blog-deep-review`) | Needs adversarial judgment and a web search; too expensive per-commit. **Reviewers are confidently wrong — recompute every challenged number from raw inputs before accepting a correction.** |
 | Build correctness | Layer 2 (pre-commit) | Fast, blocks bad commits |
 | Astro design tokens | Layer 3 (`audits.yml`) | Per-commit, blocks broken design |
 | Accessibility | Layer 3 (`a11y.yml`) | Per-commit, axe-playwright |


### PR DESCRIPTION
The pre-publish gate passed a post with wrong arithmetic, two-year-old uncited prior art, a literally false title, and its most obvious objection unanswered — with zero banned words, verified URLs, no NDA risk and a located thesis. The gate worked. It just can't see any of that.

`blog-deep-review` is the audit that can: four independent reviewers in parallel — reason-to-exist, facts vs primary sources, prose/structure, and prior-art + fairness + ethics. Expensive by design, so it's a separate skill rather than another gate step.

**The rule at the top of it is the one that cost the most to learn:**

> Reviewers are confidently wrong, including when they agree with each other.

Two of four independently said a headline figure was wrong. Both were wrong the same way, and accepting their fix would have introduced the error they were complaining about, mirrored. So every quantitative correction is **recomputed from raw inputs** before acceptance, and where treatments differ the range is reported — a result robust across treatments beats any single point estimate.

Also documents:
- **Already-published protocol** — correct visibly, name the direction the error ran, fix upstream before the copy, keep the slug.
- **Back-catalogue triage** — old posts fail differently. Highest-value check is grepping for claims a withdrawn-claims register has since retracted. Ran it: **clean**.

Skill file lives with the other author-time skills in `~/.claude/skills/`; this commit is the pipeline doc and the pointer from `blog-pre-publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)