### PR TITLE
posts: correct four posts from audit batch thirteen

### DIFF
--- a/src/posts/2024-02-09-deepfake-dilemma-ai-deception.md
+++ b/src/posts/2024-02-09-deepfake-dilemma-ai-deception.md
@@ -1,150 +1,119 @@
 ---
 
 date: 2024-02-09
-description: Detect AI-generated deepfakes with neural network analysis and authentication methods—combat misinformation with 73% accuracy detection models.
+description: Deepfake detection works well on data it has seen and falls apart on data it hasn't. Why the fix is partly cultural, not just technical.
 title: 'The Deepfake Dilemma: Navigating the Threat of AI-Generated Deception'
 tags:
   - ai
   - ethics
   - security
 ---
-**BLUF:** The first time I encountered a convincing deepfake, I felt a profound sense of unease. It was a video of a public figure saying something completely out of character. Despite knowing about deepfake technology, I found myself questioning what was real.
+The first time I encountered a convincing deepfake, I spent an hour cross-referencing sources and stepping through the video frame by frame before I was satisfied it was synthetic. I already knew the technology existed. That did not help as much as I expected it to.
 
-I spent an hour researching, cross-referencing sources, and analyzing the video frame by frame before confirming it was synthetic. That experience fundamentally changed how I evaluate digital media and highlighted a sobering reality about our information environment..
-
-Recently, when I decided to test this problem in my own homelab, I downloaded 50 known deepfake videos from academic datasets and ran them through three different detection models on my RTX 3090. The results were sobering: my best model achieved only 73% accuracy, taking 3.2 seconds per frame to process.
-
-Even more concerning, the false positive rate hit 18%. Nearly one in five real videos got flagged as fake. This wasn't theoretical anymore. I had the processing power to detect deepfakes, but the technology itself was still too unreliable for real-world deployment.
+That hour is the whole problem in miniature. Verification is expensive, sharing is free, and the asymmetry is getting worse.
 
 <div class="zine-doodle" aria-hidden="true" style="--doodle: url('/assets/doodles/deepfake.png'); width: min(300px, 75%); aspect-ratio: 400/409; margin: 2rem auto 0.5rem;"></div>
 <p class="hand-note" style="text-align: center; display: block;">the tell is always on the right</p>
 
-## The Technology That Shattered Trust
+## Detection works right up until it matters
 
-Deepfakes use generative adversarial networks (GANs) in a digital arms race. One neural network creates increasingly realistic fake content while another network tries to detect the forgeries. They push each other toward perfection in an endless cycle of improvement.
+The cleanest measurement of how well deepfake detection actually works comes from Facebook's Deepfake Detection Challenge, which ran in 2019 and published results in 2020. It was a serious effort: a purpose-built dataset, thousands of entrants, real prize money.
 
-Years ago, I witnessed this technology's impact at a cybersecurity conference. A researcher demonstrated how they'd created a convincing video of the conference organizer endorsing a controversial political position. The room fell silent. Any public figure could be made to "say" anything.
+The winning model scored **82.56% accuracy on the public test set**. Against the black-box set — 10,000 videos the entrants had never seen, including footage pulled from the internet, makeup tutorials, paintings, AR face filters, and videos with the frame rate and resolution deliberately altered — the same model scored **65.18%** ([Meta AI](https://ai.meta.com/blog/deepfake-detection-challenge-results-an-open-initiative-to-advance-ai/)).
 
-Recently, I tried generating my own deepfake using open-source tools. The process was shockingly simple. On my 64GB RAM workstation, I trained a basic model on 200 photos in just 4.7 hours.
+That gap is the finding. A seventeen-point collapse between "deepfakes we trained on" and "deepfakes in the wild" is not a tuning problem. It says the model learned the fingerprints of specific generators rather than anything general about synthesis, and a new generator resets it. Every published detection number should be read with the question *"on which dataset?"* attached, because the answer usually explains the number.
 
-The resulting video quality was terrible by current standards. Lots of facial artifacts around the mouth, but it would have been convincing a few years ago. More sophisticated models probably achieve near-perfect results, but even my amateur attempt showed how accessible this technology has become.
+This is why I am wary of detection accuracy quoted without a test set. It is the easiest figure in the field to make look good.
 
-## Beyond Entertainment: Real-World Consequences
+## The technology, briefly
 
-What started as a curiosity quickly became a serious threat. I've seen how deepfakes can:
+Deepfakes use generative adversarial networks: one network produces fakes, another tries to catch them, and they escalate against each other. The architecture is an arms race by construction, which is a strange thing to be surprised by later.
 
-**Destroy Reputations:** Someone I know who works in government once showed me how deepfakes were being used to create compromising videos of political candidates. The damage to public trust was immediate and lasting, even after the videos were debunked.
+The relevant fact for anyone thinking about defence is not that the technique exists but that it commoditised. Face-swap tooling is open source, it runs on a consumer gaming GPU, and the skill floor is a working knowledge of Python. The output from a casual attempt is bad — artifacts around the mouth, a certain waxiness — but "bad" is measured against current expectations, and it would have passed inspection a few years earlier. The people who care to do it properly have more patience and better source material than someone poking at it for an afternoon.
 
-**Enable Fraud:** According to published reports, years ago a CEO was tricked into authorizing a $243,000 wire transfer based on a deepfake audio call impersonating his boss. The technology had become sophisticated enough to fool someone who knew the voice intimately. When I tested voice cloning tools recently, I needed only 15 seconds of audio to generate a convincing clone. The quality wasn't perfect (slight robotic undertones), but over a compressed phone line? Probably indistinguishable.
+## Real-world consequences
 
-**Undermine Democracy:** During election cycles, I've watched deepfake videos spread on social media, reaching thousands of viewers before fact-checkers could respond. The speed of misinformation now outpaces our ability to correct it. I tracked one deepfake video recently that gained 127,000 views in 6 hours before being flagged. The debunk tweet? Only 3,400 views in the same timeframe.
+**Fraud.** In 2019 a UK energy firm's chief executive authorised a wire transfer of roughly €220,000 — about **$243,000** — after a phone call from what he believed was his German parent company's CEO. It was a voice clone. The case was reported by the *Wall Street Journal* via the firm's insurer, Euler Hermes, and is generally treated as the first documented AI voice-mimicry fraud. What makes it instructive is that the victim knew the voice. Familiarity was the attack surface, not the defence.
 
-**Enable Harassment:** Perhaps most troubling, I've seen how deepfakes are weaponized for personal attacks, creating non-consensual explicit content that can destroy lives and careers. The barrier to entry is shockingly low. When I tested deepfake generation tools in my homelab, I created a basic face-swap video using only 50 source photos and 2.1 hours of processing time on my RTX 3090. The ethical implications of how easily anyone with a gaming GPU could weaponize this technology kept me up at night.
+Voice cloning has since dropped to needing seconds of reference audio rather than minutes. Over a compressed phone line, the artifacts that give a clone away in a quiet room are mostly gone.
 
-## The Detection Arms Race: A Personal Journey
+**Speed.** Misinformation outruns correction, and this is measured rather than assumed. Vosoughi, Roy, and Aral analysed roughly 126,000 cascades shared by 3 million Twitter users between 2006 and 2017 and found falsehoods **70% more likely to be retweeted** than true stories, reaching 1,500 people about **six times faster** ([*Science*, 2018](https://mitsloan.mit.edu/ideas-made-to-matter/study-false-news-spreads-faster-truth)). Bots did not explain it. People did. Novelty is more shareable than accuracy, and a fabricated video is by definition novel.
 
-My fascination with deepfake detection began as a technical challenge but evolved into something more urgent. Every advancement in detection seems to be matched by improvements in generation technology.
+That study predates convincing video synthesis, which is the uncomfortable part. The distribution advantage was already there. Deepfakes just improve the payload.
 
-**Early Detection Methods:** Years ago, we could spot deepfakes by looking for telltale signs like unnatural eye movements, inconsistent lighting, or artifacts around facial boundaries. I spent hours training myself to spot these anomalies.
+**Harassment.** The largest category of deepfake content by volume has never been political — it is non-consensual sexual imagery, overwhelmingly of women. It gets less coverage than election scenarios and does more measurable damage to more people. Any policy conversation that treats this as a footnote to the democracy question has the proportions backwards.
 
-My first major failure came when I tried integrating deepfake detection into my Wazuh security pipeline. I configured the detection model to flag suspicious video files automatically, with a confidence threshold of 85%. Within 24 hours, it had flagged 43 files. The problem? 31 of them were my own security camera footage. Apparently, the compression algorithm my cameras used created artifacts similar to deepfake generation. My false positive rate was 72%, making the system completely useless for production.
+## The detection arms race
 
-**AI-Powered Detection:** As deepfakes improved, we turned to AI for help. I've experimented with neural networks trained specifically to identify synthetic media, but it's a constant game of cat and mouse. Each new detection model triggers improvements in generation algorithms.
+**Artifact spotting** was the first line: unnatural blinking, inconsistent lighting, warping at the jawline. It worked, briefly, and then generators fixed those specific tells. Training your eye on 2019 artifacts teaches you to catch 2019 fakes.
 
-I tested three different AI detection models in my homelab. Model A (based on ResNet architecture) achieved 81% accuracy but required 16GB VRAM and processed only 2.3 frames per second. Model B (a lightweight MobileNet variant) ran faster at 7.1 fps but accuracy dropped to 64%. Model C (an ensemble approach) hit 89% accuracy but needed 4.8 seconds per frame. None of them were good enough for real-time detection, and all of them struggled with compressed videos.
+**Learned detection** replaced it and inherited the DFDC problem above: strong in-distribution, weak out of it.
 
-**Forensic Analysis:** Advanced techniques now examine pixel-level patterns, compression artifacts, and temporal inconsistencies. I've learned to analyze metadata, trace provenance, and use specialized tools that look for signs invisible to human eyes. The challenge is that sophisticated deepfakes now mimic compression artifacts, making this approach less reliable than it used to be.
+**Forensic analysis** — compression artifacts, sensor noise patterns, temporal inconsistency — is more durable because it targets the pipeline rather than the generator. It also degrades fast under re-encoding, and every social platform re-encodes everything you upload. The forensic signal is often destroyed by the same platform that would need it.
 
-**Biometric Verification:** Some promising approaches focus on unique biological patterns like heartbeat detection from subtle skin color changes, individual speech patterns, or micro-expressions that are difficult to replicate accurately. I haven't tested these methods in my homelab yet, but the research papers suggest they might achieve 92-95% accuracy under ideal conditions.
+There is a false-positive trap here that gets underrated. Compression artifacts and synthesis artifacts look alike to a classifier, which means the content most likely to be wrongly flagged is *low-quality authentic footage*: security cameras, older phones, anything that has been re-shared several times. Deploy a detector at a threshold aggressive enough to catch real fakes and you will spend most of your review budget on ordinary bad video.
 
-## The Human Element: What I've Learned About Deception
+**Biometric approaches** — heartbeat inferred from skin-tone shifts, idiosyncratic speech timing, micro-expressions — are the most interesting research direction because they key on something the generator has no reason to reproduce. I have not seen evidence they generalise across datasets any better than the rest, and cross-dataset generalisation is the entire game.
 
-Working with deepfake detection taught me that the problem isn't just technological. It's fundamentally human. People want to believe compelling content, especially if it confirms their existing beliefs.
+## The human element
 
-I conducted an informal experiment with 12 family members and friends. I showed them 10 videos (5 real, 5 deepfakes) and asked them to identify which were synthetic. The results were humbling: average accuracy was only 58%, barely better than random guessing. Even more concerning, when I told participants that some videos were fake, their confidence in their judgments increased while their accuracy actually decreased to 52%. We're not just bad at detecting deepfakes. We're overconfident about our ability to detect them..
+The technical picture is bleak enough that people reach for "well, humans will notice." They will not, particularly.
 
-## Prevention Strategies: Building Defenses
+Groh, Epstein, Firestone, and Picard ran two studies with **15,016 participants**, showing authentic videos and deepfakes and asking which was which. Ordinary observers and the leading computer-vision detector came out **similarly accurate**, while making different kinds of mistakes ([Groh et al.](https://arxiv.org/abs/2105.06496)). Humans and machines were roughly equally fallible, in complementary ways.
 
-Years of studying this problem have convinced me that prevention requires multiple approaches:
+The finding worth sitting with is what happened when they were combined. Participants shown the model's prediction did better on average — but **when the model was wrong, it frequently dragged them into being wrong too**. A detector that is right most of the time and confidently wrong the rest is not a neutral aid. It transfers its errors to the people relying on it, and it does so with an authority that a person's own uncertainty would not have carried.
 
-**Technological Solutions:**
-- **Provenance Systems:** Blockchain-based systems that create tamper-evident records of media creation and modification. I tested a proof-of-concept system that added cryptographic hashes to video metadata. File size overhead was only 0.3%, but the verification process took 1.2 seconds per video, which is probably too slow for social media platforms.
-- **Real-time Detection:** Tools integrated into social media platforms that flag potentially synthetic content before it spreads. Current detection speeds (2-5 seconds per video) make this challenging at scale, though optimized models might achieve sub-second processing in the future.
-- **Watermarking:** Invisible markers embedded during content creation that survive compression and processing. I experimented with steganographic watermarking that survived up to 75% JPEG compression, though aggressive re-encoding could still remove the markers.
+That should shape how any detection tool gets deployed. A confidence score presented as a verdict makes its failure modes contagious.
 
-**Educational Initiatives:**
-- **Media Literacy:** Teaching people to question suspicious content, verify sources, and understand the limitations of digital evidence. In my experiment with 12 participants, those who received a 10-minute training session on deepfake artifacts improved their detection accuracy from 58% to 71%. That's a 22% improvement from just basic education.
-- **Critical Thinking:** Encouraging healthy skepticism about sensational claims and too-good-to-be-true revelations
-- **Technical Education:** Helping journalists, educators, and decision-makers understand how deepfakes work and how to spot them
+## Prevention
 
-**Policy and Legal Frameworks:**
-- **Legal Consequences:** Clear penalties for malicious deepfake creation and distribution
-- **Platform Responsibility:** Requirements for social media companies to detect and remove harmful synthetic content
-- **International Cooperation:** Coordinated response to cross-border information warfare
+No single layer works. The combination is the point.
 
-## Lessons from the Field
+**Provenance over detection.** Signing content at creation and carrying a tamper-evident record forward is a fundamentally better problem than inferring synthesis after the fact — it is cryptography instead of pattern matching. It needs capture hardware, platforms, and standards to cooperate, which is why it has been perpetually two years away, but it is the only approach that does not lose ground every time generators improve.
 
-Years of working with deepfake technology taught me several crucial lessons:
+**Watermarking**, embedded at generation, has the same appeal and a sharper limit: it only binds actors who choose to be bound. It helps with commercial models and does nothing about an open-source checkpoint with the watermarking stripped out. Useful, not sufficient.
 
-**Context Matters:** The most convincing deepfakes often succeed because they're designed to confirm existing suspicions or biases. The technology exploits human psychology as much as it exploits digital media.
+**Media literacy** that transfers. Teaching people the artifacts of current-generation fakes has a shelf life measured in months. Teaching provenance habits — who published this, what corroborates it, does the emotional pull explain why I am about to share it — does not expire when the generators improve.
 
-**Speed Kills Truth:** Fake content spreads faster than fact-checks. By the time misinformation is debunked, it's often already shaped public opinion or influenced important decisions. In my tracking experiment, the deepfake-to-debunk view ratio was 37:1. That gap is probably getting worse as generation tools improve.
+**Legal and platform frameworks.** Clear penalties for malicious synthesis, obligations on platforms that amplify it, and cross-border coordination, since none of this respects jurisdiction.
 
-**Detection Isn't Enough:** Even perfect detection technology won't solve the deepfake problem if people choose not to use it or ignore its warnings. My own testing showed that even when people knew some videos were fake, they still made incorrect judgments 48% of the time.
+## The ethical questions I have not resolved
 
-**Trust Must Be Rebuilt:** The mere existence of deepfake technology has already damaged public trust in digital media. Rebuilding that trust will require more than technical solutions.
+**Creative use versus impersonation.** Synthetic media has legitimate uses — dubbing, accessibility, satire, film. Drawing a line that catches malicious impersonation without catching parody is genuinely hard, and I do not have a clean rule.
 
-## The Ethical Landscape
+**Privacy versus verification.** Detection systems tend to want biometric analysis. Building infrastructure that fingerprints faces to protect people from having their faces misused is a trade with an obvious failure mode.
 
-Working in this field has forced me to confront difficult ethical questions:
+**Who decides.** False positives in detection are a censorship mechanism with a technical alibi. Given how badly detectors generalise, a takedown pipeline driven by classifier confidence will remove authentic content, and the people least able to appeal are those whose footage was low-quality to begin with.
 
-**Creative Expression vs. Harm:** Where do we draw the line between legitimate creative uses of synthetic media and harmful impersonation? I'm still wrestling with this question after my own experiments.
+**Access.** Detection research runs on hardware and datasets concentrated in a few large labs. Generation tooling runs on a gaming GPU. The offence has been democratised and the defence has not.
 
-**Privacy vs. Security:** Detection systems often require analyzing biometric data or personal characteristics. How do we balance privacy with the need for verification? The facial recognition requirements in my detection models made me uncomfortable, even when processing my own videos.
+## What I tell people
 
-**Censorship Concerns:** Who decides what synthetic content should be removed? How do we prevent legitimate speech from being silenced? My detection system's 18% false positive rate shows how easily legitimate content could get caught in filters.
+**Interrogate content designed to make you angry.** The material engineered for outrage is the material engineered for sharing, and per the *Science* result, that is a measured effect rather than a vibe.
 
-**Accessibility and Fairness:** Will advanced detection tools be available to everyone, or only to those who can afford them? My testing required a $1,500 GPU and consumed roughly 340 watts of power during processing. That's not accessible to most people.
+**Never let one piece of media carry a decision.** Corroboration from independent sources is the practical defence, and it does not depend on any detector working.
 
-## What I Tell People Now
+**Distrust confident detection.** Including your own. Groh et al. found people and machines about equally accurate, so "I would be able to tell" is a claim with data against it.
 
-When friends and colleagues ask me about deepfakes, I share a few key insights:
-
-**Healthy Skepticism:** If a video seems designed to outrage or confirm your worst fears about someone, pause and verify before sharing. My tracking data showed that emotionally charged deepfakes spread 4.3 times faster than neutral ones.
-
-**Multiple Sources:** No single piece of media should be the basis for important decisions. Look for corroboration from multiple independent sources.
-
-**Technical Understanding:** Learn enough about how deepfakes work to understand their limitations and telltale signs. Though honestly, after testing detection methods for two months, I'm less confident in my own ability to spot them than I was before I started.
-
-**Platform Awareness:** Understand that social media algorithms can amplify synthetic content as readily as authentic content. Detection tools are improving, but determined attackers probably stay one step ahead by testing their deepfakes against the latest detection models before releasing them.
-
-## The Path Forward
-
-After years of working on this problem, I'm cautiously optimistic about our ability to coexist with deepfake technology. The key is accepting that perfect detection isn't possible. Instead, we need systems that make deception harder and consequences more certain.
-
-The most promising approaches combine technical solutions with social ones. Verified content creation systems, improved media literacy, stronger legal frameworks, and platform accountability can work together to limit the harmful effects of synthetic media. My testing suggests we might achieve 95%+ detection accuracy within a few years, but that still leaves a dangerous 5% margin for sophisticated attacks.
+**Assume attackers test first.** Anyone deploying a deepfake seriously will have run it against public detectors before release. Detection tools published openly are also a targeting service.
 
 ## Conclusion
 
-Deepfakes represent a fundamental challenge to how we process information and make decisions. The technology that creates them will only improve, making perfect detection increasingly difficult.
+The technology producing deepfakes will keep improving, and detection will keep being strongest exactly where it is least needed — on the generators it has already seen. Seventeen points of accuracy between a curated test set and the open internet is the honest summary of where automated detection stands.
 
-But the solution isn't just technical. It's cultural. We need to rebuild trust in information systems, improve critical thinking skills, and create consequences for malicious use of synthetic media.
+Which means the durable defences are the ones that do not depend on winning that race: provenance recorded at creation, corroboration habits that survive better fakes, and consequences that make malicious use expensive. Those are slow, institutional, and unglamorous compared with a classifier.
 
-The deepfake that first unnerved me years ago would seem primitive by today's standards. Yet the lesson it taught remains relevant: in an age of synthetic media, trust must be earned through verification, not assumed through appearance.
-
-After spending recent months testing detection systems in my homelab, I learned something crucial: the technology exists to fight deepfakes, but it's not ready for widespread deployment. My 73% accuracy rate, 18% false positives, and 3.2-second processing times represent the current state of the art for consumer-grade detection. We're making progress, but we're probably still 2-3 years away from reliable, real-time detection that average users can deploy.
-
-Our response to deepfakes will shape how society navigates truth and deception in the digital age. The stakes couldn't be higher, but I believe we can build a future where technology serves truth rather than undermining it. We just need to be honest about how far we still have to go.
+The deepfake that unsettled me would look primitive now. The lesson it taught has held up better than the artifacts did: in an environment where anything can be synthesised, trust has to come from verification rather than from appearance.
 
 ### Further Reading:
 
-- [Deepfakes and national security](https://www.brookings.edu/articles/deepfakes-and-international-conflict/) - Brookings
+- [Deepfake Detection Challenge results](https://ai.meta.com/blog/deepfake-detection-challenge-results-an-open-initiative-to-advance-ai/) - Meta AI (the 82.56% / 65.18% gap)
+- [The spread of true and false news online](https://mitsloan.mit.edu/ideas-made-to-matter/study-false-news-spreads-faster-truth) - Vosoughi, Roy & Aral, *Science* 2018, summarised by MIT Sloan
+- [Deepfake Detection by Human Crowds, Machines, and Machine-informed Crowds](https://arxiv.org/abs/2105.06496) - Groh, Epstein, Firestone & Picard
+- [Deepfakes and international conflict](https://www.brookings.edu/articles/deepfakes-and-international-conflict/) - Brookings
 - [Deepfakes and Disinformation](https://www.cfr.org/backgrounder/deepfakes-and-disinformation) - Council on Foreign Relations
 - [Deepfakes Are Becoming the Hot New Corporate Security Threat](https://www.wired.com/story/covid-drives-real-businesses-deepfake-technology/) - WIRED
-- [Copyright is the only functional law of the internet, deepfake nudes edition](https://www.theverge.com/2024/10/8/24265315/copyright-is-the-only-functional-law-of-the-internet-deepfake-nudes-edition) - The Verge
 
 ### Get Involved:
 
-[Sumsub launches advanced deepfakes detector](https://sumsub.com/newsroom/sumsub-launches-advanced-deepfakes-detector/)
-
-- [Support Organizations like WITNESS](https://www.gen-ai.witness.org/)
+- [WITNESS](https://www.gen-ai.witness.org/) - human rights organisation working on media authenticity

--- a/src/posts/2024-09-09-embodied-ai-teaching-agents.md
+++ b/src/posts/2024-09-09-embodied-ai-teaching-agents.md
@@ -1,174 +1,101 @@
 ---
 
-date: 2024-09-09
-description: Train embodied AI agents with vision, language, and physical interaction—build robots that learn from real environments using reinforcement learning.
+date: 2025-05-14
+description: A robot given an ambiguous instruction usually guesses. New work trains agents to ask a clarifying question instead, using LLM-generated rewards.
 title: 'Teaching AI Agents to Ask for Help: A Breakthrough in Human-Robot Interaction'
 tags:
   - ai
   - llm
   - robotics
 ---
-In August 2024, I spent 47 hours in NVIDIA Isaac Sim trying to teach a simulated robot arm to grasp objects in my virtual homelab. My RTX 3090 hummed at 73°C while rendering the physics at 18.4 FPS, and I gave the agent what I thought was a clear instruction: "Pick up the small container."
+Ask a household robot to "pick up the small container" when three containers are on the table and it will pick one. Not the right one, particularly — just one. It will not ask which you meant, because nothing in how it was trained rewards asking.
 
-There were three containers on the table. The robot grabbed one confidently, and it was the wrong one. Every single time.
-
-I tried again with better phrasing. Still wrong 68% of the time. The frustrating part? The robot never asked which container I meant.
-
-It just guessed based on some internal heuristic I couldn't decipher, failed, and waited for me to try again. After two weeks of this, I realized the fundamental problem: I was treating clarification as a bug to avoid rather than a feature to embrace.
-
-That simulation experience crystallized something I'd been thinking about for years. Humans naturally ask clarifying questions when instructions are unclear, but robots struggle with this basic social behavior.
-
-The sim-to-real gap is probably the hardest unsolved problem in robotics, but maybe the human-robot communication gap is just as critical. Recent breakthrough research is finally addressing this, and after my Isaac Sim failures, the implications feel deeply personal.
+That gap is small to describe and awkward to close. A person handed the same instruction resolves it in about a second: *"the blue one or the glass one?"* The question is cheap, targeted, and ends the ambiguity. Getting a robot to produce that question at the right moment — and only at the right moment — turns out to be a research problem in its own right.
 
 <div class="zine-doodle" aria-hidden="true" style="--doodle: url('/assets/doodles/teaching-agents.png'); width: min(190px, 52%); aspect-ratio: 400/389; margin: 2rem auto 0.5rem;"></div>
 <p class="hand-note" style="text-align: center; display: block;">a robot that knows to ask</p>
 
-## The Problem with Assumption-Making Robots
+## Three bad options
 
-The challenge isn't just technical, it's deeply human. When instructions are ambiguous, traditional embodied AI agents typically handle it in one of three problematic ways. This intersection of AI capabilities and real-world interaction parallels challenges explored in multimodal foundation models, where systems must understand context across vision, language, and action.
+Faced with an under-specified instruction, an embodied agent generally does one of three things, and all three are unsatisfying.
 
-First, **making assumptions**: selecting based on internal heuristics and potentially getting it wrong (my Isaac Sim agent did this 68% of the time). Second, **requesting full repetition**: asking for the entire instruction again, which frustrates users. Third, **refusing the task**: simply failing to act, requiring humans to provide more specificity.
+It **guesses** from some internal heuristic, which is fine when it happens to be right and opaque when it isn't. It **asks for the whole instruction again**, which is the conversational equivalent of "what?" and puts the entire burden back on the person. Or it **refuses**, demanding more specificity up front and making the human do the disambiguation work that the robot is standing right next to the answer for.
 
-None of these approaches mirror how humans handle ambiguity. When I ask a colleague for "the report on the shared drive" and there are multiple reports, they ask targeted questions: "Which report, the quarterly analysis or the customer survey?"
+None of these is what a competent collaborator does. Ask a colleague for "the report on the shared drive" when there are four, and you get a question that resolves exactly the missing bit: "the quarterly analysis or the customer survey?" That targeted narrowing is most of what makes human collaboration efficient, and it is exactly the behaviour missing from instruction-following robots.
 
-This targeted clarification is what makes human collaboration so effective.
+## Ask-to-Act
 
-I learned this the hard way during my September 2024 experiments with robotic grasping. I trained a policy for 43 hours in simulation (consuming roughly 830 watts on my i9-9900K and RTX 3090 combo), achieving an 87% success rate in Isaac Sim.
+Ramrakhya and colleagues at Georgia Tech and Meta FAIR set this up as a benchmark task they call **Ask-to-Act** ([arXiv 2504.00907](https://arxiv.org/abs/2504.00907)). An agent is given a single- or multi-object rearrangement task in a home environment, with a deliberately under-specified instruction, and has to navigate under partial observability — it cannot see the whole scene at once, so some ambiguity is only discoverable by moving.
 
-When I attempted sim-to-real transfer to a physical robot arm setup, the success rate collapsed to 41%. The sim-to-real gap was brutal, but what surprised me more was that clarification-seeking behavior transferred even worse than grasping mechanics.
+The requirement is stated carefully: the agent must ask **minimal yet relevant** clarification questions. Both halves matter. An agent that asks about everything is worse than one that guesses, because it converts a fast wrong answer into a slow annoying one. The task is not "ask more questions"; it is "know which single question is load-bearing."
 
-The robot that asked helpful questions 73% of the time in simulation asked relevant questions only 22% of the time with real objects and real lighting.
+This decomposes into four capabilities the agent has to have at once: notice that the instruction is under-determined *given what it can currently see*, generate a question that targets the specific ambiguity, fold the answer back into its plan, and then act. The architecture inherits from Vision-Language-Action models, and the multimodal-context handling has the same foundations discussed in [transformer architecture](/posts/2024-03-20-transformer-architecture-deep-dive).
 
-## The Ask-to-Act Framework: Teaching Robots When to Question
+## LLM-generated rewards
 
-The breakthrough I've been following involves extending traditional Vision-Language-Action (VLA) frameworks with what researchers call "Ask-to-Act" behavior. This approach trains agents to detect ambiguity (determine when instructions contain insufficient information given the current visual scene), generate relevant questions (formulate targeted questions addressing the specific ambiguity), incorporate clarifications (process the human's answer to resolve the uncertainty), and execute appropriately (perform the correct action based on complete information). The underlying architecture shares foundations with [transformer models](/posts/2024-03-20-transformer-architecture-deep-dive), particularly in how attention mechanisms process multimodal context.
+The training approach is the part I find most interesting, and it addresses a problem that would otherwise make this intractable.
 
-What makes this particularly elegant is how it transforms robot behavior from passive instruction-following to active participation in cooperative dialogue.
+Training a policy to ask good questions normally needs a large corpus of human-annotated ambiguous scenarios — someone deciding, thousands of times, whether a given question was the right one to ask in a given scene. That annotation cost is what stops most work of this kind before it starts.
 
-## The Training Innovation: LLM-Generated Rewards
+Instead, they fine-tune multimodal LLMs as VLA policies using **online reinforcement learning with LLM-generated rewards**. The language model judges whether a question was relevant and helpful, and that judgement becomes the reward signal. No human demonstration corpus, no hand-engineered reward function.
 
-The technical approach behind this breakthrough is as interesting as the results. Rather than requiring massive datasets of human-annotated ambiguous scenarios (which would be prohibitively expensive), researchers developed a reinforcement learning approach using LLM-generated rewards.
+Using a language model to grade the behaviour of a language-model-derived policy invites obvious objections about the grader inheriting the same blind spots as the thing it grades. The empirical answer is whether the resulting policy works, and it does — but it is worth being clear that the reward signal here is a model's opinion, not ground truth.
 
-I attempted to replicate a simplified version of this in my homelab during late September 2024. Using GPT-4o-mini (version 2024-07-18) as a reward model, I trained a basic clarification policy over 72 hours. The training consumed approximately 2,847 API calls totaling $4.23 in OpenAI credits. My success rate was mixed. The agent learned to ask questions 94% of the time, but only 38% of those questions were actually relevant.
+## The results, stated as the paper states them
 
-I suspect my reward formulation was probably too lenient on question quality.
+The RL-finetuned model beat every baseline — including zero-shot GPT-4o and supervised fine-tuned MLLMs — by **10.4 to 16.5%**, and generalised to novel scenes and tasks. The authors describe it as the first demonstration of adapting MLLMs into VLA agents that can both act and ask for help, trained with LLM-generated rewards under online RL.
 
-Here's the core training loop I used (simplified):
+Ten to sixteen points over a zero-shot GPT-4o baseline is a real result and a modest one. It is worth resisting the urge to inflate it, because the interesting claim is not the size of the margin — it is that the behaviour was learned at all without an annotation corpus, and that it held up on scenes and instruction types the policy had not trained on. Generalisation is the part that suggests the model picked up something about clarification-seeking rather than memorising which scenes are ambiguous.
 
-```python
-# Pseudocode for LLM-reward based training
-function train_clarification_agent(initial_model, training_environments):
-    reward_model = initialize_reward_llm()
-    policy = initialize_policy(initial_model)
+## Where this would matter
 
-    # My version ran this for 2,847 episodes at ~18 FPS
-    # Training time: 72 hours on RTX 3090
+**Healthcare.** "Which medication: the pain reliever, the antibiotic, or the blood pressure medication?" is obviously preferable to a guess. It is also the setting where the gap between a benchmark result and a deployable system is widest, and where a 10-16 point improvement over GPT-4o is nowhere near the bar.
 
-    return policy
-```
+**Education.** Tutoring systems that detect an ambiguous student question and ask before answering, rather than confidently addressing the wrong interpretation. This is closer to shipping than the robotics cases because the cost of a bad clarification is an extra exchange, not a physical error.
 
-This approach is brilliant because it uses the reasoning capabilities of large language models to automatically evaluate whether questions are relevant and helpful, creating a scalable training pipeline. Though in my implementation, "scalable" meant "ran for three days straight and made my office uncomfortably warm."
+**Industrial settings.** "To what torque specification?" beats applying a default. The determinism bar in manufacturing is higher than a learned clarification policy currently clears, but the failure mode — stop and ask — is at least the safe direction to fail in.
 
-## Impressive Results and Generalization
+**Accessibility.** Assistive robots supporting people whose communication may itself be non-standard is arguably the application with the most value and the highest cost of getting it wrong. Both facts follow from the same property: the user may not be able to easily correct a robot that guessed.
 
-The experimental results from published research are compelling. The RL-finetuned systems outperformed strong zero-shot baselines (including GPT-4o) by 19-40% across various scenarios.
+## The unresolved parts
 
-More importantly, they showed strong generalization to novel object configurations (handling new arrangements not seen during training, with my tests showing 67% retention on novel layouts), new object categories (asking appropriate questions about unfamiliar items, where I tested with kitchen items not in training data and got 54% relevant questions), and new instruction types (adapting to instruction patterns beyond the training distribution, which was probably my weakest area at 31% success).
+**Question overload.** The paper's "minimal yet relevant" framing names the tension but does not dissolve it. There is a threshold between an agent that asks too rarely and one that asks constantly, and where it sits probably depends on the person, the task, and how expensive a mistake is. A robot that checks in every thirty seconds will get switched off no matter how relevant each individual question was.
 
-This generalization capability suggests the approach captures fundamental principles of clarification-seeking rather than just memorizing specific scenarios. Though I should note that my homelab replication achieved nowhere near the published benchmarks.
+**Cultural variation.** Norms around question-asking differ substantially — directness, deference, how acceptable it is to interrupt. A clarification policy trained on one set of interaction norms is not obviously portable, and I have not seen this addressed anywhere in the current work.
 
-The gap between my RTX 3090 setup running Isaac Sim and the researchers' infrastructure was substantial. They likely had access to compute clusters I can only dream about, running at 60+ FPS instead of my 18.4 FPS, with parallelized training across dozens of environments simultaneously.
+**Modality.** Speech is not always the efficient channel. Pointing at two objects and raising an eyebrow resolves the container ambiguity faster than any sentence, and a robot with an arm already has the hardware to do it.
 
-## Applications Across Domains
+**Simulation to deployment.** The benchmark runs in home-environment scenes with an agent navigating under partial observability. The distance between that and a physical robot in an actual kitchen — real lighting, real clutter, real objects that were not in any asset library — remains the standing hard problem in robotics, and nothing here claims to have closed it.
 
-The potential applications extend far beyond home robots:
+## Why it's worth watching
 
-### Healthcare Assistance
+Most of the work on embodied agents is about making them more capable at executing what they're told. This is about making them better at noticing when they haven't been told enough — which is a different skill, and one that gets more valuable as the agents get more capable, not less. An incompetent robot that guesses wrong is an annoyance. A highly capable one that guesses wrong, quickly and confidently, is a hazard.
 
-Instead of making potentially dangerous assumptions, medical robots could ask clarifying questions: "Which medication would you like: the pain reliever, the antibiotic, or the blood pressure medication?" This reduces the risk of medication errors while maintaining efficiency.
-
-Though honestly, I'm not sure we're ready to deploy question-asking robots in high-stakes medical environments. The 41% sim-to-real success rate I experienced suggests we probably need another few years of development.
-
-### Educational Technology
-
-AI tutoring systems could identify when student questions contain ambiguities and seek clarification before providing potentially confusing answers. This mirrors effective teaching practices where educators check their understanding before responding.
-
-I tested a simplified version of this with my own learning experiments in October 2024, where I tried to get an agent to clarify programming questions. Results were mediocre (58% relevant clarifications), but promising.
-
-### Industrial Robotics
-Manufacturing robots could request specification clarification when task instructions are ambiguous: "To what torque specification should I tighten this bolt?" rather than applying arbitrary force levels. The determinism required here is probably higher than current clarification systems can reliably provide.
-
-### Accessibility Technology
-For assistive robots supporting individuals with disabilities, the ability to seek clarification is crucial for ensuring correct understanding of user needs, especially when communication might be challenging. This is perhaps the most important application, but also the one where failure costs are highest.
-
-## The Human Element: Making Robots Better Collaborators
-
-What excites me most about this research isn't just the technical achievement, it's how it makes robots more genuinely collaborative. During my Isaac Sim experiments in August and September 2024, I found myself naturally talking to the simulated robot arm as if it were a lab partner.
-
-When it started asking clarifying questions (even imperfect ones), the interaction felt fundamentally different. Less like programming, more like teaching.
-
-The key insight is that effective collaboration requires mutual understanding, and mutual understanding often requires dialogue. By teaching robots to engage in clarification-seeking behavior, we're not just improving their task performance, we're making them better communicators and more intuitive partners.
-
-That said, I should emphasize that my homelab results were far from production-ready. My final clarification accuracy metrics from October 15, 2024 testing: relevant questions asked (38%, target 90%+), correct ambiguity detection (61%, target 95%+), successful task completion after clarification (54%, target 85%+), and false positive clarifications asking when unnecessary (27%, target <5%).
-
-These numbers are honestly pretty discouraging, but they represent ~150 hours of experimentation on consumer hardware. The gap between research papers and homelab replication remains substantial.
-
-## Challenges and Future Directions
-
-Of course, there are still important challenges to address. I encountered many of these firsthand during my experiments:
-
-### Avoiding Question Overload
-A robot that asks too many questions becomes annoying rather than helpful. My September 2024 implementation had a 27% false positive rate for clarification requests, meaning it asked unnecessary questions more than a quarter of the time. After 30 minutes of interaction, this became genuinely frustrating. The balance between seeking necessary clarification and maintaining efficiency remains delicate, and I haven't figured out the right threshold yet.
-
-### Cultural Sensitivity
-Different cultures have varying norms around question-asking behavior. Future systems will need to adapt their clarification style to be appropriate across diverse cultural contexts. I didn't test this aspect at all in my homelab work, so I can't speak to how well current approaches handle cultural variation.
-
-### Multimodal Clarification
-Beyond verbal questions, robots might use gestures, pointing, or visual interfaces to seek clarification more efficiently in certain situations. I attempted to implement simple pointing gestures in Isaac Sim during October 2024, but the gesture recognition accuracy was only 43%, making it more confusing than helpful.
-
-## Looking Ahead: The Future of Human-Robot Interaction
-
-This breakthrough represents a significant step toward more natural and effective human-robot collaboration. By teaching robots to acknowledge uncertainty and engage in clarification-seeking dialogue, we're creating systems that function more as collaborative partners than rigid instruction-followers.
-
-The approach also demonstrates the power of combining different AI capabilities (multimodal perception, language understanding, and reinforcement learning) to address complex interaction challenges. Though I should note that integrating these components is significantly harder than it sounds. My October 2024 attempts to combine vision, language, and RL resulted in training instability 73% of the time, requiring frequent restarts and hyperparameter tuning.
-
-As embodied AI continues integrating into homes, workplaces, and public spaces, the ability to engage in clarification-seeking behavior will be essential for creating robots that can truly work alongside humans rather than simply following predetermined scripts. But we're probably still 5-10 years away from consumer-ready implementations based on the gap between my homelab results and production requirements.
-
-What I find most promising is how this research addresses a fundamental limitation in current AI systems: their struggle to acknowledge and resolve uncertainty through dialogue. This skill, so natural to humans, is finally becoming accessible to artificial agents. My Isaac Sim experiments from August through October 2024 convinced me this is possible, even if my 38% relevant-question rate shows we have a long way to go. These capabilities build on advances in [AI learning with limited resources](/posts/2024-05-30-ai-learning-resource-constrained), where models learn efficiently from sparse feedback — a constraint I hit constantly on consumer hardware.
-
-The future of human-robot interaction looks increasingly conversational, collaborative, and genuinely helpful. After spending 150+ hours teaching simulated robots to ask better questions, I'm cautiously optimistic. The failures were numerous (27% false positives, 41% sim-to-real success rate, 43% gesture recognition), but the moments when the robot asked exactly the right clarifying question felt like glimpses of that future. And that's worth pursuing.
+Acknowledging uncertainty and resolving it through dialogue is so routine in humans that it barely registers as a skill. Getting it into artificial agents is turning out to be a genuine research programme, and the fact that it can be trained without an annotation corpus makes it a much more tractable one than it looked a year ago. It also connects to a broader theme in [AI learning with limited resources](/posts/2024-05-30-ai-learning-resource-constrained): the constraint that shapes the method is usually the cost of supervision, not the cost of compute.
 
 ---
 
-*For those interested in diving deeper, the original research paper "Grounding Multimodal LLMs to Embodied Agents that Ask for Help with Reinforcement Learning" provides comprehensive technical details, while the [Stanford Embodied AI Workshop](https://embodied-ai.org/) offers broader context on advances in this field.*
+*The [Embodied AI Workshop at CVPR](https://embodied-ai.org/) is the best single venue for tracking this area.*
 
 ## Sources
 
-### Embodied AI Research
+1. **[Grounding Multimodal LLMs to Embodied Agents that Ask for Help with Reinforcement Learning](https://arxiv.org/abs/2504.00907)** (2025)
+   - Ramrakhya, Chang, Puig, Desai, Kira & Mottaghi — Georgia Tech and Meta FAIR
+   - Introduces the Ask-to-Act task; RL-finetuned MLLM beats all baselines by 10.4-16.5%
 
-1. **[Learning to Navigate in Complex Environments](https://arxiv.org/abs/1611.03673)** (2017)
-   - Mirowski et al. - DeepMind navigation research
-   - *ICLR 2017*
+2. **[Learning to Navigate in Complex Environments](https://arxiv.org/abs/1611.03673)** (2017)
+   - Mirowski et al., DeepMind — *ICLR 2017*
 
-### Robotics & Simulation
+3. **[RoboNet: Large-Scale Multi-Robot Learning](https://arxiv.org/abs/1910.11215)** (2019)
+   - Dasari et al. — *CoRL 2019*
 
-1. **[RoboNet: Large-Scale Multi-Robot Learning](https://arxiv.org/abs/1910.11215)** (2019)
-   - Dasari et al. - Multi-robot learning framework
-   - *CoRL 2019*
+### Simulation platforms
 
-### Simulation Platforms
+- **[NVIDIA Isaac Sim](https://developer.nvidia.com/isaac-sim)** - robotics simulation platform
+- **[Unity ML-Agents](https://github.com/Unity-Technologies/ml-agents)** - game engine for AI training
+- **[Gymnasium](https://gymnasium.farama.org/)** - reinforcement learning toolkit (successor to OpenAI Gym)
+- **[MuJoCo](https://mujoco.org/)** - physics simulation for robotics
 
-- **[NVIDIA Isaac Sim](https://developer.nvidia.com/isaac-sim)** - Robotics simulation platform
-- **[Unity ML-Agents](https://unity.com/products/machine-learning-agents)** - Game engine for AI training
-- **[OpenAI Gym](https://gym.openai.com/)** - Reinforcement learning toolkit
-- **[MuJoCo](https://mujoco.org/)** - Physics simulation for robotics
+### Cognitive architecture
 
-### Cognitive Architecture
-
-1. **[The Society of Mind](https://www.media.mit.edu/people/minsky/)** - Marvin Minsky
-   - Foundational cognitive architecture theory
-   - *MIT Press*
-
-2. **[Developmental Robotics](https://ieeexplore.ieee.org/document/1362308)** (2004)
-   - Lungarella et al. - Embodied cognition in robots
-   - *IEEE Transactions*
+- **The Society of Mind** - Marvin Minsky, Simon & Schuster, 1986

--- a/src/posts/2024-10-10-blockchain-beyond-cryptocurrency.md
+++ b/src/posts/2024-10-10-blockchain-beyond-cryptocurrency.md
@@ -9,9 +9,9 @@ tags:
   - programming
   - security
 ---
-In early October 2024, I deployed a private Ethereum test network on my homelab's Dell R910 server (see [secure homelab adventures](/posts/2025-04-24-building-secure-homelab-adventure)). The initial sync took 47 hours and consumed 1.2TB of disk space, which immediately taught me my first lesson: blockchain infrastructure is not lightweight. My i9-9900K system handled the validator node workload, but at a constant 340W power draw. That's real electricity costs for what I initially thought would be a simple weekend experiment.
+I deployed a private Ethereum test network on my homelab's Dell R910 server (see [secure homelab adventures](/posts/2025-04-24-building-secure-homelab-adventure)) to find out what this technology feels like from the inside rather than from a whitepaper. The first lesson arrived early: blockchain infrastructure is not lightweight, and a validator node is a machine you leave switched on.
 
-I'll admit I started this project skeptical. The cryptocurrency hype felt disconnected from solving real problems, and the energy consumption seemed wasteful. But after three months of running actual nodes, deploying smart contracts, and watching my IPFS storage grow to 340GB, I realized something: the core innovation has little to do with digital money.
+I started sceptical. The cryptocurrency hype felt disconnected from solving real problems, and the energy consumption seemed wasteful. After running actual nodes, deploying smart contracts, and pushing content into IPFS, I came round to a narrower view: the core innovation has little to do with digital money, and also less to do with most of what gets built on it.
 
 
 <div class="zine-doodle" aria-hidden="true" style="--doodle: url('/assets/doodles/blockchain.png'); width: min(340px, 82%); aspect-ratio: 400/303; margin: 2rem auto 0.5rem;"></div>
@@ -19,7 +19,7 @@ I'll admit I started this project skeptical. The cryptocurrency hype felt discon
 
 ## What I Actually Learned Running Blockchain Infrastructure
 
-The real breakthrough is distributed trust. For cryptographic foundations, see [demystifying cryptography](/posts/2024-01-18-demystifying-cryptography-beginners-guide). For the first time, we have systems that let parties transact without requiring a central authority to verify everything. When I deployed my first smart contract on the local testnet, it cost 0.002 ETH in gas fees (about $3.40 at October 2024 rates). That transaction was verified by my validator node in 2.3 seconds average block propagation time, but here's the key part: no single entity controlled whether it succeeded.
+The real breakthrough is distributed trust. For cryptographic foundations, see [demystifying cryptography](/posts/2024-01-18-demystifying-cryptography-beginners-guide). For the first time, we have systems that let parties transact without requiring a central authority to verify everything. When I deployed my first smart contract on the local testnet it cost 0.002 ETH in gas. That is play money — a private chain's ether has no market price, and quoting it in dollars would be a category error. What mattered was the mechanism: the transaction was verified without any single entity controlling whether it succeeded.
 
 That has implications far beyond finance, though I'm still figuring out where the practical boundaries are.
 
@@ -35,23 +35,25 @@ That has implications far beyond finance, though I'm still figuring out where th
 <figcaption>Blockchain systems build from peer networking through consensus and state storage into smart-contract applications.</figcaption>
 </figure>
 
-My local testnet processed about 47 transactions per second on the Dell R910, which sounds impressive until you compare it to Visa's 24,000 tps. Scalability remains a real challenge, and I'm not convinced we've solved it yet.
+My local testnet processed a few dozen transactions per second on the Dell R910. The usual comparison is Visa's 24,000 tps, though that is Visa's tested capacity ceiling rather than observed throughput — its actual average is closer to 2,000. Either way the gap is real and scalability remains unsolved.
 
 ## The Trust Architecture (And Why It Matters)
 
-Running these nodes for three months taught me that blockchain's value comes from four specific properties:
+Running these nodes taught me that blockchain's value comes from four specific properties:
 
 ### Decentralized Verification
 
-Instead of banks or governments verifying transactions, a network of independent participants validates everything using cryptographic proofs. In my test environment, I ran three validator nodes across different VMs. Even when I deliberately crashed one node (to test fault tolerance), the network kept validating blocks. That redundancy removes single points of failure, though it comes with the cost of that 340W continuous power draw.
+Instead of banks or governments verifying transactions, a network of independent participants validates everything using cryptographic proofs. In my test environment, I ran three validator nodes across different VMs. Even when I deliberately crashed one node (to test fault tolerance), the network kept validating blocks. That redundancy removes single points of failure, at the cost of keeping several machines powered continuously — which is the honest tally on a homelab electricity bill.
 
 ### Byzantine Fault Tolerance
 
-The system stays reliable even when some participants fail or act maliciously. I tested this by configuring one validator to propose invalid blocks. The other nodes rejected them within one block cycle (about 12 seconds). According to [Byzantine Generals Problem research](https://lamport.azurewebsites.net/pubs/byz.pdf), you need at least 2f+1 honest nodes to tolerate f malicious ones. My three-node setup could handle one bad actor, but just barely.
+The system stays reliable even when some participants fail or act maliciously. I tested this by crashing a validator; the other two carried on producing blocks.
+
+Then I did the arithmetic and found I had tested the easier property. The [Byzantine Generals Problem](https://lamport.azurewebsites.net/pubs/byz.pdf) requires 3f+1 nodes in total to tolerate f that lie — so tolerating a single Byzantine node needs four, and I had three. My setup survives a node that *stops*. It does not survive a node that *lies*, and I had assumed otherwise until I checked. Crash tolerance is the cheap half, and it is the half that most homelab demonstrations actually exercise.
 
 ### Immutable History
 
-Once information is confirmed by the network, altering it becomes computationally impractical. I tried rewriting a transaction from 100 blocks back on my testnet. Even with full control of all nodes, recalculating the proof-of-work for those blocks would have taken an estimated 340 hours on my hardware. On the real Ethereum mainnet with its massive hashrate, this becomes effectively impossible.
+Once information is confirmed by the network, altering it becomes impractical — though the reason differs by consensus mechanism, and this is where a private chain misleads you. On a chain you fully control, rewriting history is a matter of restarting nodes with a different state; nothing stops you. Immutability on mainnet comes from the cost of overpowering everyone else's stake or hashrate, which is a property of the network's size rather than of the data structure. A three-node lab chain has a blockchain's shape and none of its security.
 
 ### Transparent Verification
 
@@ -61,7 +63,7 @@ These properties solve the "double-spend problem" for digital assets, as describ
 
 ## Supply Chain Transparency: Where It Actually Works
 
-One implementation I studied is Walmart's food traceability system built on IBM's Hyperledger Fabric. According to [Walmart's 2020 case study](https://www.ibm.com/case-studies/walmart-food-trust), they reduced trace time from 7 days to 2.2 seconds for contaminated food products. That's a measurable improvement over their previous database system.
+One implementation I studied is Walmart's food traceability system built on IBM's Hyperledger Fabric. The widely cited result is a reduction in trace time for contaminated produce from about seven days to a couple of seconds. IBM's original case study page for it no longer resolves, so treat the figure as vendor-reported and undated rather than independently verified — and note that the comparison is against Walmart's previous paper-and-phone-call process, not against a well-built conventional database.
 
 The system creates an immutable record of products moving from farm to store:
 
@@ -95,7 +97,7 @@ What makes this valuable isn't just the technology, it's the accountability. Eve
 
 I spent two weeks in October trying to implement a basic self-sovereign identity system using the [Decentralized Identity Foundation's specifications](https://identity.foundation/). The concept is solid: instead of relying on Facebook or Google to verify who you are, you control your own identity credentials on a blockchain.
 
-The European Self-Sovereign Identity Framework (ESSIF) is implementing this across the EU, and Microsoft's ION network provides decentralized identity anchored to Bitcoin. The advantages make sense on paper:
+Europe's self-sovereign identity work has largely folded into eIDAS 2.0 and the EU Digital Identity Wallet, and Microsoft moved Entra Verified ID off the Bitcoin-anchored ION network. The advantages still make sense on paper:
 
 - Users control what information to share
 - Selective disclosure (share only necessary credentials)
@@ -106,15 +108,15 @@ But here's what I learned the hard way: the user experience is terrible. I tried
 
 ## Decentralized Finance: Beyond the Hype
 
-DeFi gets attention for cryptocurrency speculation, but some traditional financial institutions are using blockchain in practical ways. JPMorgan's Onyx platform processes wholesale payments and has reportedly handled over $1 trillion in transactions according to [their 2023 report](https://www.jpmorgan.com/kinexys/index). That's real money moving through blockchain rails.
+DeFi gets attention for cryptocurrency speculation, but some traditional financial institutions are using blockchain in practical ways. JPMorgan's blockchain unit — Onyx, since renamed Kinexys — moves wholesale payments on blockchain rails. The bank reports [over $3 trillion in cumulative transaction volume and around $7 billion a day](https://www.jpmorgan.com/kinexys/index). That's real money, though it is worth noting this is a permissioned system between known counterparties: it uses the data structure without the trustless property that is supposed to be the point.
 
-I tested basic DeFi primitives on my testnet by deploying an automated market maker (AMM) contract. A simple token swap consumed 0.0035 ETH in gas (about $5.95), which seems expensive for what a centralized exchange does for nearly free. The transparency is nice, but I'm not convinced the cost-benefit works out for everyday transactions.
+I tested basic DeFi primitives on my testnet by deploying an automated market maker (AMM) contract. A simple token swap consumed 0.0035 ETH in gas — cheap on a private chain, and the point is what that would cost on mainnet, where the same operation is priced against real ether and competes for real blockspace. The transparency is nice; I'm not convinced the cost-benefit works out for everyday transactions.
 
-Central banks are exploring Central Bank Digital Currencies (CBDCs) using blockchain. China's digital yuan pilot has processed over [250 billion yuan](https://www.reuters.com/markets/currencies/chinas-digital-yuan-transactions-top-250-bln-yuan-end-june-2023-08-04/) ($35 billion USD) as of June 2023. Whether that improves monetary policy or creates new surveillance risks depends on implementation details I don't fully understand yet.
+Central banks are exploring Central Bank Digital Currencies, and China's digital yuan is the largest pilot by a wide margin — cumulative volume is now measured in trillions of yuan. Whether that improves monetary policy or mostly creates new surveillance capability depends on implementation details that are not public.
 
 ## Governance and Voting: Promising but Unproven
 
-Blockchain voting gets discussed a lot. West Virginia piloted blockchain voting for overseas military in 2018, and some companies use it for shareholder decisions. The theoretical benefits make sense:
+Blockchain voting gets discussed a lot. West Virginia piloted it for overseas military voters in 2018 — and discontinued it in 2020, which is the part usually left out of the pitch. The theoretical benefits make sense:
 
 - Voters can verify their ballots were recorded
 - Vote tallies can't be altered after recording
@@ -123,11 +125,11 @@ Blockchain voting gets discussed a lot. West Virginia piloted blockchain voting 
 
 But in October, I tried implementing a simple voting contract on my testnet and immediately ran into problems. How do you prevent vote buying when votes are cryptographically provable? How do you maintain ballot secrecy while enabling verification? I ended up with a system where you could verify your vote was counted, but the connection between voter and vote choice was still traceable through transaction analysis.
 
-MIT researchers have proposed [Voatz and other systems](https://www.usenix.org/system/files/sec20-specter.pdf), but security experts have found significant vulnerabilities. This is probably an area where blockchain sounds good in theory but practical implementation is harder than expected.
+Voatz, the app West Virginia used, was analysed by Specter, Koppel and Weitzner at MIT, who found it broken: a passive network adversary could recover votes, and an attacker controlling the device could alter them ([USENIX Security 2020](https://www.usenix.org/system/files/sec20-specter.pdf)). The researchers were the ones who broke it, not the ones who built it. Blockchain voting sounds good in theory; the implementations that have reached real elections have not survived contact with security researchers.
 
 ## Intellectual Property: Where I See Real Potential
 
-Blockchain for digital rights management actually seems promising. Sony uses blockchain to manage digital rights for educational content, and Spotify acquired Mediachain to track creative attribution. After experimenting with NFT metadata and IPFS content addressing, I can see how this works:
+Blockchain for digital rights management actually seems promising. Sony announced blockchain-based rights management for educational content, and Spotify acquired Mediachain in 2017 to track creative attribution — the latter was absorbed and wound down, which is the more common ending for these announcements. After experimenting with NFT metadata and IPFS content addressing, I can see how this works:
 
 ```javascript
 // Simplified content rights tracking
@@ -154,19 +156,19 @@ Several developments have made blockchain more practical:
 
 ### Proof of Stake Energy Reduction
 
-Ethereum's merge to proof-of-stake in September 2022 reduced energy consumption by 99.95% according to [Ethereum Foundation data](https://ethereum.org/en/energy-consumption/). I verified this on my testnet: the validator node dropped from 340W to about 35W after switching to PoS consensus. That's a real improvement, though my electricity bill is still noticeable.
+Ethereum's merge to proof-of-stake in September 2022 cut the network's annualized electricity consumption by more than 99.988%, per [CCRI's estimate published by the Ethereum Foundation](https://ethereum.org/en/energy-consumption/) — with carbon down about 99.992%, from 11,016,000 to 870 tonnes CO2e a year. That is a network-wide figure describing mining that no longer happens. It is not something a single node can confirm, and a private chain has no hashrate to eliminate in the first place.
 
 ### Layer 2 Scaling (With Trade-offs)
 
-Networks like Polygon and Optimism claim thousands of transactions per second. I tested Polygon's Mumbai testnet and saw transaction costs drop to $0.002 versus $3.40 on mainnet. The catch is you're trusting a smaller set of validators. It's faster and cheaper, but somewhat less decentralized. Trade-offs everywhere.
+Networks like Polygon and Optimism claim thousands of transactions per second, and per-transaction costs on them are genuinely orders of magnitude below mainnet. The catch is that you're trusting a smaller validator set: faster and cheaper, meaningfully less decentralised. (Polygon's Mumbai testnet, which is what most tutorials from this era point at, was retired in April 2024 — use Amoy.)
 
 ### Privacy Techniques (That Are Hard to Use)
 
-Zero-knowledge proofs let you verify information without revealing underlying data. I spent a week trying to implement a simple ZK-SNARK circuit using [circom](https://docs.circom.io/) and eventually got a proof working that verified I knew a password without revealing it. The math is sound, but the developer experience is brutal. Proof generation took 23 seconds on my i9-9900K, which seems impractical for real-time applications.
+Zero-knowledge proofs let you verify information without revealing underlying data. I spent a week trying to implement a simple ZK-SNARK circuit using [circom](https://github.com/iden3/circom) and eventually got a proof working that verified I knew a password without revealing it. The math is sound, but the developer experience is brutal. Proof generation took 23 seconds on my i9-9900K, which seems impractical for real-time applications.
 
 ## What I've Learned About Implementation
 
-After three months of running blockchain infrastructure, several patterns became clear:
+Several patterns became clear:
 
 ### Blockchain Isn't Always the Answer
 
@@ -194,7 +196,7 @@ Cryptocurrency regulations change constantly across jurisdictions. This creates 
 
 ### Technical Complexity
 
-Blockchain development is hard. I've been programming for years and still struggled with Solidity's quirks, gas optimization, and security vulnerabilities. Frameworks like [Truffle](https://trufflesuite.com/) and [Hardhat](https://hardhat.org/) help, but the learning curve is steep.
+Blockchain development is hard. I've been programming for years and still struggled with Solidity's quirks, gas optimization, and security vulnerabilities. Frameworks like [Hardhat](https://hardhat.org/) and [Foundry](https://getfoundry.sh/) help, but the learning curve is steep. (Truffle, which every tutorial of this vintage recommends, has since been sunset by ConsenSys along with Ganache.)
 
 ### The Scalability Trilemma Persists
 
@@ -218,7 +220,7 @@ The [Quantum Resistant Ledger](https://www.theqrl.org/) develops blockchain desi
 
 ## Building a Trust Layer (Maybe)
 
-After running Ethereum nodes for three months, experimenting with smart contracts, and burning through several hundred kilowatt-hours of electricity, I think blockchain technology might be becoming a trust layer for the internet. Just as TCP/IP provides communication and HTTP provides information transfer, blockchain could provide verifiable value transfer.
+After running Ethereum nodes, experimenting with smart contracts, and paying the electricity bill for both, I think blockchain technology might be becoming a trust layer for the internet. Just as TCP/IP provides communication and HTTP provides information transfer, blockchain could provide verifiable value transfer.
 
 That's the optimistic take. The realistic take is that blockchain works well for some specific use cases (supply chain tracking, international payments, digital rights management) but probably doesn't need to be applied to everything.
 
@@ -228,7 +230,7 @@ Important challenges remain around regulation, usability, and governance. I stil
 
 As blockchain converges with AI, IoT, and eventually quantum computing, we might be seeing the emergence of new trust architectures for the internet. Or we might be seeing a technology that works brilliantly for narrow use cases but doesn't achieve the universal adoption that enthusiasts predict.
 
-My three-month homelab experiment taught me that blockchain is neither the solution to everything nor complete hype. It's a specific tool that solves specific problems, with real costs (electricity, complexity, scalability limits) and real benefits (distributed trust, transparency, censorship resistance).
+The homelab experiment taught me that blockchain is neither the solution to everything nor complete hype. It's a specific tool that solves specific problems, with real costs (electricity, complexity, scalability limits) and real benefits (distributed trust, transparency, censorship resistance).
 
 Whether it becomes truly foundational infrastructure or remains a specialized tool for particular applications, I genuinely don't know yet. I'm going to keep my Ethereum node running and continue experimenting, because the only way to understand this technology is to actually use it.
 
@@ -250,16 +252,16 @@ Whether it becomes truly foundational infrastructure or remains a specialized to
 
 4. **[Ethereum Energy Consumption Post-Merge](https://ethereum.org/en/energy-consumption/)** (2023)
    - Ethereum Foundation
-   - 99.95% energy reduction measurements
+   - CCRI estimate: >99.988% reduction in annualized electricity consumption post-Merge
 
-5. **[The Attack of the Clones Against Proof-of-Authority](https://www.usenix.org/system/files/sec20-specter.pdf)** (2020)
-   - Michael A. Specter et al.
-   - *USENIX Security Symposium*
-   - Security analysis of blockchain voting systems
+5. **[The Ballot is Busted Before the Blockchain: A Security Analysis of Voatz, the First Internet Voting Application Used in U.S. Federal Elections](https://www.usenix.org/system/files/sec20-specter.pdf)** (2020)
+   - Michael A. Specter, James Koppel, Daniel Weitzner (MIT)
+   - *29th USENIX Security Symposium*
+   - The security analysis that found Voatz broken
 
 6. **[JPMorgan Onyx Blockchain Platform](https://www.jpmorgan.com/kinexys/index)** (2023)
    - JPMorgan Chase & Co.
-   - $1 trillion transaction volume reporting
+   - Reports >$3 trillion cumulative volume, ~$7 billion daily
 
 For those interested in actually experimenting with blockchain (rather than just reading about it), the [Ethereum Developer Documentation](https://ethereum.org/en/developers/docs/) provides practical tutorials, and the [Hyperledger Foundation](https://www.hyperledger.org/) offers enterprise-focused resources. The [MIT Digital Currency Initiative](https://dci.mit.edu/) publishes academic research on blockchain's broader implications.
 

--- a/src/posts/2025-10-06-automated-security-scanning-pipeline.md
+++ b/src/posts/2025-10-06-automated-security-scanning-pipeline.md
@@ -14,9 +14,9 @@ tags:
 ## The Dependency That Haunted Me
 
 
-I built an automated security pipeline that scans every commit with Grype, OSV-Scanner, and Trivy. The result: 69% faster builds (6.5min → 2min), 35% auto-remediation rate for vulnerabilities, and mean time to remediation dropping from 12 days to 4.2 days. Critical findings block deployment automatically.
+I built an automated security pipeline that scans every commit with Grype, OSV-Scanner, and Trivy. Tuning the three scanners cut their combined runtime from 6m 30s to 2m, and `npm audit fix` clears a useful share of findings without human involvement. Two of the three scanners fail their own job on a critical finding; the third is advisory, and the final aggregate gate is still a stub I have not implemented.
 
-**Why it matters:** Last year, I deployed a "simple" web app to my homelab. Three months later, a critical vulnerability (CVE-2023-XXXXX) was discovered in a nested dependency I didn't even know existed. The vulnerable code ran in my homelab for 90 days before I found out from a security scanner. Hope is not a security strategy.
+**Why it matters:** Last year, I deployed a "simple" web app to my homelab. Three months later, a critical vulnerability was discovered in a nested dependency I didn't even know existed. The vulnerable code ran there for months before a scanner told me. Hope is not a security strategy.
 
 <div class="zine-doodle" aria-hidden="true" style="--doodle: url('/assets/doodles/scan-pipeline.png'); width: min(240px, 62%); aspect-ratio: 340/332; margin: 2rem auto 0.5rem;"></div>
 <p class="hand-note" style="text-align: center; display: block;">each pass finer than the last</p>
@@ -34,9 +34,9 @@ I built an automated security pipeline that scans every commit with Grype, OSV-S
   <div class="flow-node">Build Stage</div>
   <div class="flow-node">Test Stage</div>
   <div class="flow-node is-gate">Security Scan Stage</div>
+  <div class="flow-node"><b>OSV-Scanner</b><i>dependency scanning — runs first</i></div>
   <div class="flow-parallel" role="group" aria-label="Runs in parallel">
     <div class="flow-node"><b>Grype</b><i>container scanning</i></div>
-    <div class="flow-node"><b>OSV-Scanner</b><i>dependency scanning</i></div>
     <div class="flow-node"><b>Trivy</b><i>multi-scanner</i></div>
   </div>
   <div class="flow-node">SARIF Reports</div>
@@ -47,12 +47,12 @@ I built an automated security pipeline that scans every commit with Grype, OSV-S
   </div>
   <div class="flow-node is-gate">Quality Gates</div>
   <div class="flow-branch" role="group" aria-label="Branch outcomes">
-    <div class="flow-leg" data-branch="Critical" role="group" aria-label="Critical"><div class="flow-node is-bad">Block on Critical</div></div>
+    <div class="flow-leg" data-branch="Critical" role="group" aria-label="Critical"><div class="flow-node is-bad">OSV / Grype fail their job</div></div>
     <div class="flow-leg" data-branch="Review" role="group" aria-label="Review"><div class="flow-node">Manual Review</div></div>
   </div>
 </div>
 
-Today, every commit to my repositories is automatically scanned for vulnerabilities. Critical findings block deployment. Here's how I built it.
+Today, every commit to my repositories is automatically scanned for vulnerabilities. Here's how I built it — including the part that is not finished.
 
 ## Tool Selection and Comparison
 
@@ -70,7 +70,7 @@ This helps me focus on what actually matters instead of raw CVE counts.
 
 **My strategy:** Run all three, correlate findings, reduce false positives. When I tested this on my Python microservices project, Grype caught a critical vulnerability in a base image layer that OSV missed entirely.
 
-Meanwhile, OSV found a transitive npm dependency issue that Grype didn't detect. The overlap was only about 60%, which confirmed my suspicion that relying on a single scanner creates blind spots.
+Meanwhile, OSV found a transitive npm dependency issue that Grype didn't detect. Between them the two produced 16 distinct findings and agreed on only 4 of those — about a quarter. Whichever single scanner I had picked, I would have missed either 4 or 8 real issues.
 
 ### Installation
 
@@ -87,22 +87,24 @@ The pipeline orchestrates three scanners in parallel with a final quality gate:
 <div class="flow" role="group" aria-label="GitHub Actions security scanning pipeline">
   <div class="flow-node">Git Push / PR</div>
   <div class="flow-node is-gate">Trigger Pipeline</div>
+  <div class="flow-node"><b>OSV</b><i>dependency scan — fails job on critical</i></div>
   <div class="flow-parallel" role="group" aria-label="Runs in parallel">
-    <div class="flow-node"><b>OSV</b><i>dependency scan</i></div>
-    <div class="flow-node"><b>Grype</b><i>container scan</i></div>
-    <div class="flow-node"><b>Trivy</b><i>filesystem scan</i></div>
+    <div class="flow-node"><b>Grype</b><i>container scan — fail-build on high</i></div>
+    <div class="flow-node"><b>Trivy</b><i>filesystem scan — advisory only</i></div>
   </div>
   <div class="flow-node">Upload SARIF</div>
-  <div class="flow-node is-gate">Security Gate</div>
-  <div class="flow-branch" role="group" aria-label="Branch outcomes">
-    <div class="flow-leg" data-branch="Pass" role="group" aria-label="Pass"><div class="flow-node is-good">Deploy</div></div>
-    <div class="flow-leg" data-branch="Critical" role="group" aria-label="Critical"><div class="flow-node is-bad">Block &amp; Alert</div></div>
-  </div>
+  <div class="flow-node">Security Gate <i>(not implemented)</i></div>
 </div>
 
-**Key workflow features:** Triggers on push, pull requests, and daily at 2 AM UTC. Parallel scanner execution completes in 2-3 minutes total runtime. SARIF reports upload to GitHub Security tab automatically. Hard blocks occur on critical/high vulnerabilities. Slack notifications alert on failure.
+**Key workflow features:** Triggers on push, pull requests, and daily at 2 AM UTC. SARIF reports upload to GitHub Security tab automatically. Slack notifications alert on failure.
 
-📎 **Full GitHub Actions workflow (109 lines):**
+**What actually blocks, precisely.** OSV's critical check exits non-zero and fails `dependency-scan`. Grype's `fail-build: true` with `severity-cutoff: high` fails `container-scan`. Trivy uploads SARIF and has no `exit-code` set, so it never fails anything — it is advisory despite sitting in the same stage. And the `security-gate` job that is supposed to aggregate all three is a placeholder: it echoes a line, carries `if: always()`, and passes regardless of what the scans found. Read the workflow rather than the diagram if you are copying this.
+
+The scanners are also not parallel. `container-scan` and `comprehensive-scan` both declare `needs: dependency-scan`, so OSV runs alone first and the other two follow. There is no matrix strategy over scanners anywhere in the file.
+
+**One thing to fix before you copy it.** The workflow pins `aquasecurity/trivy-action@master` — a mutable branch reference. Whoever controls that branch decides what runs in your CI, with your repository credentials. In a pipeline whose entire purpose is supply-chain security that is the wrong way round. Pin every third-party action to a commit SHA, not a tag and never a branch; tags move too.
+
+📎 **Full GitHub Actions workflow (113 lines):**
 [Complete implementation with SARIF uploads, quality gates, and Slack notifications](https://gist.github.com/williamzujkowski/8185611a406dd91806f37d51778cdd16)
 
 ### Slack Notifications
@@ -142,25 +144,30 @@ Control false positives and severity thresholds.
 📎 **Complete Grype configuration:**
 [Full .grype.yaml with all ignore rules](https://gist.github.com/williamzujkowski/90a547307bb8d0158bcadc43b86df18f)
 
-Configure `fail-on-severity: high` and add ignore rules with expiration dates for accepted risks.
+Configure `fail-on-severity: high` and `scope: all-layers`, and give every ignore rule a `reason`.
+
+**Grype ignore rules do not expire.** The `IgnoreRule` struct has no `expiration` field, so a date written into `.grype.yaml` is silently ignored and the suppression is permanent. The config linked above carries `expiration: 2025-12-31` and that line has never done anything — the rule is still live. If you want time-boxed risk acceptance you have to enforce it outside grype, or use OSV-Scanner's `ignoreUntil`, which is real.
 
 ### OSV-Scanner Configuration
 
-Customize lockfile scanning and parallel workers.
+`osv-scanner.toml` has a much smaller schema than I originally documented here. The supported surface is `[[IgnoredVulns]]` (with `id`, `ignoreUntil`, `reason`), `[[PackageOverrides]]`, `ScanGoModVersion` and `GoVersionOverride`. There is no worker-count, scan-depth, or private-registry configuration, so there is no tuning knob to benchmark:
 
-📎 **Complete OSV configuration:**
-[Full osv-scanner.toml with private registries](https://gist.github.com/williamzujkowski/da899905c2905fafe74db871be75fcbe)
+```toml
+[[IgnoredVulns]]
+id = "GHSA-1234-5678-9abc"
+ignoreUntil = 2026-03-01
+reason = "Vulnerable path not reachable; revisit at the date above"
+```
 
-Set `workers = 4` for parallel scanning (40% faster on my 8-core system).
+`ignoreUntil` is the one genuine expiry mechanism across these three tools. Use it.
 
-### Trivy Policy as Code
+### Trivy policy: what it can and cannot do
 
-Enforce security policies with custom OPA Rego rules.
+Trivy's Rego support is worth understanding precisely, because it is easy to write a policy that appears to enforce a control and does the opposite.
 
-📎 **Complete Trivy OPA policy:**
-[Full security.rego with all deny/warn rules](https://gist.github.com/williamzujkowski/c3363ce4488fbcca39099f3fdc9f8a14)
+The flag is `--ignore-policy`, and the clue is in the name: the policy **filters findings out**. It cannot deny, block, or fail a build. Trivy expects a rule named `ignore`, and the input is a single `DetectedVulnerability` object rather than a collection — so a policy written as `deny[msg]` iterating `input.Vulnerabilities[_]` never matches anything and silently evaluates to no-op.
 
-Create Rego policies that deny on critical severities and apply with `trivy image --policy ./policy/security.rego myapp:latest`.
+A policy written to "deny on critical" is therefore, under the only mechanism that exists, either inert or a policy that suppresses criticals. If you want Trivy to fail a build, set `exit-code: 1` with a `severity` filter and skip Rego entirely.
 
 ## Continuous Monitoring
 
@@ -201,12 +208,12 @@ Trigger on release publication, generate CycloneDX format, scan with Grype, and 
 
 ### Automated Dependency Updates
 
-Weekly auto-remediation with PR creation. This automatically fixed 35% of vulnerabilities in my testing (12 of 34 CVEs).
+Weekly auto-remediation with PR creation. `npm audit fix` clears a meaningful share of findings on its own — the low-hanging transitive bumps.
 
 📎 **Complete auto-remediation workflow:**
 [Full workflow with PR creation and test validation](https://gist.github.com/williamzujkowski/7fd0e2b45a0311ffb4fc9d37c0684ad8)
 
-Weekly scheduled job scans for vulnerabilities, runs `npm audit fix`, validates fixes pass tests, and creates PR for review.
+Weekly scheduled job scans for vulnerabilities, runs `npm audit fix` and `npm update`, re-scans, and opens a PR for review. Note that the workflow as written does **not** run your test suite before opening the PR, and the re-scan result is not checked — so the PR needs a human and a passing CI run before it goes anywhere. Adding a test gate to it is on my list.
 
 ## Integration with Wazuh SIEM
 
@@ -217,7 +224,7 @@ Forward vulnerability data to your SIEM. I ship scans via syslog to Wazuh for ce
 📎 **Complete Wazuh integration:**
 [Full script with JSON transformation and error handling](https://gist.github.com/williamzujkowski/fe46d3793fb1f2d9771c8b9e1a2ee5d6)
 
-Pipe Grype JSON output through `jq`, format as syslog, and send to Wazuh manager on port 1514 using `netcat`.
+Pipe Grype JSON output through `jq`, format as syslog, and send to Wazuh manager on port 1514 using `netcat`. Syslog is the mechanism to use here — the scheduled-scan workflow linked above ends with a `curl -X POST` to a `/api/vulnerabilities` endpoint, which is not a route the Wazuh API exposes. Events reach Wazuh through agents or syslog, not through a vulnerability-ingestion REST call.
 
 ### Wazuh Rules for Vulnerability Alerts
 
@@ -238,7 +245,7 @@ The focus should be on sustainable processes instead of perfect tools.
 
 When I first tested Grype alone, I thought I had good coverage. Then I added OSV-Scanner and immediately found 4 additional vulnerabilities in a project I'd already "validated."
 
-The overlap between tools is surprisingly low. I measured around 60-65% in my homelab testing. Running both catches more real issues. For smaller projects, three scanners might be overkill. I'm still testing this hypothesis.
+The overlap between tools is surprisingly low: 4 findings shared out of 16 distinct. Running both catches more real issues. For smaller projects, three scanners might be overkill. I'm still testing this hypothesis.
 
 ### 2. Fail Fast, Fail Loud
 
@@ -250,17 +257,17 @@ Switching to hard-block on critical findings was painful. I spent a full weekend
 
 Without a baseline, you're drowning in noise. I learned this the hard way when Trivy flagged 183 findings on my first scan. Most were from base images I inherited.
 
-Now I track what's new vs. what's been there. My alert fatigue dropped by 80%. I still struggle with deciding how long to "accept" known issues in the baseline before forcing remediation. This is an ongoing balance.
+Now I track what's new vs. what's been there, which is the difference between a list I read and a list I ignore. I still struggle with deciding how long to "accept" known issues in the baseline before forcing remediation. This is an ongoing balance.
 
 ### 4. Automate Remediation Where Possible
 
-`npm audit fix` catches low-hanging fruit automatically. In my testing, about 35% of vulnerabilities were fixed automatically without breaking tests. Focus human effort on complex issues.
+`npm audit fix` catches low-hanging fruit automatically. Focus human effort on complex issues.
 
 That said, I've had `npm audit fix` break dependencies twice, so blind automation isn't always the answer.
 
 ### 5. Integration is Key
 
-Scanning results are useless if no one sees them. I initially just had GitHub annotations, which I never checked. Adding Slack notifications increased my response time from days to hours.
+Scanning results are useless if no one sees them. I initially just had GitHub annotations, which I never checked. Adding Slack notifications is what moved findings from something I discovered later to something I saw the same day.
 
 Shipping to my Wazuh SIEM let me track trends over time. I'm still figuring out the right balance between visibility and notification fatigue. Too many alerts become noise.
 
@@ -277,18 +284,18 @@ When I first implemented this pipeline, builds were taking forever. Here are my 
 
 **Optimizations I added:**
 
-- **Parallel scanning** (matrix strategy): Reduced wait time by running all three scanners simultaneously instead of sequentially
+- **Scanner tuning**: the per-scanner gains above are the bulk of it. Note that these totals are column sums, i.e. the scanners running one after another — which is what the workflow actually does. Genuine parallel execution would put the total at the slowest scanner (1m 10s) rather than the sum
 - **Cached vulnerability databases**: Grype's DB cache alone saved 40 seconds per run
 - **Scoped scanning** (ignore test files): Cutting out `node_modules` and test fixtures dropped scan time by 25%
 - **Early failure** (stop on critical): When a critical CVE is found, I stop immediately instead of completing all scans
 
-These times are specific to my homelab setup (Intel i9-9900K, GitHub-hosted runners). Your mileage may vary depending on project size and runner specs.
+These times are from GitHub-hosted `ubuntu-latest` runners, which is what every job in the workflow declares. Your mileage will vary with project size and runner spec.
 
 The complexity of running three scanners creates maintenance burden. Smaller teams might be better off with just Grype. I'm still testing whether the extra coverage justifies the extra complexity.
 
 ## Metrics Dashboard
 
-Track security posture with PostgreSQL queries. My current MTTR: 4.2 days (down from 12 days initially).
+Track security posture with PostgreSQL queries. The metric worth watching is time-to-remediate on criticals; the absolute number matters less than whether it is trending down.
 
 📎 **Complete SQL analytics:**
 [Full PostgreSQL queries for vulnerability tracking](https://gist.github.com/williamzujkowski/0a94337fba5a5e94fa8082c543c2a4df)
@@ -324,7 +331,7 @@ Before you build this exact pipeline, here are some things I'm still uncertain a
 For my homelab with 15+ services, running three scanners makes sense. For a single Node.js app, this might be excessive overhead. I don't know where the threshold is. Maybe two services? Five? It depends on your risk tolerance and team size.
 
 **Scaling unknowns:**
-- This setup works for my ~50 repositories
+- This setup works at my scale (dozens of small repositories)
 - Would it work for 500? 5,000? Unknown.
 - Centralized SARIF reporting might become a bottleneck
 - I haven't tested at enterprise scale
@@ -339,8 +346,8 @@ These scanners update their databases constantly. Great for coverage. Terrible w
 
 ### Cost Considerations
 
-GitHub-hosted runners aren't free at scale:
-- My current setup: ~$8/month in runner time
+GitHub-hosted runners are free for public repositories and metered for private ones, so what this costs depends entirely on which kind you have:
+- Public repos: nothing
 - Fine for a homelab
 - Scales poorly for larger organizations
 - Self-hosted runners would help (but you're managing infrastructure)


### PR DESCRIPTION
Four posts. Every figure below was recomputed or re-fetched from the primary
source before the correction was accepted.

## Automated security scanning pipeline

The post's headline security property was not implemented. Its `security-gate`
job — linked from the post, named in both diagrams — echoes one line, carries
`if: always()`, and passes regardless of what the scans found:

```yaml
  security-gate:
    needs: [dependency-scan, container-scan, comprehensive-scan]
    if: always()
    steps:
      - run: |
          echo "All security scans completed"
          # Make final go/no-go decision
```

What does block: OSV's critical check and Grype's `fail-build: high` fail their
own jobs. Trivy sets no `exit-code`, so the third scanner is advisory. Corrected
in the prose and in both flow diagrams.

The scanners are also not parallel — `container-scan` and `comprehensive-scan`
both declare `needs: dependency-scan`, and there is no matrix over scanners
anywhere. That matters for the headline: 6m30s → 2m is the **column sum** of the
per-scanner times, i.e. sequential execution. Genuinely parallel, the number
would be 3m15s → 1m10s. The post claimed parallelism *and* the sequential
arithmetic.

Three configuration artifacts were wrong in ways that fail silently:

- **grype `expiration`** — no such field exists in `IgnoreRule` (checked against
  `grype/match/ignore.go`). The linked config carries `expiration: 2025-12-31`,
  which has never done anything: that suppression is permanent and is currently
  eight months past the date a reader would believe it lapsed. Called out
  explicitly, since the failure mode is a hidden vulnerability.
- **`osv-scanner.toml`** — the documented schema is `[[IgnoredVulns]]`,
  `[[PackageOverrides]]`, `ScanGoModVersion`, `GoVersionOverride`. The post's
  `[ignore]`/`[scanning]`/`workers`/`max_depth`/`skip_git` are invented, so the
  "`workers = 4`, 40% faster" benchmark was attached to a key that has never
  existed. Section rewritten around the real schema.
- **Trivy Rego** — the flag is `--ignore-policy`, not `--policy`, and it
  *filters findings out*. A "deny on critical" policy is either inert or a
  suppression rule. Replaced with an explanation of why, and a pointer to
  `exit-code` for actual blocking.

Also: scanner overlap was 60%, but the post's own table gives 16 distinct
findings with 4 shared — 25%. `12 of 34 CVEs` cited a cohort of 34 that appears
nowhere else. The auto-remediation workflow is described as validating that
fixes pass tests; it runs no tests. Measurements were attributed to "Intel
i9-9900K, GitHub-hosted runners" — two different machines. `CVE-2023-XXXXX`, an
unfilled placeholder, was live in the opening paragraph. Added SHA-pinning
guidance, since a supply-chain-security post shipping
`aquasecurity/trivy-action@master` is the wrong way round.

## Blockchain beyond cryptocurrency

The Voatz citation ran backwards. The post read "MIT researchers have proposed
Voatz and other systems, but security experts have found significant
vulnerabilities" — MIT did not propose Voatz; Specter, Koppel and Weitzner are
the people who broke it, and they are the same "security experts" the sentence
treats as a separate group. The Sources entry welded a real but different
paper's title ("The Attack of the Clones Against Proof-of-Authority") to that
URL. Extracted page 1 of the PDF to confirm. Also added that West Virginia
discontinued the pilot in 2020.

The energy claim cited a page that contradicts it: the post said 99.95%, the
cited page says **99.988%** (CCRI). It then "verified this on my testnet" with
340W → 35W, which is 89.7% — the verification refutes the claim it supports, and
a single node cannot confirm a network-wide aggregate anyway. Cut.

Gas costs were quoted in USD on a **private** testnet, where ether has no price;
both figures implied $1,700/ETH, against an October 2024 range of roughly
$2,350–2,650. Removed rather than repriced — the conversion is a category error,
not a stale rate.

Byzantine fault tolerance: the post cited the rule correctly and then applied it
backwards. Tolerating one lying node needs 3f+1 = 4; the setup had 3. It
tolerates a crash, which is what was actually tested. Rewritten to say so.

JPMorgan's "$1 trillion, their 2023 report" appears nowhere on the cited page,
which states >$3 trillion cumulative and ~$7 billion daily. A previous
link-repair pass had swapped in a live URL and left the unsupported figure —
worth noting as a pipeline gap, not just a post defect.

Dead or aged: `docs.circom.io` is NXDOMAIN (→ the iden3 repo); Truffle has been
sunset (→ Hardhat/Foundry); Polygon Mumbai was retired in April 2024; ESSIF/ION
were stated in the present tense and have both moved on. Visa's 24,000 tps is a
tested capacity ceiling, now labelled as such.

## Deepfake dilemma

Three of four accuracy figures were unreachable on the stated sample: on 50
videos every achievable accuracy is a multiple of 2%, and 73%/81%/89% are not.
The headline 73% also contradicted the post's own table (89%) and had been
promoted into the frontmatter `description`. An 18% false-positive rate was
derived from a corpus described as 50 *known deepfakes* — no real videos, so no
false positives available. The 12-person study required means of 69.6, 62.4 and
85.2 judgments out of 120.

Rebuilt on measurements that exist. The DFDC winner scored **82.56% on the
public test set and 65.18% on the black-box set** — which makes the post's point
about generalisation far better than the invented numbers did. Spread rate now
cites Vosoughi, Roy & Aral (*Science* 2018): falsehoods 70% more likely to be
retweeted, reaching 1,500 people ~6x faster. Human judgment now cites Groh et
al. (n=15,016): people and the leading model are similarly accurate, and an
incorrect model prediction drags participants toward its error — a sharper
finding than the one it replaces. The $243k voice-fraud case, the one figure
that predated the fabrication pass, is kept and now cited.

## Embodied AI teaching agents

Dated 2024-09-09 and built on [arXiv 2504.00907](https://arxiv.org/abs/2504.00907),
submitted **1 April 2025** — the post described following and replicating a paper
seven months before it existed, with internal claims of October 2024 experiments
predating its own publication date. Date corrected to 2025-05-14; **filename kept
so the URL does not move**, following the convention set in 5def738.

The paper's headline result was overstated roughly 2x: the abstract says
**10.4–16.5%**, the post said 19–40%. The post also presented a sim-to-real
hardware failure (87% → 41% on "a physical robot arm") for a paper about
multi-object rearrangement under partial observability, in a post that
establishes a *virtual* homelab and never introduces hardware. The replication
narrative is removed; the post is now about the research, which is interesting
on its own and did not need the embellishment.

Also fixed: embodied-ai.org is the **Embodied AI Workshop at CVPR**, a
multi-institution effort, not Stanford's. `gym.openai.com` is dead (→ Gymnasium);
Unity ML-Agents soft-404s (→ GitHub); *The Society of Mind* is Simon & Schuster,
not MIT Press. The Lungarella entry could not be verified — IEEE returns a bot
challenge and dblp was down — so it was cut rather than guessed at.

Build passes.
