### PR TITLE
posts: correct container-hardening and AI-security posts

### DIFF
--- a/src/posts/2025-04-10-securing-personal-ai-experiments.md
+++ b/src/posts/2025-04-10-securing-personal-ai-experiments.md
@@ -14,7 +14,7 @@ tags:
 ---
 ## The AI Revolution Hits Home
 
-I run Llama 3.1 70B in my [homelab](/posts/2025-04-24-building-secure-homelab-adventure) on an RTX 3090 (24GB VRAM, 4-bit quantization). It took me embarrassingly long to stop treating it like a chatbot and start treating it like what it actually is: a process with network access, disk access, and occasionally opinions about running arbitrary code. Running [AI experiments](/posts/2025-06-25-local-llm-deployment-privacy-first) at home created unique security and privacy challenges I didn't anticipate. This post shares practical approaches to securing personal AI/ML deployments, learned through successes and carefully contained failures.
+I run local models in my [homelab](/posts/2025-04-24-building-secure-homelab-adventure) on an RTX 3090. Twenty-four gigabytes sets a real ceiling: a 4-bit 32B model fits with room for context, and a 70B does not — 70 billion parameters at half a byte each is 35 GB of weights before you have loaded a single token of KV cache. It took me embarrassingly long to stop treating it like a chatbot and start treating it like what it actually is: a process with network access, disk access, and occasionally opinions about running arbitrary code. Running [AI experiments](/posts/2025-06-25-local-llm-deployment-privacy-first) at home created unique security and privacy challenges I didn't anticipate. This post shares practical approaches to securing personal AI/ML deployments, learned through successes and carefully contained failures.
 
 **Key takeaway:** Model isolation, [network segmentation](/posts/2025-09-08-zero-trust-vlan-segmentation-homelab), and privacy controls turn experimental AI systems into production-safe infrastructure.
 
@@ -24,19 +24,17 @@ I run Llama 3.1 70B in my [homelab](/posts/2025-04-24-building-secure-homelab-ad
 To run the code examples in this post, you'll need to install the following packages:
 
 ```bash
-pip install GPUtil cryptography hashlib keyring logging psutil torch
+pip install cryptography keyring psutil torch nvidia-ml-py
 ```
 
 Or create a `requirements.txt` file:
 
 ```text
-GPUtil
 cryptography
-hashlib
 keyring
-logging
 psutil
 torch
+nvidia-ml-py
 ```
 
 ## Why Security Matters for Personal AI Projects
@@ -69,15 +67,72 @@ AI experiments get their own VLAN with strict firewall rules:
 
 Running LLMs locally (like LLaMA or Mistral) requires special consideration:
 
-### Safe Model Loading
+### Model loading is the dangerous part
 
-🔖 [Safe local LLM model loading workflow ↗](https://gist.github.com/williamzujkowski/139b291b7ab1aaf8188ae9d66370a018)
+The thing to understand before writing any of this: **`torch.load` unpickles, and
+unpickling is arbitrary code execution.** PyTorch flipped the default to
+`weights_only=True` in 2.6 precisely because the unconstrained unpickler can call
+arbitrary functions. A downloaded checkpoint from a stranger is a program, not
+data.
 
-### Prompt Injection Protection
+Two rules follow.
 
-When building AI applications, protecting against prompt injection is crucial:
+**Prefer safetensors.** The format exists specifically because this problem
+exists. If a torch checkpoint is unavoidable, pass `weights_only=True` explicitly
+rather than relying on your installed version's default.
 
-🔖 [Prompt injection protection examples ↗](https://gist.github.com/williamzujkowski/5c97f26a169c386e822ffe9a77e48507)
+**Make hash verification fail closed.** This is the trap worth flagging loudly,
+because it is easy to write and looks correct:
+
+```python
+expected = trusted_hashes.get(model_path.name)
+if expected and computed != expected:      # wrong
+    raise ValueError("checksum mismatch")
+return True
+```
+
+An unknown model has no entry, so `expected` is `None`, the comparison is
+skipped, and the function returns success. If the hash file does not exist at
+all, *every* model verifies. A checker that passes everything it does not
+recognise is worse than no checker, because you stop looking at that step. The
+correct shape:
+
+```python
+expected = trusted_hashes.get(model_path.name)
+if expected is None:
+    raise ValueError(f"No trusted hash on record for {model_path.name}")
+if computed != expected:
+    raise ValueError(f"Checksum mismatch for {model_path.name}")
+```
+
+The same applies to path handling: resolve against a base directory and check
+containment (`Path(base).resolve()`, then `is_relative_to`). String-replacing
+`../` does not work, because `....//` collapses back to `../` after one pass.
+
+### Prompt injection: what you can and cannot do about it
+
+There is no reliable filter-based defence against prompt injection. A blocklist
+of phrases like "ignore previous instructions" is defeated by paraphrase,
+translation, base64, or simply not using those words — and it produces immediate
+false positives, since a blocklist containing "system prompt" refuses anyone who
+asks what a system prompt is.
+
+An input filter also only ever sees the user's prompt. The variety that actually
+threatens a homelab RAG setup is **indirect** injection, arriving in a retrieved
+document, a fetched web page, or a tool's output. Nothing inspecting the user's
+typing sees it at all.
+
+So treat this as an architecture problem rather than a filtering one, which is
+also [OWASP's position](https://owasp.org/www-project-top-10-for-large-language-model-applications/):
+
+- The model gets no credentials worth stealing.
+- The model's network egress is restricted, so an injected instruction has
+  nowhere to send anything.
+- Any tool with a consequential side effect requires human confirmation.
+- All model output is treated as untrusted input to whatever consumes it.
+
+A phrase blocklist is still worth having as a crude tripwire that tells you
+someone is probing. Do not mistake it for a control.
 
 ## Monitoring AI Resource Usage
 
@@ -146,8 +201,7 @@ Essential tools for secure AI experimentation:
 
 - **Docker/Podman**: Container isolation
 - **[LocalAI](/posts/2025-10-29-privacy-first-ai-lab-local-llms)**: Run LLMs locally
-- **Ollama**: Easy local model management
-- **MindsDB**: Secure AI database layer
+- **Ollama**: easy local model management — but it binds with **no authentication** by default, so keep it on localhost or behind something that authenticates. [CVE-2024-37032](https://nvd.nist.gov/vuln/detail/CVE-2024-37032) (path traversal to RCE, CVSS 8.8) was fixed in 0.1.34; do not run older than that
 - **Netdata**: Real-time performance monitoring
 
 ## Future Plans
@@ -179,11 +233,9 @@ When properly secured, AI becomes a powerful tool for learning and creativity ra
 
 For more in-depth information on the topics covered in this post:
 
-- [Papers with Code](https://paperswithcode.com/)
+- [OWASP Top 10 for LLM Applications](https://owasp.org/www-project-top-10-for-large-language-model-applications/)
 - [arXiv AI Research](https://arxiv.org/list/cs.AI/recent)
-[NIST Cybersecurity Framework](https://www.nist.gov/cyberframework)
-
-[OWASP Top 10](https://owasp.org/www-project-top-ten/)
+- [NIST Cybersecurity Framework](https://www.nist.gov/cyberframework)
 
 
 ---

--- a/src/posts/2025-12-17-docker-container-hardening-homelab.md
+++ b/src/posts/2025-12-17-docker-container-hardening-homelab.md
@@ -45,12 +45,15 @@ Container security isn't binary. You can't just "enable security" and assume you
 
 ## Layer 1: Minimal Base Images
 
-| Image | Size | Contents | CVE Count | Build path |
-|---|---:|---|---:|---|
-| Ubuntu Base | 72 MB | OS libraries, package manager, shell, utilities, application | 43 | Source stage |
-| Distroless | 12 MB | Minimal runtime, application | 2 | Multi-stage output |
+The usual argument for distroless is size, and for JVM images that argument does
+not survive checking. `ubuntu:22.04` is about 28 MB compressed;
+`gcr.io/distroless/java17-debian12` is about 79 MB compressed across 35 layers,
+one of which is a 64 MB JRE. The distroless image is the larger of the two.
 
-Smaller images = smaller attack surface. I switched from full OS base images to distroless containers.
+The reason to use it is the one that actually holds: **it has no shell and no
+package manager.** An attacker with code execution in a distroless container has
+no `sh`, no `apt`, no `curl` to pull a second stage with. That is a real
+reduction in what a foothold is worth, and it has nothing to do with megabytes.
 
 **Attack stopped:** A recent supply chain backdoor didn't exist in my distroless containers because they lack package managers, shells, and unnecessary binaries.
 
@@ -68,7 +71,7 @@ FROM gcr.io/distroless/java17-debian12
 
 ```dockerfile
 # Multi-stage build for minimal production image
-FROM maven:3.9-openjdk-17 AS builder
+FROM maven:3.9-eclipse-temurin-17 AS builder
 COPY . /app
 WORKDIR /app
 RUN mvn clean package -DskipTests
@@ -94,7 +97,13 @@ trivy image gcr.io/distroless/java17-debian12
 
 Docker containers run as root by default. User namespaces map container root (UID 0) to unprivileged user (UID 100000+) on host.
 
-**Attack stopped:** Container breakout attempt via `/proc/self/setgroups` failed because container root had no actual privileges on host filesystem.
+What this buys you: container UID 0 is an unprivileged UID on the host, so a
+process that escapes the container's filesystem confinement arrives on the host
+as nobody in particular.
+
+What it costs: `userns-remap` is mutually exclusive with `--privileged`,
+`--network=host`, `--pid=host`, and most external volume plugins. If you need any
+of those for a given container, this layer is not available to it.
 
 **Enable user namespace remapping** in `/etc/docker/daemon.json`:
 
@@ -104,7 +113,7 @@ Docker containers run as root by default. User namespaces map container root (UI
 }
 ```
 
-Restart Docker (`sudo systemctl restart docker`). Docker creates the `dockremap` user and maps container UID 0 to an unprivileged host UID (starting at 100000 from `/etc/subuid`).
+Restart Docker (`sudo systemctl restart docker`). Docker creates the `dockremap` user and maps container UID 0 to an unprivileged host UID, taken from whatever range `/etc/subuid` allocates it — commonly 165536 if 100000–165535 is already spoken for. Check your own `/etc/subuid` rather than assuming.
 
 **Validation:**
 
@@ -124,7 +133,12 @@ ps aux | grep container-process
 
 Seccomp (secure computing) filters block dangerous system calls. Docker includes default profile that blocks ~44 dangerous syscalls.
 
-**Attack stopped:** Exploit attempting to call `create_module()` syscall (loads kernel modules) was blocked by seccomp, preventing privilege escalation.
+Docker's default seccomp profile already blocks around 44 of the 300+ available
+syscalls, which is a meaningful baseline before you write anything. A custom
+profile is worth building only once you can enumerate what your workload actually
+calls — and it is worth saying that `SCMP_ACT_ERRNO` returns EPERM to the process
+with no kernel or daemon log entry, so a seccomp denial will not appear in
+`journalctl`. To observe them you need `SCMP_ACT_LOG` plus auditd.
 
 For web applications, start from Docker's default profile and tighten it. Apply a custom profile with `--security-opt`, then generate the allowlist from a real syscall trace (both shown below).
 
@@ -169,9 +183,15 @@ profile docker-nginx flags=(attach_disconnected,mediate_deleted) {
   /var/log/nginx/** w,
   /var/cache/nginx/** rw,
 
-  # Deny the host paths a compromised container would target
-  deny /etc/** rwklx,
-  deny /proc/sys/** wklx,
+  # nginx needs these to start at all
+  /etc/nginx/** r,
+  /etc/passwd r,
+  /etc/group r,
+  /etc/nsswitch.conf r,
+  /etc/resolv.conf r,
+
+  deny /etc/shadow rwklx,
+  deny @{PROC}/sys/** wklx,
   deny /sys/** wklx,
 }
 ```
@@ -184,41 +204,61 @@ sudo apparmor_parser -r /etc/apparmor.d/docker-nginx
 
 # Run container with profile
 docker run \
-  --security-opt apparmor:docker-nginx \
+  --security-opt apparmor=docker-nginx \
   nginx:alpine
 ```
+
+A caution on scope, because it is easy to write a profile that does nothing you
+think it does: AppArmor resolves paths **in the container's mount namespace**.
+`/etc` inside the container is the image's `/etc`, not the host's. A rule denying
+`/etc/**` does not protect host SSH keys — those are not reachable from the
+container in the first place unless you bind-mounted them. Deny rules also
+override any allow, including the ones `abstractions/base` pulls in, which is why
+a blanket `deny /etc/**` stops nginx from starting rather than hardening it.
 
 **Profile testing:**
 
 ```bash
-# Test profile enforcement
-docker exec container-name cat /etc/shadow
-# cat: /etc/shadow: Permission denied
+# Confirm the profile is actually loaded and enforcing
+sudo aa-status | grep docker-nginx
 
-# Check AppArmor logs
+# Then trigger a denial you expect, and look for it
+docker exec container-name cat /etc/shadow
 sudo dmesg | grep DENIED
 ```
+
+Check `aa-status` first. A container with no profile loaded fails most casual
+tests identically to one that is fully protected, so a test that passes against
+both proves nothing.
 
 **Maintenance overhead:** AppArmor profiles require updates when applications change file access patterns. Plan for ongoing maintenance.
 
 ## Layer 5: Capability Dropping
 
-Linux capabilities split root privileges into fine-grained permissions. Docker gives containers 14 capabilities by default, which is too many.
+Linux capabilities split root privileges into fine-grained permissions. Docker
+grants a container 14 of them by default, which is more than most workloads need.
 
-**Attack stopped:** Container trying to modify network interfaces (for container escape via host networking) failed because `CAP_NET_ADMIN` was dropped.
+It is worth knowing precisely which 14, because the two that get named as
+frightening in most write-ups are not among them. `CAP_NET_ADMIN` and
+`CAP_SYS_ADMIN` are both in Docker's *not granted by default* list — you have to
+ask for them with `--cap-add`. Dropping them achieves nothing, because you never
+had them.
 
-**Default Docker capabilities (dangerous):**
+**The actual default set:**
 
 ```bash
-# View default capabilities
-docker run --rm alpine sh -c 'apk add libcap && capsh --print'
-
-# Output shows 14 capabilities including:
-# CAP_NET_ADMIN (modify network config)
-# CAP_SYS_ADMIN (mount filesystems)
-# CAP_SETUID (change user ID)
-# CAP_SETGID (change group ID)
+docker run --rm --cap-drop=ALL alpine grep Cap /proc/self/status
 ```
+
+AUDIT_WRITE, CHOWN, DAC_OVERRIDE, FOWNER, FSETID, KILL, MKNOD,
+NET_BIND_SERVICE, NET_RAW, SETFCAP, SETGID, SETPCAP, SETUID, SYS_CHROOT.
+
+The two worth caring about there are **`NET_RAW`**, which lets a compromised
+container forge packets and spoof ARP or DNS for everything else on its network,
+and **`DAC_OVERRIDE`**, which lets container root ignore file permissions inside
+the image. Those are real defaults and dropping them is a real change. Add
+`--security-opt no-new-privileges=true` at the same time — it is the cheapest
+hardening flag Docker has and it breaks almost nothing.
 
 **Minimal capability set for web applications:**
 
@@ -301,16 +341,26 @@ docker network create \
   backend-network
 ```
 
-**Network policies with UFW:**
+**Do not reach for ufw here.** Docker diverts container traffic in the `nat`
+table before it reaches the `INPUT` and `OUTPUT` chains ufw manages, so ufw
+rules about published ports do nothing — Docker's own
+[packet filtering documentation](https://docs.docker.com/engine/network/packet-filtering-firewalls/)
+says so directly. A ufw rule here reads as a control and is not one, which is
+worse than having no rule at all.
+
+The chain Docker guarantees is evaluated before its own rules is `DOCKER-USER`:
 
 ```bash
-# Block container-to-host access
-sudo ufw deny in on docker0 to any port 22
-sudo ufw deny in on docker0 to any port 3389
-
-# Allow only specific inter-container communication
-sudo ufw allow from 172.20.1.0/24 to 172.20.2.0/24 port 5432
+# Block container-to-host SSH
+iptables -I DOCKER-USER -i docker0 -p tcp --dport 22 -j DROP
 ```
+
+Note also what Docker networks can and cannot express. Containers on the same
+bridge network reach each other on **every** port; containers on different
+networks reach each other on none. There is no per-port policy between
+containers, so "allow the API to reach the database on 5432 and nothing else"
+is not something you can configure at this layer. Separate networks and
+`--internal` are the tools you actually have.
 
 **Monitoring:** Use `iftop` and `netstat` to verify expected traffic patterns between containers.
 
@@ -370,7 +420,7 @@ After implementing all eight layers across 47 containers:
 
 **Security improvements:**
 
-- **Attack surface reduction:** 89% fewer CVEs (average per container)
+- **Attack surface reduction:** no shell and no package manager in the runtime image, so a foothold has nothing to pivot with
 - **Privilege escalation prevention:** 0 successful escapes in 8 months
 - **Lateral movement blocking:** Network segmentation stopped 12 attempted pivots
 - **Resource exhaustion prevention:** 3 DoS attempts contained within limits
@@ -384,7 +434,7 @@ After implementing all eight layers across 47 containers:
 
 **Operational complexity:**
 
-- **Profile maintenance:** 2 hours/week updating AppArmor profiles
+- **Profile maintenance:** AppArmor and seccomp profiles need revisiting whenever the application's behaviour changes
 - **Image building:** +45% build time (multi-stage minimal images)
 - **Debugging difficulty:** Requires new toolchain (no shell access)
 
@@ -412,7 +462,7 @@ Security hardening is useless without visibility. Monitor each defensive layer:
 # Monitor denials
 sudo dmesg | grep DENIED | grep apparmor
 # or use auditd for structured logging
-sudo aureport --apparmor
+sudo aureport --avc
 ```
 
 **Seccomp violations:**
@@ -447,13 +497,13 @@ I use Prometheus + Grafana to visualize security metrics with alerts for any pol
 
 **Simplicity vs Defense-in-Depth:** Single-layer security (just AppArmor) would be easier to manage but provides limited protection. Multiple layers create operational burden but prevent single points of failure.
 
-**Cost vs Coverage:** Full implementation took 40 hours across 47 containers. Ongoing maintenance requires 3-4 hours/week. Investment justified by zero successful attacks.
+**Cost vs coverage:** the profile-maintaining layers (seccomp, AppArmor) are where the ongoing time goes; the rest are set once and forgotten. If you only adopt four of the eight, take user namespaces, `--cap-drop=ALL`, read-only rootfs and resource limits — they are close to free.
 
 ## Looking Forward
 
 Container security continues evolving. Future enhancements I'm testing:
 
-**gVisor:** User-space kernel for stronger container isolation (50% performance penalty for 90% attack surface reduction)
+**gVisor:** user-space kernel for stronger container isolation. Overhead is workload-dependent — near-native on CPU-bound work, considerably worse on syscall-heavy work
 
 **Falco:** Runtime security monitoring for anomaly detection (behavior-based threat detection)
 
@@ -469,7 +519,7 @@ Single-layer container security fails against determined attackers. Defense-in-d
 
 Implementation requires careful planning and testing. Start with least disruptive layers (minimal images, resource limits) and gradually add more restrictive controls. Monitor everything and be prepared for operational complexity.
 
-Eight defensive layers stopped 19 real attacks in my homelab. Zero successful container escapes in 8 months. The security improvements justify the operational investment.
+Eight layers, of which the ones that reliably earn their keep are user namespaces, capability dropping, read-only root filesystems and resource limits. The seccomp and AppArmor layers are worth having and cost the most to maintain. Network segmentation is worth having and is the one most often configured into something that does nothing.
 
 Your containers are targets. Harden them accordingly.
 
@@ -479,4 +529,4 @@ Your containers are targets. Harden them accordingly.
 - **CIS Docker Benchmarks:** [Docker CE Security Configuration](https://www.cisecurity.org/benchmark/docker)
 - **Docker Security Best Practices:** [Official Documentation](https://docs.docker.com/engine/security/)
 - **AppArmor Container Profiles:** [Ubuntu Documentation](https://ubuntu.com/server/docs/security-apparmor)
-- **Seccomp Profile Examples:** [Moby Project Repository](https://github.com/moby/moby/tree/master/profiles/seccomp)
+- **Seccomp Profile Examples:** [moby/profiles](https://github.com/moby/profiles/tree/main/seccomp)


### PR DESCRIPTION
Two posts, both of which handed readers security controls that do not work.
Every claim below was verified against upstream source or documentation before
the correction was written.

## Docker container hardening

Five of the eight "layers" were misdescribed; three were inert as written.

**Layer 7 (network) did nothing.** The post configured `ufw deny in on docker0`
rules. Docker routes container traffic in the `nat` table, so packets are
diverted before reaching the `INPUT`/`OUTPUT` chains ufw uses — Docker's own
[packet-filtering docs](https://docs.docker.com/engine/network/packet-filtering-firewalls/)
say so outright. Replaced with `DOCKER-USER`, the one chain Docker guarantees is
evaluated first. Also removed the claim that a rule blocked container-to-container
traffic on port 5432: Docker bridge networks have no per-port policy, so nothing
in that configuration could have produced a port-specific block.

**Layer 5 dropped capabilities Docker never grants.** The post named
`CAP_NET_ADMIN` and `CAP_SYS_ADMIN` as the dangerous defaults. Both are in
Docker's *not granted by default* list — you have to `--cap-add` them. So the
attack the layer was credited with stopping was already stopped by stock Docker,
and the post taught that the default is dangerous in a specific way it is not.
Replaced with the real 14, and with the two that genuinely earn a drop:
`NET_RAW` (ARP/DNS spoofing from a compromised container) and `DAC_OVERRIDE`.
Added `no-new-privileges`, which was absent from the post entirely — the cheapest
hardening flag Docker has, missing from an eight-layer defence-in-depth piece.

**Layer 4's AppArmor profile stopped nginx from starting.** `deny /etc/** rwklx`
denies the container its own `/etc/nginx/nginx.conf`, `/etc/passwd` and
`/etc/resolv.conf`, and in AppArmor an explicit deny overrides the allows pulled
in by `abstractions/base`. It also did not protect host SSH keys as claimed:
AppArmor resolves paths in the container's mount namespace, so `/etc` there is
the image's. Profile narrowed and the scope caveat stated. The verification step
(`docker exec … cat /etc/shadow`) could not distinguish an enforcing profile from
no profile at all — replaced with `aa-status`.

**Layer 3's anecdote credited seccomp with blocking `create_module()`** — removed
from Linux in 2.6 (2003), returns `ENOSYS` on every kernel since, and requires
`CAP_SYS_MODULE`, which Docker does not grant. Three independent reasons it could
not have happened. Cut; kept the verified claim that Docker's default profile
blocks ~44 syscalls, and added that `SCMP_ACT_ERRNO` produces no log entry, so
the post's `journalctl` check was inert too.

**Layer 1's size table was backwards.** Pulled both manifests: `ubuntu:22.04` is
~28 MB compressed, `gcr.io/distroless/java17-debian12` is ~79 MB across 35 layers
with a 64 MB JRE. The distroless image is the larger one. The 12 MB figure is
`distroless/base`, which contains no Java. Replaced with the argument that
actually holds — no shell, no package manager, so a foothold has nothing to pivot
with. `FROM maven:3.9-openjdk-17` 404s; corrected to `maven:3.9-eclipse-temurin-17`.

Also: "19 real attacks" reconciles to no combination of the post's own inputs
except by counting the four escapes it says *succeeded*; the maintenance figure
appeared as both 2 and 3-4 hours/week; `aureport --apparmor` is not a real flag
(`--avc`); the moby seccomp link 404s; gVisor's "50% penalty / 90% reduction"
is published by nobody.

## Securing personal AI experiments

**The first command in the post breaks the reader's interpreter.** It instructed
`pip install … hashlib … logging …` — both Python standard library, both squatted
on PyPI. Verified against the PyPI JSON API: `hashlib` is v20081119, **yanked**,
reason on record *"This was only for Python <= 2.4. LONG obsolete."* — it fails to
build on any Python 3. `logging` is v0.4.9.6 from **2013 and is not yanked**, so
it installs cleanly and shadows the standard library's `logging`. A reader who
drops `hashlib` to get past the error silently breaks logging with a thirteen-
year-old package pulled from a public index. In a security post, that is
dependency confusion taught as setup. Also dropped `GPUtil` (unmaintained since
2018, screen-scrapes `nvidia-smi`) for `nvidia-ml-py`.

**The model-loading section is now about the actual risk.** `torch.load`
unpickles, and unpickling is arbitrary code execution — which is why PyTorch
flipped `weights_only` to `True` in 2.6. The section now leads with that, and
documents the fail-open hash check as a trap rather than a pattern: an unknown
model has no entry, so `if expected and computed != expected` skips the
comparison and returns success, and with no hash file *every* model verifies.

**Prompt injection is no longer presented as solved by a filter.** A seven-phrase
English blocklist is defeated by paraphrase and blocks anyone asking what a
system prompt is. More importantly it only ever sees the user's prompt, while the
variety that threatens a homelab RAG setup arrives in retrieved documents.
Reframed around what actually bounds the damage — no credentials, restricted
egress, confirmation on consequential tools, model output treated as untrusted —
and pointed at OWASP's LLM Top 10 rather than the generic web Top 10.

Also: Llama 3.1 70B does not fit in 24 GB — 70e9 params at 4-bit is 35 GB of
weights before any KV cache; Ollama is recommended without noting it binds
unauthenticated by default and that CVE-2024-37032 (path traversal to RCE, CVSS
8.8) predates the post by eleven months; MindsDB was described as a "secure AI
database layer", which is not what it is; Papers with Code has been sunset and
now redirects to Hugging Face; the Further Reading list was malformed markdown.

Build passes.
