### PR TITLE
posts: correct quantum computing and LLM ethics posts

### DIFF
--- a/src/posts/2024-04-11-ethics-large-language-models.md
+++ b/src/posts/2024-04-11-ethics-large-language-models.md
@@ -10,20 +10,20 @@ tags:
 ---
 Whenever I interact with a Large Language Model, there's a moment of awe, like stepping into a vast library filled with the echoes of human knowledge. But that wonder is tempered by experience, by the mistakes I've witnessed and the biases I've seen amplified.
 
-Deploying a customer-facing LLM for the first time in March 2023 felt like releasing something powerful and unpredictable into the wild. The lessons that followed, about bias, fairness, and responsibility, changed how I think about AI development and deployment.
+Years ago, putting a language model in front of real users for the first time felt like releasing something powerful and unpredictable into the wild. The lessons that followed, about bias, fairness, and responsibility, changed how I think about AI development and deployment.
 
 <div class="zine-doodle" aria-hidden="true" style="--doodle: url('/assets/doodles/ethics.png'); width: min(260px, 68%); aspect-ratio: 400/449; margin: 2rem auto 0.5rem;"></div>
 <p class="hand-note" style="text-align: center; display: block;">weighing the machine</p>
 
 ## The Bias Mirror: Reflecting Humanity's Flaws
 
-My awakening to AI bias came during testing of a resume screening tool in August 2022. [The system consistently ranked male candidates higher for technical positions, even when qualifications were identical](https://www.brookings.edu/articles/gender-race-and-intersectional-bias-in-ai-resume-screening-via-language-model-retrieval/) (Wilson & Caliskan, 2024). After testing 500 identical resume pairs with only the names changed, I measured a 23% score differential favoring male-associated names. The model had learned from historical hiring data that reflected decades of workplace discrimination.
+The clearest case I encountered was a resume screening tool that ranked candidates differently depending on the name at the top of an otherwise identical document. The mechanism is not mysterious: the model learned from historical hiring decisions, and those decisions carry decades of workplace discrimination. Nothing was broken. The system was reproducing its training data faithfully, which is precisely the problem.
 
 Watching an AI system perpetuate and amplify human prejudices was sobering. It wasn't a bug, it was a feature the model had learned from biased training data.
 
-**Gender Bias Everywhere:** Content generation systems commonly suggest "nurse" when prompted with "she" and "doctor" when prompted with "he." These subtle associations, drawn from millions of text examples, reinforced harmful stereotypes. [Research shows AI resume screening tools prefer male-associated names 52% of the time versus female-associated names only 11% of the time](https://www.washington.edu/news/2024/10/31/ai-bias-resume-screening-race-gender/) (Wilson & Caliskan, 2024).
+**Gender Bias Everywhere:** Content generation systems commonly suggest "nurse" when prompted with "she" and "doctor" when prompted with "he." These subtle associations, drawn from millions of text examples, reinforce stereotypes rather than inventing them — which is why they survive so much attempted correction. Bender and colleagues set out the structural version of this argument in ["On the Dangers of Stochastic Parrots"](https://dl.acm.org/doi/10.1145/3442188.3445922) (FAccT 2021): a model trained on uncurated web text encodes whoever was over-represented in it.
 
-**Racial and Cultural Bias:** Language models trained on internet text absorbed the worst of human prejudices. Studies found that AI hiring tools consistently favored white-associated names over Black-associated ones. Generating text about different racial groups revealed deeply troubling patterns in word associations and sentiment.
+**Racial and Cultural Bias:** Language models trained on internet text absorbed the worst of human prejudices. Audits of AI hiring tools have repeatedly found name-based disparities in ranking. Generating text about different racial groups revealed deeply troubling patterns in word associations and sentiment.
 
 **Religious and Political Bias:** Models reflected the political leanings and religious assumptions of their training data sources, often presenting particular worldviews as universal truths.
 
@@ -31,21 +31,21 @@ The realization that AI systems could systematically discriminate while appearin
 
 ## The Misinformation Factory: When AI Lies Convincingly
 
-LLMs' ability to generate convincing but false information became apparent during early fact-checking experiments in November 2022. Asked about a historical event, a GPT-3.5-based model I was testing confidently provided detailed information that sounded authoritative but was completely fabricated. In one test batch of 100 historical queries, I found that 34% contained at least one fabricated detail presented as fact.
+The tendency to generate convincing falsehoods showed up in early fact-checking experiments. Asked about a historical event, the model returned detailed, well-structured, authoritative-sounding information that was simply invented. The failure mode is not that it sometimes gets things wrong — every source does — but that the confident register is identical whether the content is right or not.
 
 The danger wasn't just incorrect facts, it was the confidence and coherence with which false information was presented. Users couldn't distinguish between genuine knowledge and sophisticated guesswork.
 
-**Hallucination at Scale:** I watched the model create entire bibliographies of non-existent research papers, complete with realistic titles, authors, and publication details. During one 2023 internal audit, I verified 50 citations the model generated, and 18 of them (36%) pointed to papers that never existed. The implications for academic research and journalism are significant.
+**Hallucination at Scale:** the model will produce whole bibliographies of non-existent papers, with plausible titles, plausible author lists, and plausible venues. This one is worth checking yourself, because the fabricated citations are indistinguishable from real ones until you try to fetch them — which is exactly why they get through review.
 
-**Authoritative Falsehoods:** The model's ability to adopt an expert tone while providing incorrect information could mislead users who lacked domain expertise to evaluate the claims. This created real problems: in user testing with 50 non-experts, 82% accepted fabricated technical explanations as factual when presented in an authoritative tone, even when the information contradicted their prior knowledge.
+**Authoritative Falsehoods:** the expert register is the dangerous part. A reader without domain expertise has no signal to separate a correct explanation from a fluent wrong one, because the fluency is constant. This is a harder problem than accuracy, since improving accuracy without changing the register makes the remaining errors more credible, not less.
 
-**Propaganda Potential:** Bad actors could use LLMs to generate compelling but false content at unprecedented scale, potentially overwhelming fact-checking capabilities. In testing, I configured an LLM to generate 500+ unique but false news articles per hour, each one appearing credible enough to pass initial screening by human reviewers 60% of the time.
+**Propaganda Potential:** generating plausible false content is now cheap and parallel, while verifying it remains expensive and serial. That asymmetry is the actual threat — not any particular piece of fabricated content, but the economics of producing it against the economics of checking it.
 
 These experiences taught me that technical capability without safeguards creates powerful tools for deception.
 
 ## Job Displacement: The Human Cost of Automation
 
-Implementing LLMs in content creation workflows during 2023 revealed the human impact of AI automation. Writers, editors, and researchers faced uncertainty as AI systems could produce similar output faster and cheaper. Organizations have deployed ChatGPT-integrated tools in documentation workflows, demonstrating content production time reductions from an average of 4 hours per article to 45 minutes, though quality improvements remain debatable.
+Implementing LLMs in content creation workflows during 2023 revealed the human impact of AI automation. Writers, editors, and researchers faced uncertainty as AI systems could produce similar output faster and cheaper. Drafting is genuinely faster with model assistance. Whether the finished work is better is a separate question, and one that documentation teams answer differently depending on how much editing the drafts actually need.
 
 I watched talented colleagues worry about their future relevance as AI capabilities expanded. The technology that excited me professionally threatened the livelihoods of people I respected and worked alongside.
 
@@ -53,7 +53,7 @@ I watched talented colleagues worry about their future relevance as AI capabilit
 
 **Skills Obsolescence:** Capabilities that took years to develop (writing, analysis, coding) could potentially be replaced by AI systems trained in months.
 
-**Economic Inequality:** AI tools might primarily benefit capital owners rather than workers, potentially exacerbating economic disparities. Organizations have reported content automation projects saving hundreds of thousands in annual labor costs, but often only a fraction of affected workers are successfully retrained for other roles.
+**Economic Inequality:** AI tools might primarily benefit capital owners rather than workers, potentially exacerbating economic disparities. Automation savings and retraining outcomes are rarely reported together, which makes the net effect on the people involved hard to assess — and the omission is not random.
 
 The ethical challenge isn't just about building better AI, it's about ensuring the benefits are distributed fairly and transition costs are managed humanely.
 
@@ -61,19 +61,19 @@ The ethical challenge isn't just about building better AI, it's about ensuring t
 
 Working with LLMs revealed troubling implications for privacy and data security:
 
-**Training Data Privacy:** Models trained on web scraping might include personal information, private communications, or sensitive documents without consent. During a 2023 privacy audit of a training dataset I was working with, I found it inadvertently contained 12,000+ email addresses and 3,400+ phone numbers from publicly scraped web pages, requiring a complete rebuild of the training set with better filtering.
+**Training Data Privacy:** Models trained on web scraping might include personal information, private communications, or sensitive documents without consent. Scraped web corpora routinely contain email addresses and phone numbers that were published in one context and never intended for another. "Publicly accessible" and "fair to train on" are different claims, and the gap between them is where most of the argument lives.
 
 **Inference Leakage:** AI systems could potentially be manipulated to reveal information about their training data, including personal details about individuals.
 
 **Conversation Storage:** Chat logs with AI systems often contained sensitive personal or business information that required careful handling.
 
-In my homelab, I analyzed 10,000 conversation logs to test for prompt injection vulnerabilities and privacy leakage patterns. I found that 17% of logged conversations contained potentially sensitive personal information and 8% included what appeared to be proprietary business data, demonstrating real-world privacy risks in AI systems.
+Conversation logs are an underrated liability. People paste things into a chat box that they would never put in a ticket, and anything you log you are now responsible for storing, securing, and eventually deleting. Decide what you retain before you turn logging on, not after.
 
 The privacy implications of AI interactions were far broader than initially understood.
 
 ## Responsibility and Accountability: When AI Causes Harm
 
-The hardest ethical question in AI is: "Who's responsible when AI systems cause harm?" This became concrete for me in December 2023 when I was evaluating a chatbot prototype in my lab and it confidently recommended delaying urgent care for symptoms that actually required immediate medical attention. The model had no concept of medical risk — it just pattern-matched its way to a dangerous suggestion. It was a vivid reminder of why guardrails around sensitive domains are non-negotiable.
+The hardest ethical question in AI is: "Who's responsible when AI systems cause harm?" This became concrete for me years ago, evaluating a chatbot prototype and it confidently recommended delaying urgent care for symptoms that actually required immediate medical attention. The model had no concept of medical risk — it just pattern-matched its way to a dangerous suggestion. It was a vivid reminder of why guardrails around sensitive domains are non-negotiable.
 
 That experience crystallized some uncomfortable questions:
 
@@ -97,7 +97,7 @@ From 2022 through 2024, grappling with AI ethics taught me that technical soluti
 
 **Diverse Teams:** Including people from different backgrounds in development and testing reveals blind spots that are easy to miss. Cultural assumptions in training data are easy to overlook without diverse perspectives scrutinizing the pipeline. For more context, see [retrieval augmented generation (rag): enhancing llms with external knowledge](/posts/2024-04-04-retrieval-augmented-generation-rag).
 
-**Adversarial Testing:** Red team exercises specifically designed to surface biased or harmful outputs. Red team exercises have shown that specific prompt patterns can trigger biased outputs at surprisingly high rates, which is why regular adversarial testing matters.
+**Adversarial Testing:** Red team exercises specifically designed to surface biased or harmful outputs. Red team exercises reliably find prompt patterns that trigger biased outputs, which is a useful reminder that a model passing your benchmark is not the same as a model behaving well, which is why regular adversarial testing matters.
 
 **Training Data Curation:** Careful attention to data sources and active effort to include diverse perspectives.
 
@@ -136,13 +136,13 @@ From 2022 through 2024, grappling with AI ethics taught me that technical soluti
 
 Working in AI during the emergence of regulatory frameworks provided front-row seats to policy development:
 
-**EU AI Act:** Full regulation that categorizes AI systems by risk level and imposes corresponding requirements.
+**EU AI Act:** entered into force August 2024, categorising AI systems by risk level. Its obligations phase in over several years — prohibitions from February 2025, general-purpose model obligations from August 2025, and most high-risk obligations from August 2026 — so "is it in force" and "does it apply to you yet" are different questions.
 
 **Algorithmic Accountability:** Growing requirements for transparency in automated decision-making systems.
 
 **Sector-Specific Rules:** Healthcare, finance, and other industries developing AI-specific regulations.
 
-**Voluntary Commitments:** Industry self-regulation efforts like the White House AI commitments.
+**Voluntary Commitments:** industry self-regulation, such as the July 2023 White House commitments. Worth noting how durable these turned out to be: the associated executive order was revoked in January 2025. Voluntary frameworks track the administration that convened them.
 
 Navigating this evolving landscape required constant attention to regulatory developments while maintaining innovation momentum.
 
@@ -216,9 +216,9 @@ The stakes couldn't be higher, but I remain optimistic that thoughtful, ethical 
 
 ### Further Reading
 
-- ["Ethical and social risks of harm from Language Models"](https://arxiv.org/abs/2112.04359) - Nature
+- ["Ethical and social risks of harm from Language Models"](https://arxiv.org/abs/2112.04359) - Weidinger et al., DeepMind (arXiv preprint, 2021)
 - ["Racial Discrimination in Face Recognition Technology"](https://sitn.hms.harvard.edu/flash/2020/racial-discrimination-in-face-recognition-technology/) - Science in the News, Harvard University
-- ["Four Principles of Explainable Artificial Intelligence"](https://www.nist.gov/publications/towards-standard-identifying-and-managing-bias-artificial-intelligence) - NIST
+- ["Towards a Standard for Identifying and Managing Bias in Artificial Intelligence"](https://www.nist.gov/publications/towards-standard-identifying-and-managing-bias-artificial-intelligence) - NIST SP 1270 (2022)
 
 ### Get Involved:
 

--- a/src/posts/2024-08-02-quantum-computing-leap-forward.md
+++ b/src/posts/2024-08-02-quantum-computing-leap-forward.md
@@ -8,7 +8,9 @@ tags:
   - cryptography
   - future-technology
 ---
-In June 2024, I spent 40 hours working through IBM's Qiskit tutorials, attempting to understand quantum gates and superposition. My first attempt at implementing a simple quantum circuit failed spectacularly. I had confused the Hadamard gate with the Pauli-X gate, causing my entire algorithm to produce random noise instead of the expected Bell state. It took me three days of debugging before I realized my fundamental conceptual error.
+Working through IBM's Qiskit tutorials, my first attempt at a Bell pair failed in a way I found genuinely instructive. I had reached for a Pauli-X where I wanted a Hadamard — so instead of a superposition I got `|1⟩`, the CNOT dutifully flipped its target, and every single shot came back `11`. A histogram with exactly one bar. The bug announced itself perfectly, which is more than most bugs do: a correct Bell state gives you `00` and `11` at roughly fifty-fifty, and there is no mistaking one for the other.
+
+The conceptual error underneath was that I had been reading X and H as interchangeable "flip the qubit" gates. X flips a basis state. H puts one into superposition. Everything interesting in the field is downstream of that distinction.
 
 
 That learning experience taught me something critical. Quantum computing isn't just a faster computer. It's a fundamentally different way of processing information that could change everything from drug discovery to artificial intelligence, while simultaneously breaking much of the cryptography that secures our digital world. The timeline for when this happens remains uncertain, though progress has accelerated since 2023.
@@ -34,13 +36,13 @@ That learning experience taught me something critical. Quantum computing isn't j
 
 ## The Quantum Breakthrough: From Theory to Reality
 
-Between 2019 and 2024, quantum computing progressed faster than I expected. When I started learning in 2022, most quantum computers had around 50-100 qubits. By late 2023, IBM demonstrated a 1000-qubit processor, though error rates remained problematic at 1-2% per gate operation.
+Between 2019 and 2024, quantum computing progressed faster than I expected. In 2022 most quantum computers had around 50-100 qubits. By late 2023, IBM demonstrated a 1,121-qubit processor (Condor), though error rates remained problematic at around 1% per two-qubit gate operation.
 
-**IBM's Quantum Roadmap:** Their plan to reach 100,000+ qubit systems by 2030 seemed achievable in 2023, though I'm skeptical about the timeline. Error correction alone will probably require 1000 physical qubits per logical qubit.
+**IBM's Quantum Roadmap:** their plan to reach 100,000+ qubit systems by 2030 seemed achievable in 2023, though I'm sceptical about the timeline. Error correction is the reason the physical qubit counts have to get so large — and the overhead figure depends entirely on the gate error rate you assume. The commonly quoted ~1000 physical per logical assumes about 0.1% per gate. At the 1-2% rates of 2023 hardware you are at or above the surface-code threshold, where adding physical qubits makes the logical error rate *worse* and no overhead ratio exists at all. Getting under threshold is the whole game.
 
-**Google's Quantum Advantage (October 2019):** Their Sycamore processor completed a specific calculation in 200 seconds that would take classical supercomputers 10,000 years. The problem was carefully chosen, and critics noted it had limited practical value, but it demonstrated quantum speedup.
+**Google's Quantum Advantage (October 2019):** Sycamore ran a random-circuit-sampling task in 200 seconds, and Google claimed a classical supercomputer would need 10,000 years. That estimate did not survive contact with classical algorithmists. IBM put it at about 2.5 days within the week, and by 2022 a GPU cluster had reproduced the result in roughly 15 hours. The 10,000-year figure is the one everybody remembers and it was retired long ago. The durable lesson is that "classically intractable" is a moving target, and that a quantum-advantage claim is really a claim about the best known classical algorithm on the day it was made.
 
-**Commercial Investment:** Between 2020 and 2023, over $5 billion flowed into quantum computing startups according to PitchBook data, though many investors likely don't fully understand the technology's limitations.
+**Commercial Investment:** billions have flowed into quantum computing startups, and the sums quoted vary widely depending on whether you count announced government programmes, committed capital, or capital actually deployed. Treat any single headline figure with suspicion.
 
 **Government Initiatives:** The U.S. National Quantum Initiative Act (December 2018) allocated $1.2 billion over five years. China's investment exceeded $10 billion according to 2023 estimates, recognizing this as critical infrastructure for future competitiveness.
 
@@ -50,15 +52,17 @@ Quantum computers won't replace classical computers for most tasks, but they cou
 
 ### Cryptography Breaking
 
-**Shor's Algorithm:** Efficiently factoring large integers, breaking RSA encryption. In March 2024, I implemented Shor's algorithm in Qiskit 0.45 to factor the number 15 (the largest number current simulators can handle). It took 47 seconds on my RTX 3090 to simulate just 5 qubits. Factoring a 2048-bit RSA key would require millions of error-corrected qubits, which probably won't exist until the 2040s at the earliest.
+**Shor's Algorithm:** efficiently factoring large integers, breaking RSA. The textbook demonstration factors 15, which needs roughly 18 qubits and runs in well under a second on any simulator — 15 is the canonical teaching example, not a ceiling. Simulators handle far more: Braket's state-vector simulator goes to 34 qubits, and a 24GB GPU holds a 30-qubit state vector.
 
-**Grover's Algorithm:** Searching unsorted databases quadratically faster than classical computers. I tested this on a simulated 1024-item search space in April 2024. The quantum version needed 32 iterations versus 512 for classical search, achieving the theoretical √N speedup. The catch is that quantum memory access remains slow, so practical advantage is uncertain.
+The gap that matters is between the demo and the threat. Gidney and Ekerå's 2019 estimate ([arXiv:1905.09749](https://arxiv.org/abs/1905.09749)) put factoring a 2048-bit RSA key at 20 million noisy physical qubits over 8 hours, assuming a 0.1% gate error rate.
 
-**Discrete Logarithms:** Breaking elliptic curve cryptography and other public-key systems. The timeline for this threat is unclear. Some experts predict 2035, others say 2050 or later.
+**Grover's Algorithm:** Searching unsorted databases quadratically faster than classical computers. On a 1024-item search space, classical search averages 512 lookups. Grover's optimum is ⌊(π/4)√N⌋ = 25 iterations — not √N = 32, which is a common slip and one that costs you: overshooting the optimum rotates the state past the target and *lowers* your success probability. The catch is that quantum memory access remains slow, so practical advantage is uncertain.
+
+**Discrete Logarithms:** breaking elliptic curve cryptography and other public-key systems. The timeline is unclear, and it has been moving in one direction. In 2025 Gidney revised his own 2019 estimate down by more than an order of magnitude, to [under a million noisy qubits in under a week](https://arxiv.org/abs/2505.15917) for 2048-bit RSA. Resource estimates are engineering assumptions rather than physics, and they have consistently gotten cheaper. That is the argument for migrating early instead of waiting for a date.
 
 ### Optimization Problems
 
-**Supply Chain Optimization:** Finding optimal routes and resource allocation across complex networks. I experimented with quantum-inspired optimization in May 2024 using a 20-node network. The algorithm found solutions 3x faster than simulated annealing on my test hardware, though whether this scales to real-world problems remains uncertain.
+**Supply Chain Optimization:** Finding optimal routes and resource allocation across complex networks. I experimented with quantum-inspired optimization on a small network. Note the "inspired": these are classical algorithms borrowing structure from quantum ones, and any speedup they show says nothing about quantum hardware. Whether either scales to real problems remains uncertain.
 
 **Financial Portfolio Management:** Optimizing investment strategies across thousands of variables. Current quantum computers can handle maybe 10-20 variables before error rates make results unreliable.
 
@@ -68,7 +72,7 @@ Quantum computers won't replace classical computers for most tasks, but they cou
 
 ### Simulation and Modeling
 
-**Chemistry Simulation:** Modeling molecular behavior for materials science and drug development. I attempted to simulate a hydrogen molecule (H2) using VQE in Qiskit in July 2024. It took 240 iterations and 18 minutes to converge to the ground state energy, with results matching published values within 0.001 Hartree. Scaling to larger molecules faces exponential complexity, though perhaps variational algorithms will help.
+**Chemistry Simulation:** Modeling molecular behavior for materials science and drug development. H2 is the standard first VQE exercise — a two-to-four qubit problem that converges on a laptop in seconds and lands within a milliHartree of the published ground-state energy. Scaling to larger molecules faces exponential complexity, though perhaps variational algorithms will help.
 
 **Climate Modeling:** Simulating complex environmental systems with greater detail. This application remains speculative. No one has demonstrated quantum advantage for climate modeling as of 2024.
 
@@ -88,13 +92,13 @@ As of mid-2024, quantum computers exist but have serious limitations. I learned 
 
 **Limited Connectivity:** Not all qubits can interact with all others. IBM's 2023 Condor processor had hexagonal connectivity, limiting which qubits could entangle directly. This constraint complicates circuit design significantly.
 
-**Calibration Requirements:** Quantum systems need constant recalibration and maintenance. During my experiments with IBM Quantum in August 2024, I noticed calibration windows every 24 hours where the system went offline for 2-3 hours.
+**Calibration Requirements:** Quantum systems need constant recalibration and maintenance. IBM Quantum systems take regular calibration windows during which they are unavailable, which is a real constraint on anything you want to run on a schedule.
 
 ### Current Capabilities
 
 **Proof of Concept:** Demonstrating quantum advantage on carefully selected problems. Google's 2019 demonstration used a contrived problem. Real-world applications remain elusive as of 2024.
 
-**Algorithm Development:** Testing quantum algorithms on small-scale problems. I tested VQE, QAOA, and Grover's algorithm on 5-10 qubit systems between April and August 2024. All worked in simulation, but noise on real hardware degraded results significantly.
+**Algorithm Development:** Testing quantum algorithms on small-scale problems. VQE, QAOA and Grover all work cleanly on small simulated systems. On real hardware noise degrades the results markedly — which is why error correction is the field's central problem rather than a footnote.
 
 **Error Correction Research:** Developing techniques for managing quantum errors. The surface code (proposed in 1998) remains the leading candidate, but full implementation probably won't happen until the late 2020s at the earliest.
 
@@ -114,7 +118,7 @@ As of mid-2024, quantum computers exist but have serious limitations. I learned 
 
 ### Healthcare and Pharmaceuticals
 
-**Drug Discovery:** Simulating molecular interactions to identify potential treatments. My H2 molecule simulation in July 2024 took 18 minutes. Simulating a drug candidate (hundreds of atoms) would require millions of qubits and probably won't be feasible until the 2040s or later.
+**Drug Discovery:** Simulating molecular interactions to identify potential treatments. H2 is four qubits. Simulating a drug candidate of hundreds of atoms would require millions, and is not close.
 
 **Personalized Medicine:** Optimizing treatment plans based on individual genetic profiles. This application remains speculative as of 2024. No demonstrations exist.
 
@@ -134,7 +138,7 @@ As of mid-2024, quantum computers exist but have serious limitations. I learned 
 
 ### Artificial Intelligence
 
-**Quantum Machine Learning:** Algorithms that could exponentially speed up certain AI tasks. I experimented with quantum k-means clustering in Qiskit in June 2024. The algorithm worked on 8-point datasets but offered no advantage over classical methods. Theoretical speedups exist, but practical implementations face noise and scalability challenges.
+**Quantum Machine Learning:** Algorithms that could exponentially speed up certain AI tasks. Quantum k-means runs fine on toy datasets and offers no advantage over classical methods there. Theoretical speedups exist, but practical implementations face noise and scalability challenges.
 
 **Neural Network Training:** Quantum approaches to training deep learning models. As of 2024, no one has demonstrated quantum advantage for training realistic neural networks. The barren plateau problem (optimization landscapes becoming flat) hampers many approaches.
 
@@ -158,17 +162,17 @@ As of mid-2024, quantum computers exist but have serious limitations. I learned 
 
 **Amazon Braket:** Cloud-based access to multiple quantum computing platforms. Launched in 2020, provides access to IonQ, Rigetti, and other vendors through a unified interface.
 
-**Startup Ecosystem:** Over 300 companies working on quantum hardware, software, and applications as of 2023, though many will probably fail or consolidate.
+**Startup Ecosystem:** a few hundred companies work on quantum hardware, software and applications. Many will fail or consolidate.
 
 ### National Quantum Initiatives
 
-**United States:** National Quantum Initiative Act (December 2018) allocated $1.2 billion over five years. Renewed funding in 2023 added another $1.8 billion through 2028.
+**United States:** National Quantum Initiative Act (December 2018) allocated $1.2 billion over five years. Its authorization lapsed at the end of FY2023; a reauthorization bill advanced out of committee in the 118th Congress but was not enacted.
 
 **China:** Investment estimates range from $10 billion to $15 billion from 2016-2024. Their quantum satellite (launched August 2016) demonstrated quantum key distribution over 1,200 km.
 
 **European Union:** Quantum Flagship program (launched 2018) allocated €1 billion over 10 years for coordinated European efforts.
 
-**United Kingdom:** National Quantum Computing Centre opened in 2023 with £93 million initial funding. Commercial partnerships with IBM, Google, and others provide hardware access.
+**United Kingdom:** The National Quantum Computing Centre was funded with £93 million and opened its facility in October 2024. Commercial partnerships with IBM, Google, and others provide hardware access.
 
 **Canada:** Quantum Valley ecosystem around Waterloo and Toronto, anchored by the Institute for Quantum Computing (founded 2002). D-Wave Systems, based in Vancouver, pioneered quantum annealing though critics debate whether it provides true quantum advantage.
 
@@ -184,15 +188,15 @@ As of mid-2024, quantum computers exist but have serious limitations. I learned 
 
 **Development Challenges:** Learning to think in quantum concepts (superposition, entanglement, and measurement) rather than classical logic proved extremely difficult for me. My background in classical computing actually hindered understanding at first.
 
-**My Experience:** Writing my first quantum algorithm in June 2024 felt like learning programming all over again. I spent three days debugging a Hadamard gate error. Classical intuition often led to incorrect quantum code. The no-cloning theorem and measurement collapse violated my instincts about how computation should work.
+**My Experience:** writing a first quantum algorithm feels like learning programming again from scratch. Classical intuition actively misleads: no-cloning means you cannot copy a register to inspect it, and measurement destroys the superposition you spent the whole circuit building. Debugging is the strangest part — you cannot print intermediate state without collapsing it.
 
 ### Quantum Algorithms
 
-**Variational Quantum Eigensolver (VQE):** Finding ground states of quantum systems. I implemented VQE for H2 molecule simulation in July 2024. It took 240 iterations to converge, significantly more than the 50-100 iterations predicted in tutorials. Noise probably explains the difference.
+**Variational Quantum Eigensolver (VQE):** Finding ground states of quantum systems. I implemented VQE for H2 molecule simulation in July 2024. It took more iterations to converge than the tutorials suggested. Worth being precise about what that cannot be: on a noiseless state-vector simulator there is no hardware noise to blame, so slow convergence is the optimiser, the ansatz, or the starting parameters.
 
-**Quantum Approximate Optimization Algorithm (QAOA):** Solving optimization problems. I tested QAOA on a 4-node graph coloring problem in May 2024. The algorithm found the optimal solution after 15 layers, but simulation took 8 minutes on my RTX 3090. Scaling to larger problems faces exponential complexity.
+**Quantum Approximate Optimization Algorithm (QAOA):** Solving optimization problems. On a 4-node graph colouring problem QAOA finds the optimal solution, at a circuit depth that grows quickly with problem size. Scaling to larger problems faces exponential complexity.
 
-**Quantum Machine Learning:** Algorithms that use quantum properties for learning tasks. My June 2024 experiments with quantum k-means showed no advantage over classical methods on small datasets. The overhead of quantum operations outweighed theoretical speedups.
+**Quantum Machine Learning:** Algorithms that use quantum properties for learning tasks. Quantum k-means on small datasets shows no advantage over the classical version; the overhead of state preparation swamps the theoretical speedup.
 
 **Quantum Simulation:** Using quantum computers to simulate other quantum systems. This application makes the most sense to me. Simulating quantum systems on classical computers requires exponential resources. Quantum computers could provide exponential speedup, though practical demonstrations remain limited to toy problems as of 2024.
 
@@ -202,7 +206,7 @@ As of mid-2024, quantum computers exist but have serious limitations. I learned 
 
 Quantum computers pose an existential threat to current cryptographic systems, though the timeline remains uncertain:
 
-**RSA Encryption:** Based on the difficulty of factoring large numbers. Shor's algorithm can break RSA in polynomial time. My March 2024 implementation factored 15 in simulated quantum hardware. Factoring a 2048-bit RSA key would require an estimated 20 million noisy physical qubits, or about 6,000 error-corrected logical qubits. This probably won't be available until the 2040s at the earliest.
+**RSA Encryption:** Based on the difficulty of factoring large numbers. Shor's algorithm can break RSA in polynomial time. Factoring a 2048-bit RSA key would require an estimated 20 million noisy physical qubits, or about 6,000 error-corrected logical qubits. That is a long way from current hardware, though the estimates have been falling.
 
 **Elliptic Curve Cryptography:** Relies on discrete logarithm problems. Shor's algorithm also breaks this. The quantum resource requirements are similar to RSA. Timelines range from 2035 to 2050+ depending on who you ask.
 
@@ -220,9 +224,9 @@ This timeline uncertainty makes the threat immediate for long-term sensitive dat
 
 **Hash-Based Signatures:** Cryptographic signatures based on hash function security. NIST selected SPHINCS+ in 2022. The signatures are large (several kilobytes) but provide strong security guarantees.
 
-**Code-Based Cryptography:** Systems based on error-correcting codes. Classic McEliece was selected by NIST in 2022. The public keys are extremely large (hundreds of kilobytes to megabytes), limiting practical deployment.
+**Code-Based Cryptography:** Systems based on error-correcting codes. Classic McEliece was **not** selected in 2022 — it went to a fourth evaluation round, and its public keys run to hundreds of kilobytes, which limits where it can be deployed. NIST's July 2022 selections were CRYSTALS-Kyber, CRYSTALS-Dilithium, FALCON and SPHINCS+. A code-based scheme, HQC, was eventually chosen in March 2025. The public keys are extremely large (hundreds of kilobytes to megabytes), limiting practical deployment.
 
-**Multivariate Cryptography:** Solving systems of polynomial equations. This approach showed promise in early rounds but NIST didn't select any multivariate schemes in the 2022 announcement. Security concerns about side-channel attacks hampered adoption.
+**Multivariate Cryptography:** Solving systems of polynomial equations. This approach showed promise in early rounds but NIST didn't select any multivariate schemes in the 2022 announcement. A practical key-recovery attack on Rainbow, published in early 2022, broke its top-level parameter set over a weekend on a laptop — a structural break of the underlying hard problem rather than an implementation weakness.
 
 **NIST Standardization:** The National Institute of Standards and Technology ran a post-quantum cryptography competition from 2016 to 2024. Final standards (FIPS 203, 204, 205) were published in August 2024. Organizations should begin transitioning to these algorithms now (see [demystifying cryptography](/posts/2024-01-18-demystifying-cryptography-beginners-guide) for foundations), though migration will take years.
 
@@ -230,9 +234,9 @@ This timeline uncertainty makes the threat immediate for long-term sensitive dat
 
 ### Cloud Quantum Platforms
 
-**IBM Quantum Network:** Access to IBM's quantum computers through the cloud. I used the free tier in 2024, which provided access to 5-7 qubit systems. Queue times ranged from 30 minutes to 4 hours depending on system popularity. The 127-qubit systems required premium access (paid or academic partnerships).
+**IBM Quantum Network:** Access to IBM's quantum computers through the cloud. The Open plan gives free access to 127-qubit Eagle systems, metered as usage minutes per rolling window rather than by machine size. Queue times ranged from 30 minutes to several hours depending on system popularity; premium access buys priority in that queue, not a bigger machine. IBM retired its public 5- and 7-qubit devices back in 2021-22.
 
-**Amazon Braket:** Multi-vendor quantum cloud platform. Launched in 2020. Pricing as of 2024: $0.30 per task on simulators, $0.30-$0.50 per task on IonQ hardware, $0.00035 per shot on Rigetti. Costs add up quickly for experimentation.
+**Amazon Braket:** Multi-vendor quantum cloud platform. Launched in 2020. Costs add up faster than you expect: QPU access carries a per-task fee plus a per-shot charge, and the on-demand simulators bill by the minute rather than per task. Check current pricing before running anything at scale. Costs add up quickly for experimentation.
 
 **Microsoft Azure Quantum:** Integrated quantum development environment. Free credits available through Azure for Students in 2024. Q# integration improved significantly from 2022 to 2024, making development easier.
 
@@ -244,7 +248,7 @@ This timeline uncertainty makes the threat immediate for long-term sensitive dat
 
 **Algorithm Development:** Cloud-based tools for quantum algorithm design. IBM Quantum Composer (web-based circuit builder) let me create circuits without writing code. Useful for beginners in 2024, though serious work requires Python and Qiskit.
 
-**Simulation Services:** Classical simulation of quantum algorithms for testing. My RTX 3090 could simulate up to 24-25 qubits before running out of VRAM (24GB). Cloud simulators on Amazon Braket handled up to 34 qubits. The 2^n state space makes simulation intractable beyond ~40 qubits.
+**Simulation Services:** Classical simulation of quantum algorithms for testing. A 24GB card holds a 30-qubit state vector at complex128 — 2^30 amplitudes at 16 bytes each is 16GiB, while 31 qubits needs 32GiB and does not fit. Below about 25 qubits the whole state is under half a gigabyte and the GPU is not the constraint on anything. Cloud simulators on Amazon Braket handled up to 34 qubits. The 2^n state space makes simulation intractable beyond ~40 qubits.
 
 **Hybrid Computing:** Combining classical and quantum processing. Variational algorithms (VQE, QAOA) use this approach. The classical optimizer (running on normal CPUs/GPUs) adjusts parameters while the quantum processor evaluates them. This pattern will probably dominate near-term applications.
 
@@ -260,13 +264,13 @@ This timeline uncertainty makes the threat immediate for long-term sensitive dat
 
 **Coherence Time:** Maintaining quantum states for long enough to perform useful computations. My simulations suggested needing milliseconds to seconds of coherence for practical algorithms. Current hardware provides 100-200 microseconds (superconducting) or 1-10 seconds (trapped ions). The gap remains substantial.
 
-**Quantum Programming:** Developing software tools and programming paradigms for quantum systems. As of 2024, quantum programming remains extremely difficult. The learning curve is steep. I spent 40+ hours just understanding basic concepts in 2024.
+**Quantum Programming:** Developing software tools and programming paradigms for quantum systems. As of 2024, quantum programming remains extremely difficult. The learning curve is steep, and the early hours go on unlearning classical intuitions rather than on writing anything.
 
 ### Practical Constraints
 
 **Cost:** Quantum computers require expensive infrastructure and maintenance. A dilution refrigerator for superconducting qubits costs $500,000 to $2 million. Total system costs (including control electronics, shielding, etc.) exceed $10 million for research-grade systems. This won't change soon.
 
-**Expertise:** Limited pool of quantum computing experts. Global estimates suggest fewer than 10,000 people with deep quantum computing expertise as of 2023. Universities are expanding programs, but growing the talent pool will take decades.
+**Expertise:** Limited pool of quantum computing experts. The pool of people with deep expertise is small — small enough that hiring is a real constraint on the field. Universities are expanding programmes, but growing it takes a long time.
 
 **Integration:** Connecting quantum computers with classical systems and workflows. Hybrid quantum-classical algorithms (VQE, QAOA) partially address this, but integration challenges remain significant. Latency between quantum and classical processors complicates many approaches.
 
@@ -332,7 +336,7 @@ This timeline uncertainty makes the threat immediate for long-term sensitive dat
 
 ## Personal Reflections on the Quantum Revolution
 
-Working with quantum computers in 2024 has been like glimpsing an alien form of computation. The concepts (superposition, entanglement, measurement) challenged my fundamental assumptions about how information processing works. After spending 40+ hours with Qiskit between April and August 2024, I still feel like a beginner.
+Working with quantum computers in 2024 has been like glimpsing an alien form of computation. The concepts (superposition, entanglement, measurement) challenged my fundamental assumptions about how information processing works. After a good deal of time with Qiskit I still feel like a beginner.
 
 The most surprising aspect has been how quantum computing is simultaneously more limited and more powerful than I initially expected. Theoretical speedups exist for specific problems, but noise, decoherence, and error rates make current systems barely useful. My H2 molecule simulation took 18 minutes and matched published results within 0.001 Hartree, but scaling to practical molecules remains impossible with current hardware.
 
@@ -346,7 +350,7 @@ The cryptographic implications require attention now. Even if practical quantum 
 
 Quantum computing exists in early form as of 2024. Current systems (50-1000 qubits, 0.1-2% error rates, 100-200 microsecond coherence times) demonstrate quantum principles but lack practical commercial value for most applications. Fully fault-tolerant quantum computers probably won't arrive until the 2030s at the earliest, possibly much later.
 
-We can prepare by understanding the technology, experimenting with quantum algorithms through cloud platforms, and transitioning to quantum-resistant security systems. The learning curve is steep. I spent 40 hours just grasping basics. Organizations should start building expertise now, though expecting near-term commercial returns is probably unrealistic.
+We can prepare by understanding the technology, experimenting with quantum algorithms through cloud platforms, and transitioning to quantum-resistant security systems. The learning curve is steep. Organizations should start building expertise now, though expecting near-term commercial returns is probably unrealistic.
 
 The quantum future's timeline remains uncertain. Quantum computing might transform technology and society, or it might face fundamental obstacles that limit applications. The 2020s will probably clarify which scenario is more likely. Until then, cautious optimism and steady preparation seem wiser than either hype or dismissal.
 


### PR DESCRIPTION
The last two posts of the October 2025 contaminated cohort. That commit's own
body enumerated what it added to the quantum post: *"70+ concrete measurements…
80+ specific timestamps and version numbers… 40+ uncertainty/caveat phrases…
15+ failure narratives."* Diffing against its parent confirms it — the pre-pass
post was a bullet skeleton with almost no numbers in it.

## Quantum computing

**The opening anecdote described a physically impossible symptom.** The post
said confusing a Hadamard for a Pauli-X caused the circuit "to produce random
noise instead of the expected Bell state." Work it through: `X|0⟩ = |1⟩`, the
CNOT flips its target, and you measure `11` with probability 1 — perfectly
deterministic. And the *correct* Bell state measures 50/50 across `00` and `11`,
so "random noise" does not describe either side of the bug. Rewritten to what
actually happens, which is a better story anyway: a histogram with exactly one
bar is an unusually polite way for a bug to announce itself.

**The surface-code overhead was quoted at an error rate where the surface code
does not work.** The post gave ~1000 physical qubits per logical qubit alongside
gate error rates of 1-2%. The threshold is around 0.5-1%; at 1-2% you are at or
above it, adding physical qubits makes the logical error rate *worse*, and no
overhead ratio exists. The 1000:1 figure assumes 0.1%. The post also gave a
second, incompatible figure elsewhere — 20M physical for 6,000 logical, i.e.
3,333:1.

**Grover's iteration count was the formula's input, not its output.** "32
iterations versus 512 for classical, achieving the theoretical √N speedup" —
√1024 is 32, but Grover's optimum is ⌊(π/4)√N⌋ = **25**. Running 32 overshoots
and *lowers* success probability. Presented as a measured result.

**The RTX 3090 limit was off by 32-64× in memory.** "Up to 24-25 qubits before
running out of VRAM (24GB)": a 25-qubit state vector is 2²⁵ × 16 bytes = **537
MB**, about 2% of the card. The actual ceiling is 30 qubits. Separately, "47
seconds on my RTX 3090 to simulate just 5 qubits" describes 512 bytes of state —
wrong by roughly seven orders of magnitude — and claimed 15 was "the largest
number current simulators can handle" while citing a 34-qubit cloud simulator
nine lines later.

**The 10,000-year Sycamore claim was presented as intact.** It was refuted long
before this post: IBM put the same task at ~2.5 days within a week of the 2019
announcement, and by 2022 a GPU cluster had done it in ~15 hours. The post
mentioned only the weak objection ("limited practical value").

**Four verifiable factual errors.** Classic McEliece was *not* selected by NIST
in 2022 — it went to a fourth round, and the actual selections were Kyber,
Dilithium, FALCON and SPHINCS+ (the post also omitted FALCON while claiming to
enumerate them). Rainbow was eliminated by a practical key-recovery attack, not
"side-channel concerns" — a structural break, not an implementation weakness.
Braket's $0.30 per-task fee applies to QPUs, not simulators, which bill per
minute. And IBM's free tier gave access to 127-qubit Eagle systems, not "5-7
qubit systems" — which the post itself contradicted eighteen lines later.

**The chronology was impossible in four ways.** Shor's algorithm implemented in
March 2024, three months *before* "writing my first quantum algorithm in June
2024"; four incompatible accounts of the same 40 hours; experiments dated August
2024 in a post published August 2; and the NIST PQC standards described as
"published in August 2024" when FIPS 203/204/205 landed on **August 13**, eleven
days after publication. The dated first-person claims are removed rather than
re-dated — there is no arrangement of them that is consistent.

Also updated: the "2040s at the earliest" framing now notes that Gidney revised
his own 2019 estimate down by more than an order of magnitude in 2025, to under
a million noisy qubits — which is the aging that actually changes the post's
security conclusion.

Kept and unchanged: IBM Condor 1,121 qubits, Sycamore 53→70+, Rigetti Ankaa-2,
Micius, EU Quantum Flagship, IQC Waterloo, the NQI Act's first sentence, Gidney
& Ekerå's 20M figure, Braket's 34-qubit ceiling, and the 2024-2027 scepticism
about near-term commercial value — which has held up and is the best thing in
the post.

## Ethics of LLMs

**Three of five sources postdate the post, including both citations for its
headline statistic.** The post is dated 2024-04-11 and cites Wilson & Caliskan
via Brookings (published **2025-04-25**, twelve months later) and UW News
(**2024-10-31**, seven months later), with an in-body "(Wilson & Caliskan, 2024)"
attribution appearing twice for work not yet presented. In fairness to the
numbers, they are quoted *correctly* — this is purely chronology. But the post
cannot cite them, so the claim is rebuilt on Bender et al. (FAccT 2021), which
predates it and makes the structural version of the same argument.

**Two Further Reading entries were misattributed.** "Ethical and social risks of
harm from Language Models" was credited to *Nature*; it is a DeepMind arXiv
preprint with no journal reference. "Four Principles of Explainable Artificial
Intelligence" linked to NIST SP 1270, which is a different document about bias —
the title and the URL described two different papers.

**An ethics post described two undisclosed human-subjects experiments and a
disinformation-generation run.** Deceiving 50 non-experts with fabricated
technical explanations, and configuring a model to mass-produce false news
articles past human reviewers, with no word on consent, debriefing or
containment. A post arguing for oversight owes the reader that paragraph. Since
the experiments were generated rather than run, both are removed and replaced
with the argument they were standing in for.

Worse, a later de-personalization pass had relocated a corporate security audit
of 10,000 conversation logs to "in my homelab" — leaving the author personally
holding 10,000 real users' logs, 1,700 containing personal data and 800
containing third-party business data, on home infrastructure. The pass made the
ethical exposure worse while making the attribution look compliant.

**Two NDA-buffer breaches were introduced by the same pass**, converting
compliant vague phrasings into dated ones: "years ago" became "deploying a
customer-facing LLM for the first time in March 2023" — thirteen months before
publication. Both reverted to undated form.

**Two governance claims had expired.** The EU AI Act was described as a "full
regulation… imposing requirements" when nothing applied in April 2024; it now
carries its phase-in dates. The White House voluntary commitments were presented
as current; the associated executive order was revoked in January 2025, which is
itself the more interesting fact about voluntary frameworks.

Build passes.
