### PR TITLE
posts: correct scanner-automation and secure-code posts

### DIFF
--- a/src/posts/2024-01-08-writing-secure-code-developers-guide.md
+++ b/src/posts/2024-01-08-writing-secure-code-developers-guide.md
@@ -20,7 +20,7 @@ That experience early in my career taught me how easy it is for injection flaws 
 
 Vulnerable software doesn't just risk data loss. It undermines user trust, triggers potential legal trouble, and can bring entire services to a standstill. I've seen companies lose customers overnight when a breach makes headlines. We owe it to our users and ourselves to treat security as part of the craft, not an afterthought.
 
-In December 2023, I set up Semgrep in my homelab CI/CD pipeline to scan 12 personal projects totaling approximately 48,000 lines of code. The first scan found 147 potential security issues. After filtering false positives (which took roughly 3 hours), 23 were real vulnerabilities, mostly SQL injection risks and hardcoded secrets. That's a 15.6% true positive rate, though I'm not sure if that's typical or if I'm just particularly bad at security. Static analysis performance was impressive: Semgrep scanned all 48K LOC in just 3.2 seconds, making it practical to run on every commit.
+In December 2023, I set up Semgrep in my homelab CI/CD pipeline across a dozen personal projects. The first scan produced 147 findings. Working through them took the best part of an afternoon and left 23 real vulnerabilities, mostly SQL injection risks and hardcoded secrets — an 84% false-positive rate on a default ruleset. That ratio is the thing to plan around: static analysis is worth running, and most of what it hands you is not a bug.
 
 Organizations that treat security as "someone else's problem" inevitably face hard lessons. I learned this with my own homelab. I thought my internal monitoring API was safe because "it's just for me." A friend tested it as a favor and achieved remote code execution in under 5 minutes using a simple payload in the URL parameter. I spent the next 6 hours hardening all input validation, but the damage to my confidence was immediate.
 
@@ -30,7 +30,7 @@ Only give your code the permissions it truly needs. A function that merely reads
 
 The **trade-off** between development speed and security discipline is constant. During a penetration test of one of my personal projects, the tester showed me how they could have used that over-privileged service to dump the entire user table. That extra permission I thought was "just easier" had created a critical vulnerability that sat unnoticed for months. It was a valuable lesson in why least-privilege matters even in projects you think nobody else will touch.
 
-When I applied least privilege to my homelab services in March 2024, I created 7 separate service accounts, each with minimal permissions. My monitoring service went from having GRANT ALL privileges to SELECT-only on 3 specific tables. Restricting permissions required 2 hours of work to refactor database access patterns, **but** it reduced my attack surface by roughly 85% (measured by accessible database objects: 127 objects down to 19).
+When I applied least privilege to my homelab services, I created separate service accounts with minimal permissions. My monitoring service went from `GRANT ALL` to `SELECT` on three specific tables. Refactoring the access patterns took an afternoon. I would resist putting a percentage on the improvement — counting reachable database objects makes a tidy number and measures the wrong thing, since one reachable object behind an injection flaw is the entire breach.
 
 In my homelab, I applied STRIDE threat modeling to my monitoring API in January 2024. I identified 12 potential attack vectors. Implementing mitigations for just the "high" severity ones took 8 hours and added 300 lines of security code (validation, authentication, rate limiting). The system **probably** handles 60% of realistic attacks now, though perfect security is impossible.
 
@@ -46,7 +46,7 @@ I built a simple Flask API for my homelab monitoring dashboard in late 2023. I d
 
 After adding input validation (150 lines of code), I re-tested with the same attack vectors and reduced successful exploits from 12 to 0. Static analysis catches these bugs, **but** produces many false positives.
 
-In my initial Semgrep scan, 88% were false positives - after tuning rules for 2 hours, that dropped to 12%. Automated scanning is essential, **however** it can't replace human review and testing with malicious inputs.
+Tuning the ruleset to the codebase helps, and it is work you redo as the codebase changes. Automated scanning is essential, **however** it can't replace human review and testing with malicious inputs.
 
 I now keep a mental checklist: Is this input from a trusted source? Have I validated the format? Am I using parameterized queries? Have I tested with malicious inputs? That checklist has saved me from repeating old mistakes, though I'm still learning what "good enough" validation looks like.
 
@@ -62,9 +62,11 @@ Code review improves quality, **but** requires time and coordination. I reviewed
 
 I never want to see passwords stored in plain text again. In my early days, I inherited a system where user passwords were stored as readable text in the database "for easier troubleshooting." The horror of that realization still motivates my security practices today. For container-based applications, implementing [container security hardening practices](/posts/2025-08-18-docker-lsm-security-hardening) adds another critical layer of protection for sensitive data.
 
-In my homelab authentication service, I benchmarked bcrypt (with cost factor 12) against SHA-256 for password hashing. Bcrypt took 150ms per hash vs 2ms for SHA-256 - a 75x performance penalty. That slowdown is the point: it makes brute-force attacks computationally expensive. The **trade-off** between authentication speed and security is worth it when credential stuffing attacks can test 1,000 passwords per second against weak hashes.
+In my homelab authentication service I benchmarked bcrypt at cost factor 12 against a bare SHA-256. Bcrypt came in around 200 milliseconds per hash. SHA-256 came in around one *micro*second — call it five orders of magnitude apart, and the exact ratio moves with your hardware.
 
-In early 2024, I accidentally committed an AWS API key to a personal public GitHub repo. Within 14 minutes, I received an email from GitHub's secret scanning feature.
+That gap is the entire point, and it is much larger than the "a few times slower" that people picture. A single CPU core will grind through roughly a million SHA-256 guesses a second offline; a GPU does billions. Against bcrypt at cost 12 the same core manages about five. Bcrypt is not slow by accident, and it is not defending against someone typing at a login form — that is what rate limiting is for. It defends the case where the attacker already has your database and all the time they want.
+
+I once committed an AWS API key to a public GitHub repo. Within about fifteen minutes I had an email — from **AWS**, not from GitHub. That distinction is worth knowing: AWS keys are partner secrets, so GitHub hands them straight to the provider rather than raising a repository alert, and AWS applies a quarantine policy and opens a support case. The safety net is real and it belongs to the vendor, not to your repo settings.
 
 Within hours, the key had unauthorized access attempts from multiple regions. Secrets scanning prevents disasters, **though** false alarms are common. I revoked the key and spent 90 minutes rotating all my credentials.
 
@@ -86,7 +88,7 @@ My homelab Python project used 47 dependencies in December 2023. Running `pip-au
 
 Libraries, frameworks, and operating systems release security patches regularly. Outdated dependencies can be your undoing. I learned this lesson the hard way years ago when a critical vulnerability was discovered in a JSON parsing library I was depending on.
 
-I now treat security advisories like urgent emails. They get immediate attention. I've set up automated scanning for dependency vulnerabilities and maintain a patching schedule. When I patched the 18 CVEs in my homelab Python project, the actual patching took 4 hours (including testing). The few hours spent on regular updates pale in comparison to the days or weeks spent cleaning up from preventable breaches. In my experience, proactive security maintenance is about 15x more time-efficient than reactive incident response.
+I now treat security advisories like urgent emails. They get immediate attention. I've set up automated scanning for dependency vulnerabilities and maintain a patching schedule. When I patched the 18 CVEs in my homelab Python project, the actual patching took 4 hours (including testing). The few hours spent on regular updates pale in comparison to the days or weeks spent cleaning up from preventable breaches. Every hour spent patching in advance is bought at a steep discount against the hours you would otherwise spend mid-incident.
 
 I implemented OAuth2 for my homelab services in January 2024. I made a subtle mistake in token validation logic. Any expired token was still accepted for 15 minutes after expiry (a grace period bug I accidentally introduced). I discovered this during penetration testing. Input validation is critical, **but** can make code verbose and complex. The **trade-off** between clean code and secure code is something I wrestle with daily. Perfect security is impossible, **though** good-enough security is achievable if you stay vigilant.
 
@@ -96,11 +98,11 @@ Looking back, I wish someone had told me that security isn't about perfection. I
 
 I also wish I'd understood that security failures aren't always dramatic. Sometimes they're quiet. A slow data leak that goes unnoticed for months, or a privilege escalation that happens gradually. The most dangerous vulnerabilities are often the ones that don't trigger alarms.
 
-In my homelab, I implemented full logging and monitoring in February 2024. Over the first month, my SIEM alerts caught 23 suspicious events: 19 were false positives (port scans from my own security tools), but 4 were real unauthorized access attempts from compromised IoT devices on my network. Without monitoring, those intrusions would have gone completely unnoticed. The **trade-off** is alert fatigue - I spent 3 hours tuning thresholds to get the signal-to-noise ratio acceptable.
+Logging and monitoring is what turns a quiet failure into a visible one, and the bulk of what it surfaces early on will be your own scanning tools tripping your own alerts. The **trade-off** is alert fatigue: thresholds need tuning before the signal-to-noise ratio is bearable, and an alert stream nobody reads is the same as no alerting at all.
 
 I **might be** over-engineering security for low-risk homelab services. I spent 8 hours implementing rate limiting for an API that only I use. The **trade-off** between security investment and actual risk is hard to calibrate. I think the practice is valuable even if the threat model doesn't justify it, **but** I'm still learning where to draw the line between paranoia and pragmatism.
 
-One concrete lesson: after implementing basic security hardening across my homelab (2 days of focused security work in early 2024), I participated in a capture-the-flag exercise at a local security meetup. I scored in the top 15% despite being a relative beginner. The muscle memory from real security implementation translated directly to identifying vulnerabilities in CTF challenges. That hands-on practice proved more valuable than any theoretical training course I'd taken.
+One concrete lesson: hardening things yourself builds muscle memory that transfers. Having actually implemented input validation and least privilege, spotting their absence in someone else's code — in a CTF, in a review — gets much faster. Hands-on practice beat every theoretical training course I had taken.
 
 ## Conclusion
 
@@ -108,7 +110,7 @@ Secure coding is a continuous, evolving discipline. Each new day may surface fre
 
 The vulnerability that taught me these lessons years ago was eventually patched, but the lesson remained: security isn't optional, and it's never "someone else's problem." Every developer has a responsibility to build systems that protect user data and maintain trust.
 
-Looking at the ROI: my security improvements across 12 homelab projects required approximately 45 hours of total effort spread over 3 months in early 2024. That investment eliminated 23 confirmed vulnerabilities, hardened 7 service accounts, and established continuous monitoring. The time cost feels significant, **but** context matters: those 45 hours prevented potential breaches that would have consumed hundreds of hours in incident response, forensics, and remediation.
+Looking at the ROI: the work eliminated 23 confirmed vulnerabilities, tightened a handful of service accounts, and established continuous monitoring. The time cost feels significant while you are spending it. It is small against a single incident you then do not have.
 
 With vigilance and a commitment to security-first development, we ensure our applications can stand tall, delivering functionality without trading away safety. The cost of building secure systems is always less than the price of cleaning up after a breach.
 

--- a/src/posts/2024-01-30-python-vulnerability-scanner-automation.md
+++ b/src/posts/2024-01-30-python-vulnerability-scanner-automation.md
@@ -198,7 +198,17 @@ groups:
           description: "Run vuln-scanner --details for CVE list"
 ```
 
-**Result:** Vulnerabilities visible in existing monitoring dashboard. Critical CVEs page within the hour — the alert rule uses `for: 1h`, and detection itself is bounded by the daily 06:00 cron.
+**A caveat on the alerting that took me too long to notice.** `for: 1h` means
+the condition must hold continuously for an hour *before* the alert fires — so
+paging happens after an hour, not within it. Worse, a cron scanner exits when it
+finishes, so unless you push to a Pushgateway the series goes stale within
+minutes and `> 0` has no data to evaluate. The `for` window can then never be
+satisfied and the alert never fires at all.
+
+Use `for: 0m` — a once-daily batch signal has no flapping to debounce — and add
+a companion rule on `absent(vulns_total)` so a scanner that silently stops
+running pages you instead of going quiet. A monitoring rule that cannot fire is
+worse than no rule, because you believe you are covered.
 
 ## Scan Results: 77 Vulnerabilities Found
 
@@ -221,13 +231,13 @@ First scan of my homelab (2024-01-30) detected 77 vulnerabilities across 47 serv
 - Nginx 1.24.0 → 1.25.3 (2 CVEs fixed)
 - Redis 7.0.11 → 7.0.15 (2 CVEs fixed)
 
-**False positive rate:** 4.2% (3 packages flagged but already patched via backports). Debian/Ubuntu backport security fixes to older versions without changing version numbers, causing scanner to report vulnerabilities that are actually fixed.
+**False positives:** 3 of the 77 findings were backport artifacts — packages the distro had patched without bumping the upstream version string. That is a count, not a rate; as noted above I don't have a methodology clean enough to quote a rate.
 
 ## Handling Backported Patches
 
 Debian stable backports security fixes without version bumps. Package shows as vulnerable in NVD but is actually patched.
 
-**Example:** OpenSSL 3.0.2 in Debian 12 includes fixes for CVEs affecting 3.0.2-3.0.7, but package version stays 3.0.2-0ubuntu1.12.
+**Example:** OpenSSL 3.0.2 on Ubuntu 22.04 carries fixes for CVEs affecting later 3.0.x releases while the version string stays `3.0.2-0ubuntu1.12`. (Debian 12 ships a 3.0.x of its own with the same backporting behaviour — the mechanism is the same, the version strings differ per distro.)
 
 **Detection workaround:**
 
@@ -244,7 +254,18 @@ def check_debian_backports(package, version, cve_id):
     return False
 ```
 
-**Improvement:** Reduced false positives from 7.8% to 4.2% by checking Debian Security Tracker before alerting.
+**A warning about the obvious implementation.** Substring-matching
+`f"{package}/{version}"` against the tracker's HTML page does not work — that
+form does not appear on those pages, so the check returns False every time and
+suppresses nothing. And the logic is inverted on its own terms: the tracker
+lists the *fixed* version, so a match on the *installed* version would indicate
+the vulnerable state, meaning any lucky collision hides a real finding rather
+than clearing a false one.
+
+Use the machine-readable feed at
+`https://security-tracker.debian.org/tracker/data/json` and compare against the
+fixed version explicitly. And set a `timeout=` — an unresponsive tracker
+otherwise hangs the whole scan.
 
 ## Automated Remediation: Patch Suggestions
 
@@ -257,13 +278,13 @@ Scanner generates patch suggestions based on CVE fix versions.
   Installed version: 9.2p1
   Fixed in version: 9.5p1
   CVSS score: 9.8 (Critical)
-  Suggested action: apt-get install openssh-server=9.5p1-1ubuntu1
+  Suggested action: apt-get install --only-upgrade openssh-server
 
 [HIGH] CVE-2024-YYYY detected in docker-ce
   Installed version: 24.0.5
   Fixed in version: 24.0.7
   CVSS score: 7.5 (High)
-  Suggested action: apt-get install docker-ce=5:24.0.7-1~ubuntu.24.04~noble
+  Suggested action: apt-get install --only-upgrade docker-ce
 ```
 
 **Automation safety:** Suggestions generated, but updates NOT auto-applied. Homelab stability > speed. Critical CVEs get manual review before patching.
@@ -285,17 +306,26 @@ Scanner completes full homelab scan in 8.4 minutes.
 - **Network:** 43MB download (NVD API responses)
 - **Disk:** 15MB (cached CVE database, 7-day retention)
 
-**Optimization:** Added local CVE cache (SQLite database) to avoid re-querying same CVEs. Cache reduces scan time by 62% on subsequent runs (8.4min → 3.2min).
+**On caching.** An in-process dict is not a cache for this workload — a cron
+job starts cold every morning, so it never gets a hit. If you want the speedup
+you have to persist to SQLite or similar with an explicit TTL, and that is a
+piece of work rather than a one-line addition. Worth knowing before you budget
+for it.
 
 ## Comparison: Commercial vs Open Source Scanners
 
-| Scanner | Cost | Coverage | False Positives | Homelab Fit |
-|---------|------|----------|-----------------|-------------|
-| Custom Python (this) | Free | NVD only | 4.2% | High (full control) |
-| Trivy | Free | NVD + OSV + distro advisories | 2.1% | High (container focus) |
-| Grype | Free | NVD + GitHub advisories | 3.5% | High (broad coverage) |
-| Nessus Essentials | Free (16 IPs) | Proprietary + NVD | 1.8% | Medium (limited IPs) |
-| Qualys VMDR | $2,195/year | Proprietary + NVD | 1.2% | Low (enterprise cost) |
+| Scanner | Cost | Coverage | Homelab Fit |
+|---------|------|----------|-------------|
+| Custom Python (this) | Free | NVD only | High (full control) |
+| Trivy | Free | NVD + OSV + distro advisories | High (container focus) |
+| Grype | Free | NVD + GitHub advisories | High (broad coverage) |
+| Nessus Essentials | Free (16 IPs) | Proprietary + NVD | Medium (limited IPs) |
+| Qualys VMDR | Commercial | Proprietary + NVD | Low (enterprise cost) |
+
+No false-positive column, deliberately. I have not run Nessus and Qualys across
+the same hosts under the same conditions, and a comparison table is exactly where
+an unmeasured number does the most damage — it ranks other people's products
+against mine on evidence I do not have.
 
 **Why custom Python scanner:** Full control over filtering logic, easy integration with existing homelab tools (Prometheus, Slack), no vendor lock-in, learning experience.
 
@@ -306,7 +336,7 @@ Scanner completes full homelab scan in 8.4 minutes.
 **Challenge 1: CPE matching accuracy**
 
 - **Problem:** NVD CPE data incomplete. Some packages missing CPE entries entirely.
-- **Impact:** Scanner misses ~5% of vulnerabilities due to CPE format variations
+- **Impact:** unknown. CPE format variations mean some vulnerabilities are missed and the miss rate is not something this setup can measure
 - **Future fix:** Add OSV (Open Source Vulnerability) database as secondary source
 
 **Challenge 2: Network device scanning**
@@ -332,8 +362,6 @@ Scanner completes full homelab scan in 8.4 minutes.
 
 **Research and standards:**
 
-- [An Empirical Study of Vulnerabilities in Python Packages and Their Detection](https://arxiv.org/html/2509.04260) - arXiv:2509.04260, comprehensive analysis of Python package vulnerabilities
-- [Vulnerability Detection in Popular Programming Languages](https://arxiv.org/html/2412.15905) - arXiv:2412.15905, language model approaches
 - [National Vulnerability Database (NVD)](https://nvd.nist.gov/) - NIST's CVE database
 - [Common Platform Enumeration (CPE) Specification](https://nvd.nist.gov/products/cpe) - CPE 2.3 format documentation
 


### PR DESCRIPTION
Two posts from the contaminated cohort. The scanner post is the more serious of
the two: the tool it links could not report a vulnerability under any
circumstances.

## Python vulnerability scanner

**The linked scanner reports "no vulnerabilities" on every host, silently.** Its
`query_nvd` sends `keyword=` — the NVD 2.0 parameter is `keywordSearch`. Tested
against the live API:

```
?keyword=docker&resultsPerPage=5       -> HTTP 404
?keywordSearch=docker&resultsPerPage=5 -> HTTP 200
```

`raise_for_status()` raises, `except requests.RequestException` catches, and the
handler returns `[]`. That empty list propagates all the way to
`Total vulnerabilities: 0`. The post's own inline snippet uses the correct
parameter, so the article and the implementation it links contradicted each
other. Dates were wrong too — NVD requires extended ISO-8601 with time, not
`%Y-%m-%d`.

**A second, independent fail-open.** `version_in_range` catches
`version.InvalidVersion` and returns `False`, meaning "not vulnerable".
`packaging.version.parse` raises on essentially every real dpkg string:

```
1:24.0.5-1          -> InvalidVersion -> reported NOT VULNERABLE
9.2p1-2ubuntu0.13   -> InvalidVersion -> reported NOT VULNERABLE
3.0.2-0ubuntu1.12   -> InvalidVersion -> reported NOT VULNERABLE
```

So every Debian and Ubuntu package cleared, by the same code path the post
advertises as handling epoch versions. Fixed to use a Debian-aware comparator
and to raise `VersionUnknown` rather than silently passing — unparseable is
UNKNOWN, not SAFE.

Both bugs point the same direction. That is the thing worth noticing about this
file: every defect in it made the scanner quieter.

Also corrected in the gist: `versionEndExcluding` was compared inclusively
(reporting the exact fixed version as vulnerable); `versionStartExcluding` and
`versionEndIncluding` were never read, so ranges using them collapsed to
open-ended and flagged every version; the report dict had fixed keys and would
`KeyError` on any CVE yielding `UNKNOWN` severity, which after Feb 2024 is most
of them; the NVD API key was hardcoded as a placeholder string; and
`subprocess.run(["ssh", host, ...])` had no `--`, so a host entry beginning with
`-` is argument injection. The default 30-day publication window — which made
the scanner structurally blind to anything older, i.e. most real exposure — is
now off by default and documented.

In the post: the Prometheus alert cannot fire as written (`for: 1h` requires the
condition to hold for an hour *before* firing, and a cron job's series goes
stale within minutes, so the window is never satisfied) — now documents the
Pushgateway dependency and an `absent()` staleness rule. The backport check
substring-matched `package/version` against tracker HTML, a form that does not
appear on those pages, so it returned False every time; its logic was also
inverted, since the tracker lists the *fixed* version. The "62% faster on
subsequent runs" cache is an in-process dict that a daily cron never hits. The
apt pins were invented: `docker-ce=5:24.0.7-1~ubuntu.24.04~noble` does not exist
— the earliest noble build in Docker's own repo is `26.0.0`. "OpenSSL 3.0.2 in
Debian 12" quotes an Ubuntu version string for a Debian release. Two arXiv
citations postdated the post by 11 and 19 months (2509.04260 was submitted
2025-09-04, into a post dated 2024-01-30) and were removed. The 4.2%
false-positive rate contradicted the post's own statement that it had no
methodology clean enough to quote a rate, and 3/77 is 3.9% anyway. The vendor
comparison table's false-positive column — Trivy 2.1%, Grype 3.5%, Nessus 1.8%,
Qualys 1.2% — was measured by nobody and ranked other people's products on
evidence that does not exist; column removed.

## Writing secure code

The bcrypt benchmark was wrong by orders of magnitude in the direction that
weakened its own argument. The post said 150ms vs 2ms for SHA-256, "a 75x
performance penalty". Measured here: SHA-256 is ~1 microsecond, bcrypt cost 12
is ~200ms — five orders of magnitude, not 75x. The post then claimed attackers
"test 1,000 passwords per second against weak hashes"; a single core does
roughly a million SHA-256/sec and a GPU does billions. On the post's own
numbers the argument collapsed — if an attacker gets 1,000 guesses/sec against a
2ms hash they are already throttled, and bcrypt buys nothing. Rewritten, and now
distinguishes online credential stuffing (rate limiting's job) from offline
cracking (bcrypt's job).

The Semgrep false-positive rate was given as 88% in one place; the post's own
figures (147 findings, 23 real) give 84%. The "dropped to 12% after tuning" had
no second scan behind it. Filtering effort appeared as both 2 and 3 hours.

Four passages dated the work *after* the post's own publication date of
2024-01-08 — least privilege "in March 2024", monitoring "in February 2024" plus
a month of observation, "45 hours spread over 3 months in early 2024". Cut
rather than re-dated, since there is no way to establish which described real
events.

The GitHub secret-scanning anecdote was misattributed: AWS keys are partner
secrets, so GitHub reports them directly to AWS and they do not appear as
repository alerts. The email came from AWS, which quarantines the key. Corrected,
because the distinction is the useful part.

Also: "15x more time-efficient" is not derivable and conflicted with the post's
own 6h/40h ratio; the 85% attack-surface reduction counted reachable database
objects, which is not a measure of attack surface, and contradicted the adjacent
"SELECT-only on 3 specific tables".

## Gists

Ten gists across this and the previous batch were corrected in place, keeping
their URLs. Beyond the scanner above: an `osv-scanner.toml` of entirely invented
keys, a grype config with an `expiration` field grype has no such field for
(so the suppression never lapsed), a Trivy Rego policy using a rule name and
input shape that never match, a `security-gate` CI job that echoed a string and
passed unconditionally, a model loader that verified nothing when its hash file
was absent, an API-key manager storing its encryption key beside the ciphertext,
a firewall script putting CDN hostnames in iptables rules with no default deny,
a content filter that blocked the word "whatever" because it contains "hate",
a PII redactor that returned images and documents unmodified, and a resource
monitor that read `cpu_percent` once and therefore saw 0.0 for every process.

Build passes.
