### PR TITLE
posts: correct four more posts from audit batch two

### DIFF
--- a/src/posts/2024-09-15-running-llama-raspberry-pi-pipeload.md
+++ b/src/posts/2024-09-15-running-llama-raspberry-pi-pipeload.md
@@ -15,11 +15,13 @@ tags:
 
 ## Bottom Line Up Front
 
-I ran a 7 billion parameter language model on an 8GB Raspberry Pi 4 using PIPELOAD's memory-efficient pipeline inference mechanism. Results: **90.3% memory reduction** compared to standard PyTorch, **4.24x faster inference** for BERT-style models, and **2.5 tokens/second** for generative inference on LLaMA 2 7B.
+I ran a 7 billion parameter language model on an 8GB Raspberry Pi 4 using a layer-streaming inference approach modelled on PIPELOAD. On my hardware the memory reduction was **88.6%** against loading the whole model, and BERT-style inference came out **4.25x** faster than the swap-thrashing baseline.
+
+The generation throughput I originally reported here doesn't survive its own arithmetic, so I've pulled it: at the 120-180ms per-layer load time I measured, a 32-layer model cannot stream faster than about 0.2 tokens/second, and every token re-reads every layer. The figure I published was an order of magnitude above that. I'd rather leave a gap than a number I can't reconstruct.
 
 **Why it matters:** Edge AI deployment typically fails due to memory constraints. A standard 7B model requires 14-28GB RAM for full-precision inference. PIPELOAD's dynamic memory management and parallel model loading reduce this to under 3GB, making edge deployment practical on consumer hardware.
 
-**The catch:** 12% latency overhead per token and limited to models with layer-wise decomposition. Works best for BERT, ViT, GPT-style architectures. Struggles with models requiring global attention or cross-layer dependencies.
+**The catch:** real per-token latency overhead, and it only applies to models with clean layer-wise decomposition. Works best for BERT, ViT, GPT-style architectures. Struggles with models requiring global attention or cross-layer dependencies.
 
 **What I tested:**
 - LLaMA 2 7B quantized (Q4_K_M) on Raspberry Pi 4 8GB
@@ -91,7 +93,7 @@ Standard inference caches all activations for potential backpropagation. PIPELOA
 - Standard PyTorch: Caches 32 layers × 128MB activations = 4GB
 - PIPELOAD: Caches 1 layer × 128MB + residuals = 256MB
 
-Combined with layer unloading, peak memory usage drops by 90.3% for GPT-style models ([Hermes paper](https://arxiv.org/abs/2409.04249), Table 2).
+The [Hermes paper](https://arxiv.org/abs/2409.04249) (Han et al.) reports up to 90.3% lower memory for GPT-J and 86.7% for BERT/ViT — measured against PipeSwitch on Xeon Gold 6248R CPUs in memory-capped containers, not on a Pi and not against plain PyTorch. My own numbers below are a much rougher thing on much smaller hardware.
 
 ---
 
@@ -177,7 +179,7 @@ model = model.quantize(
 print(f"Model size: {model.size_gb():.2f}GB")  # ~4.1GB for LLaMA 7B
 ```
 
-**Why 4-bit quantization:** Reduces model size from 14GB (FP16) to 4.1GB (Q4_K_M) with minimal accuracy loss. For general text generation, perplexity increases by ~3% ([GPTQ paper](https://arxiv.org/abs/2210.17323), Table 3). For my use case (homelab experimentation), this trade-off is acceptable.
+**Why 4-bit quantization:** Reduces model size from 14GB (FP16) to 4.1GB (Q4_K_M) with minimal accuracy loss. Quality loss at 4-bit is small but I don't have a clean number for this model and quantization pair — note Q4_K_M is a llama.cpp k-quant, which is a different algorithm from GPTQ and needs no calibration data. For my use case (homelab experimentation), this trade-off is acceptable.
 
 ### Step 4: Run Inference
 
@@ -260,7 +262,7 @@ I tested three scenarios on my homelab hardware:
 2. **BERT/ViT on Pi 4:** PIPELOAD is 4.2x faster than standard PyTorch. Parallel loading and activation optimization outweigh I/O overhead for smaller models.
 3. **Latency trade-off:** On workstation (NVMe PCIe 4.0), PIPELOAD is 12% slower due to unnecessary layer loading overhead. Standard PyTorch is faster when memory isn't constrained.
 
-**Why the speedup for BERT/ViT:** These models fit in Pi's memory with PIPELOAD but thrash swap with standard PyTorch. Avoiding swap I/O (250MB/s microSD) by using NVMe layer loading (400MB/s) produces net speedup.
+**Why the speedup for BERT/ViT:** These models fit in Pi's memory with PIPELOAD but thrash swap with standard PyTorch. Avoiding swap I/O (25MB/s microSD) by using NVMe layer loading (400MB/s) produces net speedup.
 
 ---
 
@@ -268,7 +270,7 @@ I tested three scenarios on my homelab hardware:
 
 ### Success: Sustainable Edge Inference
 
-After tuning batch sizes and adding active cooling, I achieved stable 2.5 tok/sec inference for 6+ hours continuously:
+After tuning batch sizes and adding active cooling, it ran continuously without thermal throttling or OOM:
 - Prompt: 50 different questions from [HumanEval benchmark](https://github.com/openai/human-eval)
 - Output: 100 tokens per response
 - Total: 5,000 tokens generated
@@ -288,10 +290,10 @@ I tried increasing batch size to improve throughput. Results:
 
 ### Failure: Model Parallelism Across Pi Cluster
 
-I attempted splitting LLaMA 2 70B across my 3 Raspberry Pi 5s (16GB each) using PIPELOAD:
+I later attempted splitting LLaMA 2 70B across three Raspberry Pi 5s using the same approach:
 - Layers 0-23 on Pi #1
 - Layers 24-47 on Pi #2
-- Layers 48-71 on Pi #3
+- Layers 48-79 on Pi #3 (70B has 80 layers, not the 72 I first planned for — which was itself the first thing that broke)
 
 **Result:** Network latency (2-5ms per layer transfer) dominated inference time. Achieved 0.3 tok/sec (8x slower than single Pi with 7B model). The overhead of serializing activations, transferring over gigabit ethernet, and deserializing killed performance.
 
@@ -446,7 +448,7 @@ Edge AI is no longer a research curiosity. It's a practical deployment option fo
 ## Sources
 
 1. **[Hermes: Memory-Efficient Pipeline Inference for Large Models on Edge Devices](https://arxiv.org/abs/2409.04249)** (2024)
-   - Zhang et al., *arXiv preprint*
+   - Han, Cai, Zhang, Fan, Liu, Ma & Buyya, *arXiv preprint*
    - Describes PIPELOAD mechanism, benchmarks 86.7-90.3% memory reduction
 
 2. **[GPTQ: Accurate Post-Training Quantization for Generative Pre-trained Transformers](https://arxiv.org/abs/2210.17323)** (2022)

--- a/src/posts/2025-07-01-ebpf-security-monitoring-practical-guide.md
+++ b/src/posts/2025-07-01-ebpf-security-monitoring-practical-guide.md
@@ -87,7 +87,7 @@ The magic happens in the kernel with eBPF programs that capture these events in 
   <li class="seq-label">If: suspicious pattern</li>
   <li class="seq-step"><b>eBPF &rarr; Detector</b><span>Alert event</span></li>
   <li class="seq-step"><b>Detector &rarr; Response</b><span>Trigger response</span></li>
-  <li class="seq-step"><b>Response &rarr; Process</b><span>Block, kill, or isolate</span></li>
+  <li class="seq-step"><b>Response &rarr; Process</b><span>alert, or kill via BPF-LSM</span></li>
   <li class="seq-label">Else: normal behavior</li>
   <li class="seq-step"><b>eBPF &rarr; eBPF</b><span>Log and continue</span></li>
 </ol>
@@ -119,7 +119,9 @@ I once spent an entire weekend debugging why my eBPF program worked perfectly on
 
 ### BTF Availability Validation
 
-**Check kernel BTF support:** Before deploying CO-RE eBPF programs, verify your kernel exposes BTF information with `ls /sys/kernel/btf/vmlinux`. If missing, kernel was built without `CONFIG_DEBUG_INFO_BTF=y`. Ubuntu 20.04+ and RHEL 8.2+ enable BTF by default. For custom kernels, rebuild with BTF enabled or use non-CO-RE eBPF (requires recompilation per kernel version).
+**One thing tracing eBPF cannot do:** a kprobe or tracepoint program observes, it does not block. The syscall has already run by the time your handler sees it. Enforcement needs BPF-LSM hooks returning `-EPERM` (5.7+, `CONFIG_BPF_LSM`), or `bpf_send_signal()` — which kills the process *after* the fact and loses a race an attacker can win. Treat everything below as detection unless you have wired up BPF-LSM.
+
+**Check kernel BTF support:** Before deploying CO-RE eBPF programs, verify your kernel exposes BTF information with `ls /sys/kernel/btf/vmlinux`. If missing, kernel was built without `CONFIG_DEBUG_INFO_BTF=y`. Ubuntu 20.10+ and RHEL 8.2+ enable BTF by default (Ubuntu's 20.04 / 5.4 kernel does not). For custom kernels, rebuild with BTF enabled or use non-CO-RE eBPF (requires recompilation per kernel version).
 
 **Debug BTF issues:** If programs fail with "CO-RE relocation failed" errors, check BTF completeness with `bpftool btf dump file /sys/kernel/btf/vmlinux format c > vmlinux.h` and search for your target struct (e.g., `grep "struct task_struct" vmlinux.h`). Missing structs indicate incomplete BTF. Install `linux-headers-$(uname -r)` to populate module BTF at `/sys/kernel/btf/<module_name>`. Verify with `bpftool btf list` showing all available BTF objects. For production deployments, add BTF validation to startup scripts: `test -f /sys/kernel/btf/vmlinux || exit 1` prevents eBPF programs from loading on incompatible kernels.
 
@@ -192,7 +194,7 @@ eBPF overhead scales **non-linearly** with event volume due to ring buffer conte
 
 eBPF maps consume kernel memory proportional to event cardinality:
 
-**Per-CPU ring buffers (most common):**
+**A note on which buffer you're sizing.** `BPF_MAP_TYPE_RINGBUF` (5.8+) is a *single shared* buffer across all CPUs — that was the point of replacing `BPF_MAP_TYPE_PERF_EVENT_ARRAY`, which is the per-CPU one. If you're on modern ringbuf, do not multiply by core count; the figures below are per-CPU perf-buffer sizing and will overshoot by your CPU count:
 ```
 Ring buffer size = (number of CPUs) × (per-CPU buffer size)
 Example: 8 CPUs × 64MB = 512MB total
@@ -349,23 +351,25 @@ Recent academic research has significantly advanced our understanding of eBPF se
 
 #### Historical Verifier Bypass CVEs
 
-**CVE-2021-31440 (CVSS 7.8):** Incorrect bounds tracking in BPF ALU32 operations
-- **Impact:** Local privilege escalation to root via out-of-bounds read/write
-- **Affected:** Linux kernels <5.11.12
+**CVE-2021-31440 (CVSS 7.0):** Incorrect bounds tracking in BPF ALU32 operations
+- **Impact:** Local privilege escalation via out-of-bounds read/write
+- **Affected:** 5.7–5.10.36, 5.11–5.11.20, 5.12–5.12.3
 - **Root cause:** Verifier failed to properly track 32-bit arithmetic operation bounds
-- **Exploitation:** Craft eBPF program that passes verification but performs OOB memory access at runtime
+- **Exploitation:** Craft an eBPF program that passes verification but performs OOB access at runtime
 
-**CVE-2021-33624 (CVSS 7.8):** BPF verifier allows pointer arithmetic on modified pointer
-- **Impact:** Arbitrary kernel memory read/write leading to privilege escalation
-- **Affected:** Linux kernels <5.12.4
-- **Root cause:** Verifier incorrectly validated pointer arithmetic after pointer modification
-- **Exploitation:** Bypass verifier checks to access arbitrary kernel memory
+**CVE-2021-33624 (CVSS 4.7):** Speculative side channel after a mispredicted branch
+- **Impact:** An unprivileged BPF program can **read** arbitrary kernel memory. Read-only — the CVSS vector is `I:N`, so there is no write and no privilege escalation
+- **Affected:** Linux kernels before 5.12.13
+- **Root cause:** A branch can be mispredicted (e.g. through type confusion), and the speculative path leaks memory contents through a side channel
+- **Exploitation:** Spectre-class measurement, not a direct memory write
 
-**CVE-2023-2163 (CVSS 8.2):** Incorrect verifier pruning of unreachable code paths
-- **Impact:** Privilege escalation via speculative execution side channels
-- **Affected:** Linux kernels <6.3
-- **Root cause:** Verifier optimization incorrectly pruned security-critical code paths
-- **Exploitation:** Time-of-check-time-of-use attacks via pruned verification paths
+**CVE-2023-2163 (CVSS 10.0):** Incorrect verifier pruning marks unsafe paths as safe
+- **Impact:** Arbitrary kernel read/write, lateral privilege escalation, and **container escape**. This is the one to care about — it is rated critical, and it is the reason the version check below matters
+- **Affected:** 5.4 and later, until 5.4.242 / 5.10.179 / 5.15.109 / 6.1.26 / 6.2.13
+- **Root cause:** The verifier's state-pruning optimization concluded that code paths were equivalent when they were not, so unsafe paths were never checked
+- **Exploitation:** Direct — the program simply does what the verifier wrongly believed it could not
+
+A note on reading these: the two you would guess are equivalent from their names are three orders of magnitude apart in severity. 33624 is a read-only side channel with a high attack complexity; 2163 hands over kernel write and container escape. Version checking is worth doing precisely because the names don't tell you that.
 
 #### Mitigation Strategies
 
@@ -407,10 +411,11 @@ sysctl kernel.unprivileged_bpf_disabled
 # Check lockdown status
 cat /sys/kernel/security/lockdown
 # Options: [none] [integrity] [confidentiality]
-# Recommended: confidentiality (most restrictive)
+# Recommended: integrity. NOT confidentiality - it disables bpf_probe_read*,
+# kprobes and kernel-data perf events, which turns off everything in this post.
 
 # Set at boot via kernel parameter
-# Add to GRUB: lockdown=confidentiality
+# Add to GRUB: lockdown=integrity
 ```
 
 **4. Namespace Restrictions:**
@@ -423,7 +428,8 @@ securityContext:
   capabilities:
     drop:
       - ALL
-      - CAP_SYS_ADMIN  # Prevents legacy eBPF loading
+      # dropping ALL already covers CAP_BPF/CAP_PERFMON/CAP_SYS_ADMIN.
+      # Note: k8s capability names omit the CAP_ prefix - the runtime adds it.
       - CAP_BPF        # Prevents eBPF program loading (kernel 5.8+)
       - CAP_PERFMON    # Prevents perf event monitoring
 ```
@@ -444,10 +450,10 @@ sysctl kernel.unprivileged_bpf_disabled
 
 # 3. Verify eBPF JIT hardening enabled
 sysctl net.core.bpf_jit_harden
-# Expected: net.core.bpf_jit_harden = 2 (maximum hardening for unprivileged users)
+# Expected: net.core.bpf_jit_harden = 2 (hardening for all users; 1 would cover unprivileged users only). Note this costs JIT performance on your own monitoring programs too
 
 # 4. Check available eBPF capabilities
-cat /proc/sys/kernel/unprivileged_userns_clone
+cat /proc/sys/kernel/apparmor_restrict_unprivileged_userns
 # Expected: 0 (user namespaces disabled, prevents container escape)
 
 # 5. Audit eBPF program usage
@@ -458,7 +464,7 @@ bpftool prog show
 **Production hardening checklist:**
 - [ ] Kernel ≥6.1 LTS with all CVE patches
 - [ ] `kernel.unprivileged_bpf_disabled=1` enforced
-- [ ] Kernel lockdown mode enabled (confidentiality)
+- [ ] Kernel lockdown mode set to `integrity` (not `confidentiality`, which disables the tracing this relies on)
 - [ ] eBPF JIT hardening enabled (`net.core.bpf_jit_harden=2`)
 - [ ] Container security contexts drop CAP_BPF/CAP_SYS_ADMIN
 - [ ] Regular `bpftool prog` audits for unauthorized programs

--- a/src/posts/2025-10-17-progressive-context-loading-llm-workflows.md
+++ b/src/posts/2025-10-17-progressive-context-loading-llm-workflows.md
@@ -30,7 +30,7 @@ Traditional LLM workflows suffer from "context obesity": stuffing every possible
 **Research shows the waste**:
 - Long-context performance degrades once a prompt carries more than the task actually needs
 - Most tasks only need a small slice of the loaded context to produce a correct answer
-- **Result**: 95% of your context is computational waste, though I'm still experimenting with optimal ratios
+- **Result**: in my workload, roughly 95% of the loaded context went unread. That's a measurement of my repository, not a general claim about yours
 
 ⚠️ **Warning:** This diagram illustrates LLM context loading strategies for educational purposes. Implement proper security controls and access restrictions when deploying progressive loading systems in production environments.
 
@@ -57,7 +57,7 @@ In October 2024, I tested progressive loading with my RTX 3090 running Llama 3.1
 - Progressive chunk loading: 0.3 seconds per 1K chunk
 - VRAM spike (all-at-once): 22.1GB peak
 - VRAM with progressive: stayed under 18.4GB
-- Token limit I ignored: 32K (oops)
+- Token limit I ignored: my serving config's 32K default (Llama 3.1 70B itself handles 128K — this was my `n_ctx`, not the model's ceiling)
 
 I learned the hard way that progressive loading isn't just about speed. It's about respecting model constraints and working **with** the architecture, not against it.
 
@@ -95,7 +95,7 @@ Four evolutionary stages, each solving problems from the previous generation:
 | V3 Auto-Routing | 22K | 1.4s | 94% | Medium |
 | V4 Progressive Graph | 2K | 0.3s | 98% | High |
 
-The V4 architecture achieves what [LazyLLM](https://arxiv.org/html/2407.14057v1) calls "lazy loading with minimal accuracy loss": deferring context assembly until the model's attention patterns reveal actual need, rather than preemptively loading based on pessimistic assumptions.
+The V4 architecture defers context assembly until something actually asks for it, rather than loading on pessimistic assumptions up front. The same instinct shows up inside the model in [LazyLLM](https://arxiv.org/html/2407.14057v1), which prunes prompt tokens during prefill and decode — different layer of the stack, same observation that most of what you load never gets used.
 
 ### My Chunking Strategy Disaster
 
@@ -172,7 +172,7 @@ Task flow:
 
 **Latency trade-offs I discovered**: Progressive loading adds 1.2-1.8 seconds overhead per additional chunk load. For 8 chunks, that's 10-14 seconds total compared to 4 seconds for all-at-once loading. The trade-off: better context awareness versus longer wait times. For my use case (pre-commit hooks), the extra latency is acceptable because accuracy matters more than speed. But for real-time chat, this approach **could backfire**.
 
-Architecture inspired by ChunkKV-style chunked context loading, which trades some memory for chunk-level granularity. This adapts those principles to human-readable markdown skills.
+Architecture inspired by chunk-level thinking: [ChunkKV](https://arxiv.org/abs/2502.00299) groups KV-cache tokens into semantic chunks and keeps the informative ones, which is a compression technique rather than a loading one. What transfers is the unit of granularity, applied here to human-readable markdown skills.
 
 ## Anthropic Skills Alignment
 
@@ -184,32 +184,23 @@ Anthropic announced [Skills](https://www.anthropic.com/engineering/equipping-age
 - **Progressive Loading**: Expand context based on need
 - **Explicit Metadata**: Declare purpose and requirements upfront
 
-The [Anthropic Skills repository](https://github.com/anthropics/skills) shows `file-system-search`, `web-browser`, `code-editor` skills. Standards repository uses similar patterns for coding standard enforcement.
+The [Anthropic Skills repository](https://github.com/anthropics/skills) turned out to be closer to what I'd built than I expected. A Skill there is a directory containing a `SKILL.md` file with YAML frontmatter — markdown, not code — and the loading model is progressive disclosure: name and description sit in the system prompt, the full `SKILL.md` gets read when it matches, and bundled files load on demand. The `pdf` skill, for instance, ships `SKILL.md`, `forms.md`, `reference.md` and a `scripts/` directory.
 
-**Key differences**:
+**Where they actually differ:**
 
 | Aspect | Anthropic Skills | Standards Repository |
 |--------|------------------|---------------------|
-| **Primary Use Case** | General tool integration | Coding standards enforcement |
-| **Skill Format** | Programmatic tools (MCP) | Markdown documents |
-| **Loading Mechanism** | API discovery | File-based routing |
-| **Context Type** | Procedural (how to use tools) | Declarative (what standards to enforce) |
-| **Token Overhead** | ~500 per skill | ~1,800 per skill |
-| **Extensibility** | Requires code changes | Edit markdown files |
+| **Primary Use Case** | General capability packaging | Coding standards enforcement |
+| **Skill Format** | Markdown (`SKILL.md` + bundled files) | Markdown documents |
+| **Loading Mechanism** | Progressive disclosure from the filesystem | File-based routing by extension |
+| **Context Type** | Procedural (how to do a task) | Declarative (what standards to enforce) |
+| **Extensibility** | Edit markdown (there's a `skill-creator` skill) | Edit markdown files |
 
-**Complementary approaches**:
-- Anthropic Skills: Tool integration (browsers, databases, file systems)
-- Standards repository: Knowledge-heavy validation (the skill IS the context)
+Which is a shorter table than I first drafted, because on format, loading and extensibility the two designs landed in the same place. That's the more interesting result: two people solving "how do I give a model the right context at the right time" independently arrived at markdown files with lazy loading, rather than at a plugin API. Convergence is better evidence that the pattern is right than my own benchmarks are.
 
-**Hybrid future** (I think): Combine both patterns
-1. Use Anthropic Skills for file system discovery
-2. Load coding standards progressively by file type
-3. Apply validation rules (declarative markdown)
-4. Write results (Anthropic's file-system-write skill)
+The genuine difference is the fourth row. Anthropic's skills are mostly procedural — here is how to fill in a PDF form. Mine are declarative — here is the standard this file must meet. That changes what belongs in the file, not how it gets loaded.
 
-The challenge here: Anthropic's Skills have roughly 500 tokens overhead per skill, while my markdown-based approach uses roughly 1,800 tokens. That's a **3.6x difference**, but the markdown approach **doesn't require code changes**, just editing text files. The trade-off between programmatic efficiency and maintenance simplicity seems significant, though I'm still evaluating which approach wins long-term.
-
-[Agentic RAG research](https://arxiv.org/abs/2501.09136) confirms: multi-layer architecture (tools + knowledge + reasoning) is the future, with different context types loaded at different reasoning stages.
+The [Agentic RAG survey](https://arxiv.org/abs/2501.09136) maps the wider design space here — agentic patterns layered over retrieval — if you want to see where this sits relative to the rest of the field.
 
 ## Production Results
 
@@ -232,7 +223,7 @@ Workflow-aware routing (blog standards = 2,847 tokens total):
 - **Outline creation**: + Citation requirements (1,099 tokens)
 - **Full writing**: Complete standards (2,847 tokens)
 
-**Result**: 64% average token savings per workflow, 100% standards compliance maintained.
+**Result**: 48% average token savings per workflow, 100% standards compliance maintained.
 
 **Case Study 3: Multi-Repository Consistency**
 
@@ -316,7 +307,7 @@ Four emerging innovations:
 
 Use embeddings to auto-discover skill relationships. Loading `python/type-safety` might suggest related skills like `python/null-checks` based on usage patterns. I'm not sure this is practical yet, but the research looks promising.
 
-[Sufficient context estimation](https://arxiv.org/abs/2411.06037): Models predict required context size from task descriptions, which could lead to fully automated skill selection.
+[Sufficient context](https://arxiv.org/abs/2411.06037) classifies whether the context you already retrieved is enough to answer, which is how a router could learn to stop loading — or to abstain instead of guessing. It doesn't predict a size up front; that part is still on me.
 
 **2. Compression-Aware Skills**
 
@@ -324,7 +315,7 @@ Lossless compression reduces tokens while preserving information. Ship pre-compr
 
 **3. Token-to-Thought Transformation**
 
-[Tokens to Thoughts paradigm](https://arxiv.org/html/2505.17117): Represent concepts as thought graphs versus token sequences. Skills could evolve from markdown to graph-structured knowledge, potentially leading to another 10x cost reduction. Though I'm skeptical about the practical implementation complexity.
+Graph-structured skills instead of flat markdown. I have no measurement to offer here and no idea what it would save — it's a direction I find interesting, not a projection.
 
 **4. Reinforcement Learning Optimization**
 
@@ -414,7 +405,7 @@ Early "modular" attempts had hidden dependencies. V4's strict metadata forced ac
 
 **3. Human-Readable Wins**
 
-Markdown beats binary formats. Token overhead (roughly 20-30%) is worth the maintenance velocity gain. [LongRoPE](https://arxiv.org/abs/2402.13753): model performance degrades minimally with well-structured verbose context. However, for extremely token-sensitive use cases, this trade-off might not hold.
+Markdown beats binary formats. Token overhead (roughly 20-30%) is worth the maintenance velocity gain. For extremely token-sensitive use cases the trade-off might not hold, but I haven't hit that ceiling in practice.
 
 **4. Progressive Loading is Fractal**
 
@@ -450,13 +441,13 @@ For a single commit, this is negligible. But when I'm iterating rapidly (20-30 c
 
 ## Sources
 
-3. **[LazyLLM: Optimizing Language Model Performance Through Lazy Loading](https://arxiv.org/html/2407.14057v1)** (2024) - Lazy loading with minimal accuracy loss
-4. **[LongRoPE: Extending Context Windows of Large Language Models](https://arxiv.org/abs/2402.13753)** (2024) - Extended rope techniques for 1M+ token windows
+3. **[LazyLLM: Dynamic Token Pruning for Efficient Long Context LLM Inference](https://arxiv.org/html/2407.14057v1)** (2024) - Lazy loading with minimal accuracy loss
+4. **[LongRoPE: Extending LLM Context Window Beyond 2 Million Tokens](https://arxiv.org/abs/2402.13753)** (2024) - Extended rope techniques for 1M+ token windows
 6. **[ChunkKV: Efficient Chunked Key-Value Memory for Long-Context Processing](https://arxiv.org/html/2502.00299v1)** (2025) - Chunked context loading with cross-chunk attention
-8. **[From Tokens to Thoughts: Efficient Concept Representation in LLMs](https://arxiv.org/html/2505.17117)** (2025) - Representing concepts as thought graphs
+8. **[From Tokens to Thoughts: How LLMs and Humans Trade Compression for Meaning](https://arxiv.org/html/2505.17117)** (2025) - Information-bottleneck comparison of human and LLM categorisation
 9. **[Token-Efficient Reinforcement Learning for Language Models](https://arxiv.org/abs/2504.20834)** (2025) - RL techniques for token optimization
 10. **[Agentic RAG: A Survey of Retrieval-Augmented Generation in Agent Systems](https://arxiv.org/abs/2501.09136)** (2025) - Multi-layer architecture for agent design
-12. **[Sufficient Context: Predicting Required Context Length for Language Model Tasks](https://arxiv.org/abs/2411.06037)** (2024) - Automatic context size prediction
+12. **[Sufficient Context: A New Lens on Retrieval Augmented Generation Systems](https://arxiv.org/abs/2411.06037)** (2024) - Automatic context size prediction
 13. **[Anthropic Skills Announcement](https://www.anthropic.com/news/skills)** (2025) - Official Skills feature announcement
 14. **[Equipping Agents for the Real World with Agent Skills](https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills)** (2025) - Anthropic engineering blog on Skills
 15. **[Anthropic Skills GitHub Repository](https://github.com/anthropics/skills)** (2025) - Open-source Skills implementation examples


### PR DESCRIPTION
Same pattern as batch one. **Ten posts audited, ten defective.** Self-measured arithmetic holds; borrowed numbers don't.

## eBPF post — inverted CVE risk guidance

| CVE | post said | NVD says |
|---|---|---|
| CVE-2021-33624 | CVSS 7.8, arbitrary read/**write**, priv-esc | **4.7 MEDIUM**, read-only speculative side channel (`I:N`) |
| CVE-2023-2163 | CVSS 8.2, speculative / TOCTOU | **10.0 CRITICAL**, arbitrary kernel write + container escape |
| CVE-2021-31440 | CVSS 7.8, <5.11.12 | **7.0**, 5.7–5.10.36 / 5.11–5.11.20 / 5.12–5.12.3 |

The post **overstated a medium and understated a critical**, with the mechanisms swapped — in the section that tells readers which kernels to worry about.

> The reviewer reported 2163 as 8.8 HIGH. NVD says **10.0 CRITICAL**. Which is why numbers get checked rather than accepted.

Also: `lockdown=confidentiality` was recommended, which disables `bpf_probe_read*`, kprobes and kernel-data perf events — every detection the post teaches. Now `integrity`. The k8s snippet used `CAP_` prefixes Kubernetes rejects. Ring-buffer sizing described `BPF_MAP_TYPE_RINGBUF` as per-CPU (it's shared — that's the point of it), so readers were overshooting by core count. Added the caveat that tracing programs *observe*; the diagram promised "block, kill, or isolate", which needs BPF-LSM.

## Raspberry Pi post — headline numbers belong to a different paper

90.3% / 4.24x / 2.5 tok/s were the Hermes paper's, measured **against PipeSwitch on Xeon CPUs in memory-capped containers**, on BERT/ViT/GPT-J. No Pi and no LLaMA appear in that paper. Re-attributed.

The throughput claim also contradicted the post's own I/O budget by ~10x: at 120–180ms per layer across 32 layers, streaming can't exceed ~0.2 tok/s, and every token re-reads every layer. **Removed rather than replaced** — no defensible substitute exists. Author list corrected (Han, not Zhang). The 70B split assigned 72 layers to an 80-layer model. microSD speed appeared as both 25 and 250MB/s; the higher exceeds the interface.

## Context-loading post — unfair to a named vendor

The Anthropic Skills table was wrong on **three of six rows, all three flattering**. Skills are markdown `SKILL.md` files loaded by progressive disclosure — not "programmatic tools (MCP)" that "require code changes", and `skill-creator` exists so they don't. Three named skills never existed in that repo. Rewritten around the convergence, which is a stronger argument than the differences were. Four citations carried titles and claims belonging to different papers. Case-study savings recomputed: **48.1%**, not 64%.

## Transformer post

Parameter count 93M → **65M** (matching the cited paper's base config). Attention memory 4.2GB → **0.25 GiB**, which the post's own formula already gave.

Build clean, audit exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
