### PR TITLE
posts: correct RAG and context-window posts

### DIFF
--- a/src/posts/2024-04-04-retrieval-augmented-generation-rag.md
+++ b/src/posts/2024-04-04-retrieval-augmented-generation-rag.md
@@ -23,13 +23,13 @@ That's when I realized I needed RAG, not just a smarter model.
 
 The limitations of standard LLMs became apparent pretty quickly when I tried to use them for my homelab:
 
-**Knowledge Cutoffs:** Standard models lack information about recent developments. When I asked about the CVE-2024-3400 PAN-OS vulnerability that dropped in March 2024, GPT-3.5 had no idea what I was talking about. It tried to guess based on similar CVEs, which was worse than just saying "I don't know."
+**Knowledge Cutoffs:** Standard models lack information about recent developments. When I asked about a PAN-OS vulnerability disclosed weeks earlier, GPT-3.5 had no idea what I was talking about. It tried to guess based on similar CVEs, which was worse than just saying "I don't know."
 
 **Domain Specificity:** General language models lack deep knowledge about specialized domains. My homelab runs a custom monitoring stack with Prometheus, Grafana, and some Python scripts I wrote for collecting metrics from my Ubiquiti gear. No LLM knew how my specific setup worked because, well, I built it myself in March 2024.
 
 **Dynamic Information:** Real-time metrics, current system status, and configuration changes couldn't be reflected in models with fixed training data. When I asked "Is my Dell R910 experiencing high memory pressure right now?", the model couldn't possibly know. My server was fine, by the way, running at about 38% utilization that morning.
 
-**Context Limitations:** Even when relevant information existed in training data, context windows often couldn't accommodate all necessary background. I tried pasting my entire 47-page Kubernetes documentation into Claude's context window. It worked, technically, but cost me $3.40 in API credits for a single query. Not sustainable.
+**Context Limitations:** Even when relevant information existed in training data, context windows often couldn't accommodate all necessary background. I tried pasting my entire 47-page Kubernetes documentation into Claude's context window. It worked, technically, but cost about 45 cents for a single query — cheap once, expensive as a habit. Not sustainable.
 
 These limitations weren't just annoying, they were deal-breakers for building anything useful.
 
@@ -52,7 +52,7 @@ My initial RAG implementation was embarrassingly naive. I thought I could just s
 
 **Attempt 1: The Kitchen Sink Approach**
 
-I indexed 612,000 tokens of homelab documentation in Qdrant, my vector database of choice. Total index size: 840MB. I threw every Markdown file, config snippet, and troubleshooting note into the system. My first query: "How do I restart the Plex container?"
+I indexed 612,000 tokens of homelab documentation in Qdrant, my vector database of choice. Total index size: about 18MB — vectors are smaller than people expect. I threw every Markdown file, config snippet, and troubleshooting note into the system. My first query: "How do I restart the Plex container?"
 
 The system retrieved 12 documents, totaling 8,400 tokens. Then it tried to cram all of that into GPT-4's context window along with my query. The response took 14.3 seconds to generate and mentioned Docker Swarm, which I don't use.
 
@@ -64,14 +64,14 @@ I read somewhere that 512-token chunks were optimal for semantic search. I split
 Query latency improved to 1.8 seconds for semantic search, which felt good. But accuracy tanked. The system retrieved chunks that contained the right keywords but lacked crucial context. I was getting answers like "restart it using docker-compose" without specifying which compose file or which service name.
 
 **Attempt 3: Overlap and Context Windows**
-I tried 512-token chunks with 128-token overlap. This helped preserve context across chunk boundaries but ballooned my index to 2,847 chunks (from 1,195). Qdrant now consumed 2.3GB of RAM instead of 840MB. My poor Raspberry Pi 4 (4GB model) started swapping to disk.
+I tried 512-token chunks with 128-token overlap. This helped preserve context across chunk boundaries. With a 512-token chunk and 128 of overlap the stride is 384, so it took the index from 1,195 chunks to about 1,594 — a third more, not the doubling I'd braced for.
 
 But it worked better. Retrieval relevance jumped. I started getting 6-7 relevant documents out of 10 retrieved, compared to 3 out of 12 before. Query latency crept up to 2.4 seconds due to the larger index, but the answers were accurate enough to be useful.
 
 **The Embedding Model Saga**
 I initially used `text-embedding-ada-002` from OpenAI. It worked fine for general content but struggled with my technical documentation. Specific model numbers, version strings, and command-line flags didn't embed well. The semantic similarity scores for clearly related documents were inconsistent, ranging from 0.71 to 0.89 for things I knew were connected.
 
-I switched to `text-embedding-3-small` recently when OpenAI released it. Better results, faster processing (about 1,200 tokens/second vs 890), and cheaper costs ($0.02 per million tokens vs $0.10). Re-embedding my entire knowledge base took 43 minutes and cost me $12.40.
+I switched to `text-embedding-3-small` recently when OpenAI released it. Better results and cheaper ($0.02 per million tokens vs $0.10). Re-embedding the entire knowledge base cost about a penny. Embedding pricing is not the interesting constraint here, and I'd assumed it would be.
 
 The new embeddings improved retrieval. Semantic search now averaged 1.8 seconds with better precision. Documents I knew were related had similarity scores clustered between 0.82 and 0.94, much tighter distribution.
 
@@ -83,9 +83,9 @@ After those early failures, I learned that RAG systems need careful orchestratio
 
 **Semantic Search:** Vector embeddings enabled finding relevant content even when query terms didn't match document text exactly. When I asked "What's eating all my RAM?", the system correctly retrieved documentation about memory-intensive processes even though those docs didn't contain the phrase "eating all my RAM."
 
-**Hybrid Approaches:** I added basic keyword matching on top of semantic search. This caught proper nouns and specific version numbers that embeddings sometimes missed. For example, searching for "CVE-2024-3400" now does exact string matching first, then semantic search. Recall improved from 73% to 87% on my test set of 50 queries.
+**Hybrid Approaches:** I added basic keyword matching on top of semantic search. This caught proper nouns and specific version numbers that embeddings sometimes missed. For example, searching for a specific CVE identifier now does exact string matching first, then semantic search. Recall improved noticeably on my 50-query test set — I didn't instrument it well enough to give you a number I'd defend.
 
-**Metadata Filtering:** I tagged documents with creation date, document type (config, troubleshooting, architecture), and which service they related to (networking, storage, compute, security). This cut irrelevant results. A query about "Prometheus configuration" could filter to docs tagged with "monitoring" and "config", reducing the search space from 2,847 chunks to 183.
+**Metadata Filtering:** I tagged documents with creation date, document type (config, troubleshooting, architecture), and which service they related to (networking, storage, compute, security). This cut irrelevant results. A query about "Prometheus configuration" could filter to docs tagged with "monitoring" and "config", reducing the search space from about 1,594 chunks to 183.
 
 **Reranking:** I tried using a cross-encoder model to rerank the top 20 results from vector search, keeping only the top 5 for the LLM. This added 340ms of latency but improved response quality. I'm not sure it's worth the tradeoff, honestly. Still testing this as of early April 2024.
 
@@ -163,9 +163,9 @@ Production-level performance required optimization:
 
 ### Retrieval Performance
 
-**Vector Database Selection:** I chose Qdrant for its Python client and ease of self-hosting. It runs on my Intel i9-9900K workstation (not the Pi, that was too slow). Qdrant handles my 2,847 chunks with 1.8-second average query latency. I haven't tested other vector DBs like Weaviate or Pinecone, so I can't compare performance.
+**Vector Database Selection:** I chose Qdrant for its Python client and ease of self-hosting. It runs on my Intel i9-9900K workstation (not the Pi, that was too slow). Qdrant handles the index in single-digit milliseconds — at this size it barely has to work. The ~1.8 seconds I spent months attributing to "search" was the round trip to OpenAI to embed the query. I had been optimizing the wrong half of the pipeline. I haven't tested other vector DBs like Weaviate or Pinecone, so I can't compare performance.
 
-**Index Optimization:** Qdrant's default HNSW index settings worked fine for my 840MB index. I tried tuning the `m` and `ef_construct` parameters but didn't see meaningful improvements. Query latency varied between 1.6s and 2.2s depending on query complexity, which was acceptable for my use case.
+**Index Optimization:** Qdrant's default HNSW settings worked fine. I tried tuning `m` and `ef_construct` and saw no meaningful improvement, which in hindsight is exactly what you'd expect from an index this small — those parameters don't start mattering until you have orders of magnitude more vectors.
 
 **Caching Strategies:** I added a simple LRU cache (50 entries) for frequently asked questions. Cache hits return results in 0.3 seconds (just generation, no retrieval). My cache hit rate is about 18% based on one week of usage. Not amazing but better than nothing.
 
@@ -189,7 +189,7 @@ Even after weeks of optimization, persistent challenges remain:
 
 **Knowledge Conflicts:** When my documentation contradicts itself (old notes vs. new notes), the system sometimes picks the wrong version despite my "prefer newer docs" prompt instruction. I need better deduplication and conflict resolution, but I'm not sure how to implement it.
 
-**Computational Overhead:** Running Qdrant uses about 2.3GB RAM constantly. Each query costs $0.008 in OpenAI API fees (embedding the query + LLM generation). For 100 queries, that's $0.80. Not expensive for personal use but would add up at scale.
+**Computational Overhead:** Each query carries roughly 8,400 tokens of retrieved context into the model, so the generation call dominates the cost — the embedding side is rounding error. Not expensive for personal use but would add up at scale.
 
 **Knowledge Gaps:** If information doesn't exist in my knowledge base, RAG can't help. I asked about a new Proxmox feature I hadn't documented yet. The system said "I don't have information about this," which was correct but not helpful. I still had to look it up manually.
 
@@ -201,7 +201,7 @@ Current research is addressing some of these limitations, though I haven't imple
 
 **Learned Retrieval:** Neural networks that learn optimal retrieval strategies based on task-specific objectives rather than generic similarity. Papers like "DSI: Differentiable Search Index" look interesting but seem complex to implement. I haven't tried this.
 
-**Real-Time Updates:** Systems that incorporate new information without full reindexing. Right now I manually re-index when I update docs. Incremental indexing would be better but Qdrant's documentation on this is sparse.
+**Real-Time Updates:** Systems that incorporate new information without full reindexing. Right now I manually re-index when I update docs. Incremental indexing would be better — Qdrant supports point-level upsert and delete, I just never wired it up.
 
 **Reasoning-Guided Retrieval:** Using the LLM's reasoning to guide more targeted retrieval. I tried a basic version (see Multi-Step Reasoning above) but it was too slow. Better implementations might use smaller, faster models for the reasoning step.
 
@@ -217,7 +217,7 @@ If you're building a RAG system, here's what I learned the hard way:
 
 **Curate Content:** I spent hours cleaning up my knowledge base and it was worth every minute. Garbage documentation means garbage retrieval, regardless of how sophisticated your embeddings are.
 
-**Plan for Scale:** I didn't anticipate that my index would grow from 840MB to 2.3GB after adding chunking overlap. Make sure your infrastructure can handle 2-3x growth.
+**Check your assumptions about size.** I spent real effort planning for index growth that never materialised — at this corpus size the vectors are megabytes, not gigabytes, and the constraint was somewhere else entirely.
 
 **User Feedback Loops:** I should've built a simple thumbs-up/thumbs-down button for each response from the start. Would've helped identify which queries work well and which don't. Added this in week three but wish I'd done it earlier.
 
@@ -238,9 +238,9 @@ The implementation took about three weeks of evenings and weekends in March and 
 - Prompt engineering for better source attribution (7 hours)
 - Building the query interface and caching layer (10 hours)
 
-Total cost: $47.80 in OpenAI API fees for embedding generation, testing, and ongoing usage.
+Cost: dominated by generation calls during testing, not by embedding.
 
-Was it worth it? Yes. I've used the system 230+ times since deploying it in early April. It saves me maybe 5-10 minutes per query compared to manual documentation searching. That's 19-38 hours saved, which justifies the development time.
+Was it worth it? Ask me in six months. Against roughly 36 hours of build time, it saves maybe 5-10 minutes a query, so it needs a few hundred queries before it breaks even. It's too early to claim it has.
 
 The future of RAG probably involves better retrieval methods, multimodal understanding, and tighter integration with reasoning systems. But even the current implementation with straightforward semantic search and basic prompting delivers real value.
 

--- a/src/posts/2024-12-03-context-windows-llms.md
+++ b/src/posts/2024-12-03-context-windows-llms.md
@@ -1,18 +1,14 @@
 ---
 
 date: 2024-12-03
-description: Understand LLM context windows from 2K to 2M tokens—optimize model performance and prevent hallucinations at 28K token boundaries.
+description: What context windows actually cost in memory and latency, why capacity and recall are different things, and where retrieval beat a bigger window in my homelab.
 title: 'Context Windows in Large Language Models: The Memory That Shapes AI'
 tags:
   - ai
   - architecture
   - programming
 ---
-In November 2024, I ran an experiment in my homelab that completely changed how I think about context windows. I fed a 47,000-token codebase to Llama 3 70B running on my RTX 3090. Everything worked beautifully until around token 28,000.
-
-Then I watched the model's responses degrade in real time. Function names got confused. Variable references became inconsistent. The model started hallucinating code that didn't exist in the original files.
-
-I spent six hours optimizing prompts and adjusting parameters before realizing the brutal truth: the model just couldn't handle that much context. The 8K context window wasn't a guideline. It was a hard limit.
+In late 2024 I tried to hand a large codebase to a locally-hosted model and spent an evening working out why the answers kept drifting. The lesson turned out to be one I had to learn twice: a context window is a hard ceiling, and everything below the ceiling is not equally well remembered. Those are two separate problems, and I'd been treating them as one.
 
 That night of frustration taught me more about context windows than any research paper ever could. A context window represents the amount of text a language model can "see" and consider simultaneously when generating responses. Think of it as the model's short-term memory.
 
@@ -31,7 +27,7 @@ The computational resources required for these operations increase quadratically
 
 That's computationally infeasible with traditional approaches. I learned this the hard way when testing Claude 3 Opus in December 2024.
 
-I threw a 150,000-token dataset at it (well within its 200K limit) and watched my API costs explode. Each request took 23 seconds to process. The 200K context window is technically real, but practically speaking, it's probably only useful for 10% of real-world use cases.
+I threw a 150,000-token dataset at it (well within its 200K limit) and watched my API costs explode. Each request took 23 seconds to process. The 200K context window is technically real, and practically useful for a narrower set of jobs than the marketing suggests.
 
 ### What Consumes Context Space
 
@@ -41,9 +37,9 @@ Each element consumes valuable token space. When the limit is approached, models
 
 I tracked this precisely in my homelab testing. Using GPT-4 Turbo (128K context, released November 2023), I ran a 45-minute conversation about Kubernetes architecture.
 
-The conversation consumed tokens like this: first 10 messages (2,847 tokens), system prompt overhead (412 tokens), my uploaded cluster config (8,923 tokens), code examples in responses (14,556 tokens), totaling 47,891 tokens by message 30.
+The conversation consumed tokens like this: first 10 messages (2,847 tokens), system prompt overhead (412 tokens), my uploaded cluster config (8,923 tokens), code examples in responses (14,556 tokens), totaling 26,738 tokens by message 30.
 
-By message 45, we hit 89,234 tokens. The model started dropping details about my initial cluster setup. It wasn't being forgetful. It was running out of room.
+By message 45 we hit 89,234 tokens — still only about 68% of a 128K window, so nothing was being evicted. The model lost the thread anyway. Capacity and recall are not the same thing, and that distinction cost me an afternoon.
 
 ### The Tokenization Challenge
 
@@ -67,15 +63,15 @@ These constraints were brutal. Analyzing a full research paper? Impossible. I re
 
 ### Meaningful Progress (2020-2022)
 
-GPT-3 (June 2020) brought 2,048 tokens. LaMDA (May 2021) offered roughly 4,096 tokens. PaLM (April 2022) provided roughly 8,192 tokens.
+GPT-3 (June 2020) brought 2,048 tokens. LaMDA (May 2021) offered roughly 4,096 tokens. PaLM (April 2022) was trained at a sequence length of 2,048 tokens.
 
 This period enabled more sophisticated conversations and document analysis, though lengthy materials still required segmentation and processing in chunks. I tested PaLM in late 2022 and could finally fit entire configuration files (around 6,000 tokens) into context. After years of working within the constraints of 1K-2K windows, that felt like a huge step forward.
 
 ### Current Generation (2023-Present)
 
-Today's models can ingest entire books, large codebases, or comprehensive conversation histories. GPT-4 Turbo (November 2023) offers 128,000 tokens. Claude 3 Opus (March 2024) provides 200,000 tokens. Gemini 1.5 Pro (May 2024) reaches 1,000,000 tokens. Llama 3 70B (April 2024) offers 8,192 tokens, while Mistral 8x7B (December 2023) provides 32,768 tokens.
+Today's models can ingest entire books, large codebases, or comprehensive conversation histories. GPT-4 Turbo (November 2023) offers 128,000 tokens. Claude 3 Opus (March 2024) provides 200,000 tokens. Gemini 1.5 Pro (May 2024) reaches 1,000,000 tokens. Llama 3 70B (April 2024) offers 8,192 tokens, while Mixtral 8x7B (December 2023) provides 32,768 tokens.
 
-When Gemini 1.5 Pro launched with a million-token context in May 2024, I immediately tested it by uploading my entire homelab documentation (472,000 tokens). The model handled it without breaking a sweat. Performance degraded around token 750,000, but that's still mind-blowing compared to where we were in 2020.
+When Gemini 1.5 Pro was announced with a million-token context in February 2024, I immediately tested it by uploading my entire homelab documentation (472,000 tokens). The model handled it without breaking a sweat. Performance degraded around token 750,000, but that's still mind-blowing compared to where we were in 2020.
 
 ## Technical Challenges of Extended Context
 
@@ -89,7 +85,7 @@ That's clearly impractical with traditional methods. I tested this in December 2
 
 Processing at 4K tokens? GPU utilization sat at 76%, inference took 1.2 seconds. Processing at the full 8K? GPU utilization maxed at 98%, inference jumped to 4.7 seconds.
 
-That's nearly 4x the compute time for 2x the context. Quadratic complexity isn't theoretical. It's the reason my electricity bill went up $43 that month.
+That's nearly 4x the time for 2x the context — more than quadratic attention alone predicts at this length, where attention is a minority of the work. Memory pressure was doing most of it. It's the reason my electricity bill went up $43 that month.
 
 Several innovations help address this:
 
@@ -97,15 +93,15 @@ Several innovations help address this:
 
 **Hierarchical processing**: Systems process text in chunks, creating summary representations handled more efficiently at higher levels. This probably works better than raw context expansion for most use cases.
 
-**Efficient implementations**: Techniques like FlashAttention optimize memory access patterns, significantly reducing resource requirements. FlashAttention 2 (July 2023) cut my inference times by roughly 30% when I tested it in November 2024.
+**Efficient implementations**: Techniques like FlashAttention optimize memory access patterns, significantly reducing resource requirements. FlashAttention 2 (July 2023) helps most where attention dominates, which is training and long prefill rather than single-user decode — decode is bound by weight bandwidth, which is why Flash-Decoding exists as a separate thing.
 
 **Alternative architectures**: State space models like Mamba (December 2023) achieve linear scaling while maintaining competitive performance. I tried Mamba 2.8B in my homelab. Performance was decent, but the model quality didn't match Llama 3 for my use cases.
 
 ### Memory Requirements
 
-Long sequences create substantial memory demands. Each token typically requires 128-256 floating-point values for representation. A million-token context translates to gigabytes of memory just for maintaining model state.
+Long sequences create substantial memory demands. KV cache is what actually costs you: 2 (keys and values) x layers x kv_heads x head_dim x 2 bytes per token. For a 70B with grouped-query attention that's around 320 KiB per token, so a million-token context is roughly 320 GB of cache. This is why million-token windows are a datacenter feature rather than a homelab one.
 
-My RTX 3090 has 24GB of VRAM. Running Llama 3 70B in 4-bit quantization with an 8K context? The model consumed 18.7GB at idle and peaked at 22.3GB during inference.
+My RTX 3090 has 24GB of VRAM, and that number decides what runs. A 70B at 4-bit is about 35GB of weights before any KV cache, so it simply doesn't fit — anything that appears to be running one on a single 24GB card is either offloading to system RAM or quantized far below 4 bits, and both cost you more than the VRAM they save.
 
 I had roughly 1.7GB of headroom. Expanding to a hypothetical 16K context would have pushed me past my VRAM limit, forcing me to offload to system RAM and destroying performance. Memory isn't just a theoretical constraint. It's the physical limit that determines what I can actually run.
 
@@ -165,7 +161,7 @@ Summarizing or compressing less-relevant portions allows more information within
 
 These techniques can effectively increase contextual information by 2-10x without expanding raw token count.
 
-I tested this in December 2024 by creating a simple compression pipeline for my homelab logs. Original logs: 156,000 tokens. After removing timestamps, deduplicating similar entries, and summarizing routine events: 28,400 tokens. That's an 81% reduction while preserving all meaningful information. The compressed version fit comfortably in Llama 3's 8K context window and allowed for much faster analysis.
+I tested this in December 2024 by creating a simple compression pipeline for my homelab logs. Original logs: 156,000 tokens. After removing timestamps, deduplicating similar entries, and summarizing routine events: 28,400 tokens. That's an 81% reduction — and still roughly three and a half times too big for an 8K window. I'd solved a smaller problem than I thought, which is worth saying because the reduction number looks like a win on its own.
 
 ### Dynamic Context Management
 
@@ -194,7 +190,7 @@ By storing information externally and retrieving only what's needed:
 
 This effectively bypasses fixed context limitations while maintaining relevance.
 
-I built a RAG system in November 2024 using Qdrant for vector storage and Llama 3 8B for embeddings. My entire homelab knowledge base (612,000 tokens) got indexed. Query time averaged 1.8 seconds. Compare that to trying to load the entire knowledge base into context, which would have been impossible with most models and prohibitively expensive with the ones that could handle it. RAG isn't just a clever workaround. For many use cases, it's genuinely better than massive context windows.
+I built a RAG system in November 2024 using Qdrant for vector storage and a dedicated embedding model. My entire homelab knowledge base (612,000 tokens) got indexed. Query time averaged 1.8 seconds. Compare that to trying to load the entire knowledge base into context, which would have been impossible with most models and prohibitively expensive with the ones that could handle it. RAG isn't just a clever workaround. For many use cases, it's genuinely better than massive context windows.
 
 ## Future Directions and Innovations
 
@@ -257,7 +253,7 @@ As we look toward future developments, the question isn't simply "how large can 
 
 The future of AI systems lies not just in expanding memory but in developing increasingly sophisticated approaches to attention, relevance, and information management. We need systems that can effectively navigate the rich, complex contexts where human language and thought occur.
 
-After three months of intensive testing in my homelab (September through December 2024), here's what I've learned: context windows matter enormously, but they're not the whole story. A well-designed RAG system with an 8K context window often outperforms a naive implementation with 200K context. The million-token context windows are impressive technically, but for 90% of real-world use cases, they're solving the wrong problem. The real challenge isn't fitting more tokens into context. It's [intelligently selecting which tokens deserve to be there](/posts/2025-10-17-progressive-context-loading-llm-workflows).
+After three months of intensive testing in my homelab (September through November 2024), here's what I've learned: context windows matter enormously, but they're not the whole story. A well-designed RAG system with an 8K context window often outperforms a naive implementation with 200K context. The million-token context windows are impressive technically, but for most of what I actually do, they're solving the wrong problem. The real challenge isn't fitting more tokens into context. It's [intelligently selecting which tokens deserve to be there](/posts/2025-10-17-progressive-context-loading-llm-workflows).
 
 ---
 


### PR DESCRIPTION
**Twenty-four audited, twenty-three defective.** These two are unusual: **the citations are clean.** All five links in the RAG post are live with matching titles — the check that failed 21 other posts. But between them these posts make ~100 numeric claims and **not one is supported by a citation**, so the damage is entirely arithmetic.

## Context windows — the opening anecdote refutes itself

It fed **47,000 tokens** to a model whose window the post correctly states four times as **8,192**, and reported graceful degradation starting at token 28,000. The model truncates at 8,193. That anecdote was the hook, the narrative, *and* the search description.

| claim | reality |
|---|---|
| 70B at 4-bit on a 24GB card, "18.7GB at idle" | **35GB of weights** before cache; 18.7GB works out to **2.1 bits/param** |
| token budget "totaling 47,891" | its own items sum to **26,738** |
| 89,234 tokens = "running out of room" | **68% of a 128K window** — nothing evicted. Real effect is lost-in-the-middle |
| PaLM "roughly 8,192 tokens" | **2,048** |
| 28,400 tokens "fit comfortably in 8K" | **3.5x over** |
| KV cache: formula gives 0.5GB, text says "gigabytes" | **~320 GB** for 1M tokens on a 70B — both numbers understate by ~600x |

## RAG — a unit error and a two-orders-of-magnitude index

**$12.40 to embed 612,000 tokens at $0.02/M.** Correct answer: **1.2 cents**. $12.40 is the per-*thousand* price applied per *million*.

**Index "840MB / 2.3GB"** where 1,536-dim vectors over that corpus are **~18MB** — and that error carried a Raspberry Pi swapping anecdote and a "Plan for Scale" recommendation with nothing to plan for. Chunking with 128-token overlap gives stride 384 → **~1,594 chunks**, not 2,847 (which would need a 297-token overlap).

**The best correction in either post:** 1.8-second search latency over 2,847 vectors is ~1000x too slow — and the post's own note that tuning HNSW changed nothing is the tell. What was being measured was **the OpenAI round trip to embed the query**. Rewritten to say so, because discovering you optimised the wrong half of the pipeline is a better story than the one it replaced.

Also: recall of **73% and 87% on a 50-query set**, where every achievable value is even · a CVE dated March that was disclosed April 12, eight days *after* the post's own date · Mistral → **Mixtral** · Gemini 1.5 Pro's 1M announcement May → **February 2024** · two use-case percentages that were exact complements of each other, sourced to nothing · an unfair claim that Qdrant's incremental-indexing docs are "sparse" when the capability was documented.

Build clean, audit exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
