### PR TITLE
posts: proxmox and grafana corrections, promsketch and claude-flow rewrites

### DIFF
--- a/src/posts/2025-08-07-supercharging-development-claude-flow.md
+++ b/src/posts/2025-08-07-supercharging-development-claude-flow.md
@@ -2,236 +2,86 @@
 
 author: William Zujkowski
 date: 2025-08-07
-description: Deploy Claude-Flow AI agent swarms for development—achieve 84.8% SWE-Bench solve rate with neural learning and multi-agent orchestration for complex tasks.
+description: "Claude-Flow orchestrates multiple AI agents against one task. What it does, what its published numbers actually are, and why the CLI in most write-ups never existed."
 title: 'Supercharging Development with Claude-Flow: AI Swarm Intelligence for Modern Engineering'
 tags:
   - ai
   - automation
-  - machine-learning
-  - open-source
-  - tutorial
+  - programming
 ---
-## From Solo Coding to Swarm Intelligence
+## From solo coding to swarm intelligence
 
+Single-agent coding assistants have a shape you learn quickly: they are excellent at the task in front of them and have no way to work on four things at once. The obvious next move is to run several, give them distinct roles, and have something coordinate them.
 
-I used Claude-Flow to refactor a complex microservices architecture. Instead of spending hours jumping between files solo, I spawned a swarm of specialized AI agents working in parallel. The researcher analyzed the codebase, the architect designed the solution, coders implemented changes, testers validated everything, and a coordinator ensured synchronization. 12 minutes later: 15 API endpoints, 147 tests at 98% coverage, complete OpenAPI docs, and JWT authentication.
-
-**Key takeaway:** AI swarm intelligence transforms development velocity when architectural boundaries are clear. Your mileage varies with project complexity.
+[Claude-Flow](https://github.com/ruvnet/ruflo) is one attempt at that. It's worth looking at, and it's worth being careful about the numbers attached to it — including the ones I originally quoted here.
 
 <div class="zine-doodle" aria-hidden="true" style="--doodle: url('/assets/doodles/claude-flow.png'); width: min(280px, 72%); aspect-ratio: 360/270; margin: 2rem auto 0.5rem;"></div>
-<p class="hand-note" style="text-align: center; display: block;">many streams, one current</p>
+<p class="hand-note" style="text-align: center; display: block;">many hands, one task</p>
 
-## What is Claude-Flow?
+## Where the headline numbers come from
 
-Claude-Flow is an AI orchestration framework bringing swarm intelligence to software development.
-Think of it as an entire development team at your fingertips—specialized AI agents working together instead of human developers.
+You will see three figures quoted about claude-flow, usually without attribution:
 
-If you're interested in [building an MCP standards server](/posts/2025-07-29-building-mcp-standards-server) or [supercharging Claude CLI](/posts/2025-07-22-supercharging-claude-cli-with-standards), Claude-Flow provides the orchestration layer making these tools work together.
+- **84.8% SWE-Bench solve rate**
+- **2.8–4.4x speed improvement**
+- **32.3% token reduction**
 
-Core capabilities:
+All three are the project's own README bullets. They appear verbatim in `ruvnet/claude-flow`'s README as of August 2025 — line 30 for the first two, lines 475–477 for all three. They are the vendor describing itself.
 
-- **Multi-agent orchestration**: 54+ specialized agents
-- **Parallel execution**: 2.8-4.4x speed improvements
-- **Neural training**: Learns from your codebase
-- **Memory persistence**: Context across sessions
-- **GitHub integration**: Automated workflows
-- **SPARC methodology**: Systematic development
+That does not make them false. It does mean they are not independent evidence, and they should not be repeated in a sentence that implies someone reproduced them. I have not reproduced them, and I have not seen a third-party reproduction.
 
-## The Architecture of Intelligence
+Two further cautions on the SWE-Bench figure specifically. It is quoted without saying **which** SWE-Bench — full, Verified, and Lite are different benchmarks with very different numbers, and a score is meaningless without naming one. And "solve rate on curated GitHub issues" is not the same quantity as "productivity on your codebase," which is the leap the number is usually asked to make.
 
-### Swarm Topologies
+## What it actually is
 
-Claude-Flow supports multiple swarm topologies, each optimized for different scenarios:
+Claude-Flow coordinates multiple Claude Code agents against a shared task, with a persistent memory store so context survives between them. The pieces:
 
+**Topologies.** Agents can be arranged hierarchically (a coordinator delegating to workers) or as a mesh (peers coordinating directly). Which one helps depends on whether your task decomposes cleanly — hierarchical for "build these five independent endpoints," mesh for work where the parts need to know about each other.
 
+**Persistent memory.** A store agents read and write across a session, so the researcher agent's findings are available to the coder agent without re-deriving them. This is the part that makes multi-agent work meaningfully different from running the same assistant several times.
 
-## System Architecture Overview
+**MCP tools.** The coordination surface is exposed as MCP tools the model calls — `swarm_init`, `agent_spawn`, `task_orchestrate`, `memory_persist`, and so on.
 
-<figure class="arch-fig">
-<div class="arch is-stack" role="group" aria-label="Claude-Flow swarm architecture">
-  <section class="arch-tier" data-label="Swarm Topologies" role="group" aria-label="Swarm Topologies"><span class="arch-chip">Mesh - P2P Collaboration</span><span class="arch-chip">Hierarchical - Queen/Worker</span><span class="arch-chip">Ring - Sequential Pipeline</span><span class="arch-chip">Star - Centralized Control</span></section>
-  <section class="arch-tier" data-label="Core Agents" role="group" aria-label="Core Agents"><span class="arch-chip is-primary">🎭 Orchestrator</span><span class="arch-chip">🔍 Researcher</span><span class="arch-chip">🏗️ Architect</span><span class="arch-chip">💻 Coder</span><span class="arch-chip">🧪 Tester</span></section>
-  <section class="arch-tier" data-label="Intelligence Layer" role="group" aria-label="Intelligence Layer"><span class="arch-chip is-guard">💾 Persistent Memory</span><span class="arch-chip is-guard">🧠 Neural Training</span><span class="arch-chip is-guard">🔄 Pattern Recognition</span></section>
-</div>
-<figcaption>Topology choices feed the orchestrator, which coordinates specialized agents and writes learning back into the intelligence layer.</figcaption>
-</figure>
+That last point is worth dwelling on, because it is the source of a persistent error. **Those are tool names for the model to invoke, not a shell CLI.** You will find write-ups — including an earlier version of this post — showing commands like `npx claude-flow swarm init --topology hierarchical` or `npx claude-flow agent spawn --type researcher`. Those are MCP tool identifiers mechanically converted from `snake_case` into `noun verb` form and given plausible-looking flags. They were never a command surface, and running them gets you nothing.
 
-**Swarm Initialization & Agent Spawning Examples:**
+The actual CLI is smaller and differently shaped: `swarm`, `hive-mind`, `memory`, `neural`, `github`, `sparc`, `health`, `bottleneck`. If a tutorial's commands map one-to-one onto a tool list, that is a strong signal nobody ran them.
 
-🔖 [Claude-Flow swarm initialization and agent spawning examples ↗](https://gist.github.com/williamzujkowski/2e8e787541c00d8650d83f6b9c53d03a)
+## Trying it
 
-[View complete examples on GitHub Gist](https://gist.github.com/williamzujkowski/2e8e787541c00d8650d83f6b9c53d03a)
+```bash
+# Note the @alpha. Bare `npx claude-flow` resolved to a different, older line.
+npx claude-flow@alpha init
+```
 
-## Real-World Example: Building a REST API
+Two things to weigh before wiring it in. An alpha dist-tag is unpinned and mutable — you get a different artifact each day — and adding it as an MCP server hands that moving target tool access inside your development environment. That is a reasonable thing to accept knowingly on a scratch project and an unreasonable thing to do by accident on anything you care about.
 
-I used Claude-Flow to build a complete REST API for a metrics dashboard in my homelab.
-The swarm followed SPARC methodology and the coordination patterns shown above.
+## What it's good and bad at
 
-### Results (12 Minutes)
+**Good at:** work that genuinely decomposes. Several independent endpoints, a test suite alongside an implementation, research-then-write pipelines where one agent gathers and another produces. The gains come from parallelism, so they are bounded by how parallel the task actually is.
 
-The swarm delivered:
+**Bad at:** anything with a tight feedback loop between parts. Coordination overhead is real, and for a task that is fundamentally one thing, several agents is slower and more expensive than one.
 
-- 15 API endpoints with full CRUD operations
-- 147 unit tests with 98% coverage
-- Complete OpenAPI documentation
-- JWT authentication
-- Rate limiting and input validation
-- Database migrations
-- Deployment-ready Docker configuration
+**A hazard worth naming:** orchestration loops without completion criteria. It is easy to write a "keep refining until quality is acceptable" loop where "acceptable" is judged by a model. That runs until you stop it, and every iteration costs tokens. Put an iteration cap on it, and make the exit condition something checkable — tests passing, a linter clean — rather than a judgement call.
 
-## Advanced Features That Change Everything
+## Where this has gone since
 
-### Neural Training, Memory & Performance
+Written in August 2025, and the ground has shifted enough that the specifics have expired.
 
-Claude-Flow provides advanced features for learning patterns, preserving context, and optimizing workflows:
+**The project has been renamed.** `ruvnet/claude-flow` now redirects to [`ruvnet/ruflo`](https://github.com/ruvnet/ruflo), and the install is `npx ruflo@latest`. Every `npx claude-flow …` invocation in older write-ups is dead at the first token.
 
-🔖 [Claude-Flow neural training, memory, and performance examples ↗](https://gist.github.com/williamzujkowski/be7284a8615d02d17a7de1140b07938b)
+**The problem it addresses is being absorbed.** Claude Code has since grown first-class subagents, skills, and hooks, which cover a good deal of what a separate orchestration layer was reaching for. That is the normal fate of a tool built to fill a gap: the gap closes.
 
-[View complete examples on GitHub Gist](https://gist.github.com/williamzujkowski/be7284a8615d02d17a7de1140b07938b)
-
-I was skeptical about neural training features.
-After training the model on my authentication patterns, it consistently suggested the same secure approaches I had manually implemented—learning my coding style and security preferences.
-
-Cross-session memory is invaluable when working across multiple days.
-Picking up exactly where I left off, with all context intact, saves hours of re-familiarization.
-
-But AI agents aren't magic.
-Early swarm deployments produced contradictory code when agents lacked clear coordination boundaries.
-Neural training requires clean input data—garbage in, garbage out still applies.
-Memory persistence adds overhead, and token costs scale with context size.
-
-
-
-## SPARC Development Methodology
-
-<div class="flow" role="group" aria-label="SPARC development methodology">
-  <div class="flow-node"><b>📋 Specification</b><i>Define Requirements</i></div>
-  <div class="flow-node"><b>🔢 Pseudocode</b><i>Design Algorithms</i></div>
-  <div class="flow-node"><b>🏛️ Architecture</b><i>System Structure</i></div>
-  <div class="flow-node"><b>🔧 Refinement</b><i>TDD &amp; Iteration</i></div>
-  <div class="flow-node is-good"><b>✅ Completion</b><i>Integration &amp; Deploy</i></div>
-</div>
-
-## Practical Use Cases
-
-Claude-Flow excels at complex workflows:
-
-**Security Audits:**
-The swarm parallel-processes dependency scans, code patterns, auth review, input validation, and encryption checks.
-
-**Database Migrations:**
-Zero-downtime migrations with rollback procedures.
-
-**Documentation Generation:**
-Comprehensive docs including API references, architecture diagrams, and deployment guides.
-
-## Performance Metrics
-
-Real measurements from production use:
-
-| Metric | Traditional | Claude-Flow | Improvement |
-|--------|------------|-------------|-------------|
-| Feature Implementation | 8 hours | 1.8 hours | 4.4x faster |
-| Test Coverage | 67% | 94% | +40% coverage |
-| Bug Detection | Post-deploy | Pre-commit | 100% earlier |
-| Code Review Time | 2 hours | 15 minutes | 8x faster |
-| Documentation | 3 hours | 20 minutes | 9x faster |
-
-## Best Practices, Common Patterns & Troubleshooting
-
-**Production-Ready Workflows:**
-
-🔖 [Claude-Flow production-ready workflow patterns ↗](https://gist.github.com/williamzujkowski/d7c84bb665d58245f9041d951873ed53)
-
-[View complete patterns on GitHub Gist](https://gist.github.com/williamzujkowski/d7c84bb665d58245f9041d951873ed53)
-
-In my testing, the review-loop pattern works well for iterative refinement.
-But it can over-optimize without clear completion criteria.
-
-## Getting Started
-
-**Installation & Configuration:**
-
-🔖 [Claude-Flow installation and configuration guide ↗](https://gist.github.com/williamzujkowski/325ab7edde18fdd562a8d8797eed466e)
-
-[View installation guide on GitHub Gist](https://gist.github.com/williamzujkowski/325ab7edde18fdd562a8d8797eed466e)
-
-## The Future of Development
-
-Claude-Flow represents a significant change in software development.
-Instead of linear, sequential coding, we're orchestrating intelligent agents working in parallel, learning from patterns, and continuously improving.
-
-Key takeaways:
-
-- **Swarm intelligence beats solo development**: Multiple specialized agents working in parallel outperform any single developer or AI
-- **Memory creates compounding value**: Every session builds on previous knowledge
-- **Automation enables creativity**: Let AI handle repetitive tasks while you focus on architecture and design
-- **Quality improves automatically**: Built-in review, testing, and validation agents ensure high standards
-
-## Real Impact
-
-Since adopting Claude-Flow:
-
-- **Development velocity**: 4.4x increase
-- **Bug reduction**: 73% fewer production issues
-- **Test coverage**: Consistent 90%+ coverage
-- **Documentation**: Always up-to-date
-- **Code quality**: Measurable improvements in maintainability
-- **Team satisfaction**: More time on interesting problems
-
-
+The durable idea is the one worth keeping. Multiple agents with distinct roles and shared memory is a real pattern, and the honest way to evaluate any implementation of it is to decompose one task you actually have, run it, and time it — rather than reading anyone's percentage, including the project's own.
 
 ## Sources
 
-### AI Agent Systems Research
-
-1. **[Swarm Intelligence: From Natural to Artificial Systems](https://academic.oup.com/book/8358)** (1999)
-   - Bonabeau, Dorigo, and Theraulaz - Foundational swarm intelligence principles
-   - *Oxford University Press*
-
-### Multi-Agent Coordination
-
-- **[JADE Framework](https://jade.tilab.com/)** - Java Agent Development Framework
-- **[Microsoft AutoGen](https://github.com/microsoft/autogen)** - Multi-agent conversation framework
-- **[LangChain Agents](https://python.langchain.com/docs/modules/agents/)** - LLM agent orchestration
-
-### Performance Benchmarks
-
-- **[SWE-bench](https://www.swebench.com/)** - Software engineering benchmark for LLMs
-- **[HumanEval](https://github.com/openai/human-eval)** - Code generation evaluation dataset
-
-### WebAssembly & SIMD Research
-
-1. **[Bringing the Web up to Speed with WebAssembly](https://dl.acm.org/doi/10.1145/3062341.3062363)** (2017)
-   - Haas et al. - WebAssembly design and implementation
-   - *ACM SIGPLAN*
-
-2. **[SIMD Everywhere](https://github.com/simd-everywhere/simde)** - Portable SIMD implementations
-
-### Key Statistics Sources
-
-- **Performance improvements (2.8-4.4x)**: Internal benchmarking against sequential execution
-- **Token reduction (32.3%)**: Measured across standard development tasks
-- **SWE-bench results**: Official leaderboard submissions
+- [ruvnet/ruflo](https://github.com/ruvnet/ruflo) — the project, formerly claude-flow. The 84.8% / 2.8–4.4x / 32.3% figures are its own README's
+- [SWE-bench](https://www.swebench.com/) — note the distinction between full, Verified and Lite
+- [Model Context Protocol](https://modelcontextprotocol.io/) — the tool interface claude-flow exposes its coordination through
+- Bonabeau, Dorigo & Theraulaz, *Swarm Intelligence: From Natural to Artificial Systems*, Oxford University Press / SFI Studies, 1999 (ISBN 0-19-513159-2) — where the biological metaphor comes from
 
 ## Conclusion
 
-Claude-Flow is a force multiplier that fundamentally changes how we build software.
-By orchestrating specialized AI agents in intelligent swarms, we tackle complexity that would overwhelm traditional approaches.
+Multi-agent orchestration is worth understanding, and worth being unsentimental about. It helps where work parallelises and hurts where it doesn't, the published numbers are self-reported, and the specific tooling turns over fast enough that a year-old tutorial is mostly archaeology.
 
-The beauty lies in augmenting developers, not replacing them.
-While the swarm handles implementation details, testing, and documentation, we focus on architecture, user experience, and solving business problems.
-
-Start small with a single agent.
-Experiment with different topologies.
-Gradually build your swarm intelligence.
-
-The future of development isn't about coding faster—it's about orchestrating intelligence to build better software.
-
-**Update:** I've since built [nexus-agents](/posts/2026-02-09-building-nexus-agents-multi-model-orchestration/), which takes multi-agent orchestration further with consensus voting across Claude, Gemini, and Codex, adaptive model routing backed by contextual bandits, and a research-backed pipeline architecture.
-
----
-
-*Want to dive deeper? Check out the [Claude-Flow repository](https://github.com/ruvnet/claude-flow) for advanced examples, contribute to the project, or share your swarm patterns with the community. The revolution in AI-assisted development is just beginning, and you can be part of shaping it.*
-
-*Questions about implementing Claude-Flow in your workflow? Reach out – I love discussing AI orchestration patterns and learning from different use cases!*
+The part that survives is the question you should ask of any of these: does this task actually decompose? If it does, several agents help. If it doesn't, no amount of orchestration will make it.

--- a/src/posts/2025-11-19-promsketch-prometheus-optimization.md
+++ b/src/posts/2025-11-19-promsketch-prometheus-optimization.md
@@ -1,233 +1,94 @@
 ---
-title: "PromSketch: 2-100x Faster Prometheus Queries with Sketch Algorithms"
-description: "Deploy PromSketch to optimize slow PromQL queries using sketch-based approximation. Homelab benchmarks show 2-100x speedup on percentile queries."
+title: "PromSketch: What Sketch Algorithms Can and Cannot Do for Prometheus"
+description: "PromSketch accelerates *_over_time window aggregations by compiling into Prometheus as a library. What it covers, what it doesn't, and why the distinction matters."
 author: "William Zujkowski"
 date: 2025-11-19
 tags: [prometheus, monitoring, observability, performance, grafana, homelab, optimization]
 post_type: tutorial
 ---
 
-# PromSketch: 2-100x Faster Prometheus Queries with Sketch Algorithms
+# PromSketch: What Sketch Algorithms Can and Cannot Do for Prometheus
 
-PromQL queries timeout on high-cardinality metrics, and mine had gotten to the point where the dashboard took longer to load than the incident it was supposed to help me diagnose. I spent 6 months debugging slow dashboard loads in my homelab Prometheus stack (2.8 million time series, all of them apparently offended by being asked for a percentile). PromSketch cut P99 percentile query time from 12.3 seconds to 180ms using sketch-based approximation.
+PromQL queries fall over on high-cardinality metrics, and the failure mode is familiar to anyone running a homelab Prometheus: the dashboard takes longer to load than the incident it was supposed to help diagnose. Every panel is a full scan over a window, every scan touches every matching series, and the cost grows with cardinality whether or not you actually needed sample-level precision.
 
-Here's how to deploy it and benchmark the speedup.
+[PromSketch](https://arxiv.org/abs/2505.10560) (PVLDB vol. 18) is a research answer to that. It is worth understanding precisely, because it is narrower than the pitch implies and the narrowness is the interesting part.
 
-<div class="zine-doodle" aria-hidden="true" style="--doodle: url('/assets/doodles/promsketch.png'); width: min(240px, 64%); aspect-ratio: 300/235; margin: 2rem auto 0.5rem;"></div>
-<p class="hand-note" style="text-align: center; display: block;">queries, but faster</p>
+<div class="zine-doodle" aria-hidden="true" style="--doodle: url('/assets/doodles/promsketch.png'); width: min(240px, 64%); aspect-ratio: 400/248; margin: 2rem auto 0.5rem;"></div>
+<p class="hand-note" style="text-align: center; display: block;">the shape kept, the detail dropped</p>
 
-## The Prometheus Query Bottleneck
+## What it actually is
 
-Prometheus stores time series data efficiently but struggles with aggregation queries over large cardinality. Percentile calculations (`histogram_quantile`) and rate computations scan millions of data points, causing dashboard timeouts.
+Not a proxy. Not a drop-in replacement. Not something you put between Grafana and Prometheus.
 
-**Common slow query patterns:**
+PromSketch is a **Go library you compile into a patched Prometheus** — the paper describes it as "a standalone module that can be integrated into Prometheus and VictoriaMetrics." The [upstream repository](https://github.com/ProjectASAP/promsketch) is source files and no server: no Dockerfile, no published image, no HTTP handler, no listening port. There is nothing to `docker run`.
 
-```promql
-# P99 latency across 500 services (timeout after 30s)
-histogram_quantile(0.99,
-  rate(http_request_duration_seconds_bucket[5m])
-)
+This matters because the obvious mental model — a caching layer you drop in front of your existing stack — is wrong in a way that wastes an afternoon. If you want to try it, you are building a patched Prometheus from source, and that is the actual cost of adoption.
 
-# Memory usage aggregation (12.3s query time)
-sum(container_memory_usage_bytes) by (namespace, pod)
+## The function set is the whole story
+
+PromSketch does not accelerate PromQL generally. It accelerates a specific, enumerable list of window aggregations, and its dispatch table is the honest documentation:
+
+```go
+var funcSketchMap = map[string]([]SketchType){
+	"avg_over_time":      {USampling},
+	"count_over_time":    {USampling},
+	"entropy_over_time":  {EHUniv},
+	"max_over_time":      {EHKLL},
+	"min_over_time":      {EHKLL},
+	"stddev_over_time":   {USampling},
+	"stdvar_over_time":   {USampling},
+	"sum_over_time":      {USampling},
+	"sum2_over_time":     {USampling},
+	"distinct_over_time": {EHUniv},
+	"l1_over_time":       {EHUniv},
+	"l2_over_time":       {EHUniv},
+	"quantile_over_time": {EHKLL},
+}
 ```
 
-**Why this happens:**
+Read what is *not* in that map. No `rate`. No `histogram_quantile` — the string appears nowhere in the codebase. No `sum … by`, no `topk`, no `count`, no `avg`.
 
-- **Cardinality explosion:** Labels multiply time series (10 services × 50 pods × 20 metrics = 10,000 series)
-- **Histogram buckets:** Each histogram creates 10-20 time series (one per bucket)
-- **Aggregation cost:** PromQL scans all matching series before calculating percentiles
+That rules out most of what a typical Grafana dashboard is made of. The canonical slow panel — `histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))` — is untouched by PromSketch, because every function in it is outside the set. If your dashboards are built the usual way on histogram buckets and `rate`, this tool does nothing for them.
 
-**Impact:** Grafana dashboards load in 45-60 seconds. Alerting rules timeout. Users abandon slow-loading metrics.
+Where it does apply is single-series window statistics over long ranges: `quantile_over_time` on a raw latency gauge, `distinct_over_time` for cardinality estimates, `entropy_over_time` for distribution shift. Those are genuinely expensive and genuinely sketchable.
 
-## PromSketch: Sketch-Based Query Optimization
+## The algorithms, correctly named
 
-PromSketch sits between Grafana and Prometheus as a caching proxy. It uses probabilistic data structures (sketches) to approximate aggregation results with 2-100x speedup.
+Quantiles go through **EHKLL** — an Exponential Histogram wrapping a KLL sketch — not DDSketch. There is a DDSketch variant in the source but it is commented out (`// ehdd *ExpoHistogramDD`), which is a useful reminder that reading a paper's related-work section is not the same as reading its code.
 
-**Architecture:**
+The exponential histogram is the part that earns its keep. Sliding-window aggregation normally means either keeping every sample in the window or recomputing from scratch; an EH keeps buckets at exponentially increasing age granularity, so old data is summarised coarsely and recent data finely, at logarithmic space in the window length. The KLL sketch then answers rank queries within that structure.
 
-<div class="flow" role="group" aria-label="PromSketch query optimization path">
-  <div class="flow-node">Grafana Dashboard</div>
-  <div class="flow-node">PromSketch Proxy</div>
-  <div class="flow-node">Query Optimizer</div>
-  <div class="flow-node is-gate">Sketch-eligible?</div>
-  <div class="flow-branch" role="group" aria-label="Branch outcomes">
-    <div class="flow-leg" data-branch="Yes" role="group" aria-label="Yes"><div class="flow-node is-good"><b>Sketch Cache</b><i>approximation</i></div></div>
-    <div class="flow-leg" data-branch="No" role="group" aria-label="No"><div class="flow-node"><b>Prometheus</b><i>exact data</i></div></div>
-  </div>
-  <div class="flow-node is-good">Fast Result</div>
-  <div class="flow-node"><b>Background Sketch Builder</b><i>Prometheus updates cache</i></div>
-</div>
+**Count-Min Sketch** shows up in this family too, and it is worth being precise about its guarantee, because it is routinely overstated. CMS uses O((1/ε)·log(1/δ)) space — **independent of stream length**, not `O(log n)` — and gives a *one-sided additive overestimate* bounded by εN with probability 1−δ. It never undercounts and it has no multiplicative error bound. "Under 1% error" is not a thing CMS promises.
 
-**How it works:**
+## What accuracy you are trading
 
-1. **Query interception:** PromSketch parses incoming PromQL queries
-2. **Sketch eligibility:** Identifies queries suitable for approximation (percentiles, histograms, counts)
-3. **Cache lookup:** Checks if sketch exists for metric/time range
-4. **Approximation:** Returns sketch-based result (sub-second response)
-5. **Fallback:** Exact queries pass through to Prometheus
+The paper reports **at most 5% average error** across the statistics it evaluates, against speedups of up to two orders of magnitude. Take the 5% seriously rather than assuming the good case: an approximate P99 that is 5% off is fine for a dashboard trend line and is not fine for an SLO you are paying out against.
 
-**Why this works:** Percentile queries don't need exact results. "P99 latency = 250ms" is accurate enough whether real value is 247ms or 253ms. Sketch algorithms trade 1-2% accuracy for 100x speed.
+The general shape of the trade: sketches are the right tool when you are looking at a curve, and the wrong tool when a specific number has consequences. Most dashboards are the former and most alerts are the latter, which suggests keeping exact queries in the alerting path even if you sketch the visualisation.
 
-## Sketch Algorithms Explained
+## Cheaper things to try first
 
-PromSketch uses two probabilistic data structures:
+PromSketch is a research prototype under GPL-3.0 that requires building Prometheus from source. Before that, the boring options usually win:
 
-**1. Count-Min Sketch (CMS)** for frequency estimation
+**Recording rules.** The most under-used feature in Prometheus. A recording rule evaluates an expensive expression on the scrape interval and writes the result as a new series — so the dashboard queries one pre-computed series instead of aggregating thousands at render time. The storage cost is one series per rule, which is kilobytes, and it works today with no patched binary. If your dashboards are slow and you have not done this, do this.
 
-- **Use case:** Counting occurrences (request rates, error counts)
-- **Memory:** O(log n) space, constant time updates
-- **Accuracy:** <1% error with 99% confidence
-- **Paper:** [Cormode & Muthukrishnan, 2005](https://doi.org/10.1016/j.jalgor.2003.12.001)
+**Reduce cardinality at the source.** Most high-cardinality problems are a label that should never have existed — a request ID, a full URL path, a pod name in a metric that outlives the pod. `metric_relabel_configs` at scrape time is cheaper than any query-side optimisation, because the samples never get written.
 
-**2. DDSketch** for quantile approximation
+**Thanos or Cortex downsampling**, if you already run them. Worth correcting a common misconception: downsampling *adds* 5m and 1h resolutions alongside the raw blocks — it does not delete your recent data. The cost is extra storage and a multi-component deployment, not lost fidelity.
 
-- **Use case:** Percentile calculations (P50, P95, P99 latencies)
-- **Memory:** Fixed-size buckets (1-10KB per metric)
-- **Accuracy:** Relative error <2% across all quantiles
-- **Paper:** [Masson et al., 2019](https://arxiv.org/abs/1908.10693)
+**VictoriaMetrics**, which the PromSketch paper itself uses as an integration target and which is substantially more storage-efficient than Prometheus before any sketching is involved.
 
-**Example:** DDSketch stores histogram in logarithmically-spaced buckets. Query for P99 latency scans ~50 buckets instead of 2.8 million time series.
+## Where this leaves it
 
-## Homelab Deployment: Docker Stack
+Sketch-based approximation is a real idea with a real implementation behind a real paper, and it is aimed at a narrower target than the framing usually suggests: long-window statistics over individual series, in a patched binary you build yourself, at up to 5% error.
 
-I deployed PromSketch in my homelab using Docker Compose. It sits between Grafana and Prometheus with zero configuration changes to either component.
-
-**System requirements:**
-
-- Docker 24+
-- 2GB RAM for PromSketch container
-- Prometheus 2.40+ (tested on 2.47.0)
-- Grafana 9.0+ (tested on 10.2.0)
-
-**Docker Compose stack:** https://gist.github.com/williamzujkowski/7e50a6d67d50b5a940b2254a17286942
-
-```bash
-# Deploy stack
-docker-compose up -d
-
-# Verify PromSketch health
-curl http://localhost:9091/health
-```
-
-**Configuration:** PromSketch auto-detects sketch-eligible queries. No manual tuning required for basic setup.
-
-**Deployment took 8 minutes** (download images, start containers, build initial sketches from last 24h of metrics).
-
-## Benchmark Results: 2-100x Speedup
-
-I benchmarked 10 common PromQL queries before and after PromSketch deployment:
-
-| Query Type | Baseline (Prometheus) | PromSketch | Speedup |
-|------------|----------------------|------------|---------|
-| P99 histogram_quantile | 12.3s | 180ms | **68x** |
-| sum(rate) by pod | 4.7s | 95ms | **49x** |
-| topk(10, container_memory) | 8.1s | 320ms | **25x** |
-| count(up) by namespace | 2.3s | 45ms | **51x** |
-| histogram_quantile(0.95) | 9.4s | 87ms | **108x** |
-| avg(node_cpu) by instance | 1.9s | 890ms | **2.1x** |
-
-**Key results:**
-
-- **Percentile queries:** 68-108x speedup (DDSketch optimization)
-- **Aggregations:** 25-51x speedup (CMS + caching)
-- **Simple queries:** 2-3x speedup (overhead from proxy, still faster than timeout)
-
-**Accuracy verification:** I compared PromSketch approximations to exact Prometheus results. Relative error: 0.8-1.9% across all queries. Dashboard showed same trends, slightly different decimal places.
-
-**Benchmark script:** https://gist.github.com/williamzujkowski/1d827beed3727ae6992e65c782c56776
-
-## Grafana Integration
-
-PromSketch works as a drop-in Prometheus replacement. I pointed Grafana at PromSketch URL instead of Prometheus:
-
-**Before:**
-```yaml
-# Grafana datasource
-url: http://prometheus:9090
-```
-
-**After:**
-```yaml
-# Grafana datasource
-url: http://promsketch:9091
-```
-
-**Dashboard query examples:** https://gist.github.com/williamzujkowski/412c4496eeda98bcfe9fc868f7aebbad
-
-**Result:** Dashboards load in 2-4 seconds (down from 45-60s). Users no longer abandon slow-loading metrics pages.
-
-## Memory Savings
-
-Sketches consume less memory than raw time series:
-
-- **Prometheus storage:** 2.8 million series × 8 bytes/sample × 15 days retention = 46.7GB
-- **PromSketch cache:** 1,200 unique metrics × 8KB/sketch = 9.4MB
-- **Compression ratio:** 4,814:1
-
-**Why this matters:** I run Prometheus on a 64GB RAM server. Before PromSketch, queries consumed 12-18GB RAM during aggregation. After PromSketch, peak RAM usage: 3.2GB.
-
-## Limitations and Trade-Offs
-
-**Challenge 1: Approximation vs exactness**
-
-- **Trade-off:** 1-2% error acceptable for monitoring, not for billing
-- **When to use:** Dashboards, alerts, capacity planning
-- **When NOT to use:** Financial metrics, SLA calculations, audit logs
-
-**Challenge 2: Cold cache performance**
-
-- **Problem:** First query after restart takes 8-12s (builds sketch from Prometheus)
-- **Mitigation:** Pre-warm cache on startup (background job scans last 24h)
-- **Impact:** Dashboard loads slow for ~2 minutes after PromSketch restart — a brief, humbling return to the world you were trying to leave
-
-**Challenge 3: Custom aggregations**
-
-- **Limitation:** PromSketch optimizes common patterns (percentiles, sums, rates)
-- **Unsupported:** Custom PromQL functions, joins, complex subqueries
-- **Fallback:** Unsupported queries pass through to Prometheus (no speedup)
-
-**What I learned:** Start with percentile queries (biggest speedup). Expand to aggregations after validating accuracy. Monitor sketch cache hit rate (should be >80% for effective optimization).
-
-## Comparison: PromSketch vs Alternatives
-
-| Solution | Query Speedup | Memory Overhead | Accuracy | Setup Complexity |
-|----------|---------------|-----------------|----------|------------------|
-| PromSketch | 2-100x | 9.7MB (sketches) | 98-99% | Low (proxy) |
-| Prometheus recording rules | 5-10x | GB (pre-aggregated) | 100% | High (rule management) |
-| Thanos/Cortex downsampling | 3-8x | GB (downsampled data) | 95-100% | High (multi-component) |
-| VictoriaMetrics | 2-5x | Similar to Prom | 100% | Medium (migration) |
-
-**Why PromSketch fills gaps:** Recording rules require manual configuration. Downsampling loses recent data. VictoriaMetrics needs migration. PromSketch works immediately with existing setup.
+If your slow queries are `quantile_over_time` over hours of raw samples, this is aimed directly at you. If they are `histogram_quantile` over `rate` of bucket series — which is how most people write them — it is not, and no amount of deployment effort will change that. Checking which of those you have takes about a minute and saves the afternoon.
 
 ## Further Reading
 
-**Research paper:** [Approximation-First Timeseries Monitoring Query At Scale](https://arxiv.org/abs/2505.10560) (arXiv:2505.10560, VLDB 2025)
-
-**Algorithm foundations:**
-- [Count-Min Sketch](https://doi.org/10.1016/j.jalgor.2003.12.001) (Cormode & Muthukrishnan, 2005)
-- [DDSketch](https://arxiv.org/abs/1908.10693) (Masson et al., 2019)
-
-**Prometheus documentation:**
-- [PromQL query performance](https://prometheus.io/docs/prometheus/latest/querying/basics/)
-- [Recording rules](https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/)
-
-**Related research:**
-- [Gorilla TSDB compression](https://www.vldb.org/pvldb/vol8/p1816-teller.pdf) (VLDB 2015)
-- [OpenTelemetry metrics](https://opentelemetry.io/docs/specs/otel/metrics/)
-
-**Implementation:**
-- [PromSketch GitHub](https://github.com/vldb/promsketch) (research prototype)
-- [Datadog DDSketch](https://github.com/DataDog/sketches-py)
-
-**Docker Compose stack:** https://gist.github.com/williamzujkowski/7e50a6d67d50b5a940b2254a17286942
-
-**Benchmark script:** https://gist.github.com/williamzujkowski/1d827beed3727ae6992e65c782c56776
-
-**Grafana queries:** https://gist.github.com/williamzujkowski/412c4496eeda98bcfe9fc868f7aebbad
-
----
-
-**Try it yourself.** Benchmark your slowest PromQL queries. Deploy PromSketch as a proxy. Measure speedup on percentile calculations.
-
-Your mileage may vary. High-cardinality metrics benefit most. Low-cardinality queries see minimal speedup. Accuracy trades 1-2% precision for 100x speed.
+- [PromSketch: Efficient and Accurate Sketch-based Query Serving for Metric Monitoring](https://arxiv.org/abs/2505.10560) — the paper, PVLDB vol. 18
+- [ProjectASAP/promsketch](https://github.com/ProjectASAP/promsketch) — the implementation (GPL-3.0)
+- [An Improved Data Stream Summary: The Count-Min Sketch and its Applications](https://doi.org/10.1016/j.jalgor.2003.12.001) — Cormode & Muthukrishnan
+- [DDSketch: A Fast and Fully-Mergeable Quantile Sketch with Relative-Error Guarantees](https://arxiv.org/abs/1908.10693) — Masson, Rim & Lee
+- [Gorilla: A Fast, Scalable, In-Memory Time Series Database](https://www.vldb.org/pvldb/vol8/p1816-teller.pdf) — the compression scheme Prometheus's TSDB descends from
+- [Prometheus recording rules](https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/) — do this first

--- a/src/posts/2025-12-10-homelab-security-dashboard-grafana-prometheus.md
+++ b/src/posts/2025-12-10-homelab-security-dashboard-grafana-prometheus.md
@@ -73,14 +73,14 @@ First, install Prometheus. I run it containerized for consistency:
 
 ```yaml
 # docker-compose.yml
-version: '3.8'
 services:
   prometheus:
-    image: prom/prometheus:v2.48.0
+    image: prom/prometheus:v3.6.0
     ports:
-      - "9090:9090"
+      - "127.0.0.1:9090:9090"    # Prometheus has no auth; do not publish it
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./rules:/etc/prometheus/rules:ro
       - prometheus_data:/prometheus
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
@@ -106,7 +106,7 @@ global:
   evaluation_interval: 30s
 
 rule_files:
-  - "security_rules.yml"
+  - "/etc/prometheus/rules/*.yml"
 
 scrape_configs:
   # System metrics
@@ -141,8 +141,8 @@ import time
 from prometheus_client import start_http_server, Counter, Histogram
 
 ssh_auth_attempts = Counter('ssh_auth_attempts_total',
-                           'SSH authentication attempts',
-                           ['result', 'source_ip', 'username'])
+                            'SSH authentication attempts',
+                            ['result', 'username_class'])   # NOT source_ip
 
 def parse_auth_log():
     # Tail /var/log/auth.log for SSH events
@@ -170,12 +170,19 @@ Uses iptables logging to track dropped packets:
 
 ```bash
 # Enable iptables logging
-iptables -A INPUT -j LOG --log-prefix "IPTABLES-DROP: " --log-level 4
+# Log only what is about to be dropped, and rate-limit it. An unconditional
+# `-j LOG` on INPUT logs accepted traffic too, drops nothing despite the prefix,
+# and lets anyone who can send you packets fill your disk at line rate.
+iptables -N LOGDROP
+iptables -A LOGDROP -m limit --limit 5/min --limit-burst 10 \
+         -j LOG --log-prefix "IPTABLES-DROP: " --log-level 4
+iptables -A LOGDROP -j DROP
+iptables -A INPUT -j LOGDROP        # as the LAST rule in INPUT
 
 # Custom exporter parses /var/log/kern.log for patterns
 ```
 
-I tested this approach by running Nmap scans against my firewall. Custom exporter caught 847 dropped packets in 30 seconds. Standard monitoring showed "network interface active" - useless for security.
+I tested this approach by running Nmap scans against my firewall. The exporter picked the scan up immediately. Standard monitoring showed "network interface active" - useless for security.
 
 ## Grafana Dashboard Design
 
@@ -211,8 +218,8 @@ My main security dashboard has 6 panels:
 rate(ssh_auth_attempts_total{result="failed"}[5m])
 
 # Successful logins outside business hours
-ssh_auth_attempts_total{result="success"}
-  and on() hour() < 8 or hour() > 18
+increase(ssh_auth_attempts_total{result="success"}[5m]) > 0
+  and on() (hour() < 13 or hour() > 23)
 
 # Brute force detection (>10 failures in 5 minutes)
 rate(ssh_auth_attempts_total{result="failed"}[5m]) > 0.033
@@ -221,9 +228,9 @@ rate(ssh_auth_attempts_total{result="failed"}[5m]) > 0.033
 **Network Security Metrics:**
 ```promql
 # Port scan detection (multiple unique destination ports)
-count by (source_ip)
-  (count by (source_ip, destination_port)
-    (iptables_drops_total[5m]))
+count by (source_ip) (
+  count by (source_ip, destination_port) (
+    increase(iptables_drops_total[5m]) > 0))
 
 # DNS exfiltration patterns (large query sizes)
 histogram_quantile(0.95,
@@ -319,7 +326,7 @@ groups:
 
 **Detection logic:**
 - **Port scans:** 10+ unique ports in 5 minutes from single source
-- **DNS exfiltration:** Average query size >1KB (normal DNS queries ~100 bytes)
+- **DNS exfiltration:** tunnelling does not make queries *big* — it cannot, since RFC 1035 caps a domain name at 255 octets, which puts a hard ceiling of roughly 271 bytes on a query. It makes them *numerous* and *weird*. Alert on queries per second to one second-level domain, and on the ratio of unique labels to total queries
 
 ### Alert Fatigue Prevention
 
@@ -339,9 +346,11 @@ groups:
   <div class="flow-node">Deduplicate - 12h repeat interval</div>
 </div>
 
-**The problem:** Too many alerts = ignored alerts. I started with 23 different alert rules. Average: 15 alerts per day. Response rate: 30%.
+**The problem:** too many alerts means ignored alerts. I started with far more rules than I could act on, and the response rate fell accordingly.
 
-**The solution:** Ruthless prioritization. Current rules: 8 total alerts. Average: 2 per day. Response rate: 95%.
+**The solution:** ruthless prioritisation, down to a handful of rules I actually respond to.
+
+Worth being honest about what that trade buys, though, because "response rate went up" is a flattering way to measure it. Cutting the rule set raises the percentage of alerts you act on partly by removing alerts. The metric that matters is incidents caught, not alerts clicked — and I do not have a clean way to measure the ones I no longer hear about. The case for pruning is that an alert stream nobody reads catches nothing at all, not that the percentage improved.
 
 **Rules for effective alerting:**
 1. **Critical = actionable immediately** (SSH brute force, service outage)
@@ -358,12 +367,15 @@ route:
   repeat_interval: 12h
   receiver: 'homelab-security'
   routes:
-    - match:
-        severity: critical
+    - matchers: [ severity="critical" ]
       receiver: 'immediate-notify'
-    - match:
-        severity: warning
+    - matchers: [ severity="warning" ]
       receiver: 'hourly-summary'
+      # Child routes INHERIT the parent's group_interval. Without these two
+      # lines the "hourly" summary batches every 5 minutes, and the receiver's
+      # name is the only hourly thing about it.
+      group_interval: 1h
+      repeat_interval: 24h
 
 receivers:
   - name: 'immediate-notify'
@@ -397,7 +409,7 @@ receivers:
 
 **Timeline:** Several months ago
 
-**Detection:** Unusual DNS query patterns (1,200 byte average vs 95 byte baseline)
+**Detection:** an unusual volume of long, high-entropy subdomains under a single parent zone
 
 **Root cause:** Compromised IoT device attempting data exfiltration via DNS queries
 
@@ -435,8 +447,8 @@ I integrated threat intelligence feeds to enrich dashboard data:
 
 ```python
 # Custom exporter: threat_intel.py
+import os
 import requests
-import json
 
 # Check IPs against AbuseIPDB
 def check_threat_intel(ip_address):
@@ -448,7 +460,7 @@ def check_threat_intel(ip_address):
 
     if response.status_code == 200:
         data = response.json()
-        confidence = data.get('abuseConfidencePercentage', 0)
+        confidence = data['data']['abuseConfidenceScore']
         return confidence
     return 0
 
@@ -458,12 +470,21 @@ threat_score = Gauge('ip_threat_confidence',
                     ['ip_address'])
 ```
 
+**Fail closed, not open.** The version of this I first wrote returned `0` on
+every non-200 response. That looks harmless and is not: AbuseIPDB's free tier
+caps at 1,000 checks a day, and a homelab under routine SSH scanning burns
+through that before lunch. From the first 429 onward, every attacker IP scored
+zero — a clean bill of health produced by a rate limit. Same for an expired key,
+same for a DNS blip. Let the exception propagate and alert on the gap; a threat
+feed that reports "benign" when it cannot answer is worse than no feed, because
+you will believe it.
+
 **Integration result:** SSH authentication attempts now show threat intelligence scores. 203.0.113.50 with 95% abuse confidence = immediate concern. 192.168.1.100 with 0% = likely legitimate.
 
 **Grafana panel:**
 ```promql
-ssh_auth_attempts_total
-  * on(source_ip) group_left(threat_score)
+rate(ssh_auth_attempts_total{result="failed"}[5m])
+  * on(source_ip) group_left()
   ip_threat_confidence
 ```
 
@@ -520,9 +541,9 @@ Built secondary dashboard correlating multiple data sources:
 **PromQL example:**
 ```promql
 # Correlate SSH failures with port scans
-(ssh_auth_attempts_total{result="failed"} > 0)
+(increase(ssh_auth_attempts_total{result="failed"}[10m]) > 5)
   and on(source_ip)
-(iptables_drops_total > 0)
+(increase(iptables_drops_total[10m]) > 20)
 ```
 
 This correlation detected 3 sophisticated attacks that single-metric alerts missed.
@@ -533,12 +554,12 @@ This correlation detected 3 sophisticated attacks that single-metric alerts miss
 
 My homelab generates significant metrics:
 - **Raw samples:** 2.1M per day
-- **Storage space:** 450MB per week
+- **Storage space:** Prometheus compresses to roughly 1-2 bytes per sample, so the weekly figure follows directly from the sample rate — work it out from your own `rate(prometheus_tsdb_head_samples_appended_total[5m])` rather than trusting anyone's number, including mine
 - **Query latency:** P95 < 200ms
 
 **Optimization strategies:**
 1. **Recording rules** for expensive queries
-2. **Retention policies** (7 days high-res, 90 days downsampled)
+2. **Retention** — flat, and that is the only option. Prometheus has no downsampling and no tiered resolution; `--storage.tsdb.retention.time` is a single number. A high-res/low-res split needs Thanos or Mimir in front of it, which is more moving parts than most homelabs earn
 3. **Metric filtering** (drop irrelevant labels)
 
 **Recording rule example:**
@@ -637,7 +658,7 @@ Each quarter builds on previous foundation. Don't try to implement everything im
 - Machine learning anomaly detection (required constant tuning)
 - Real-time streaming (batch processing sufficient for homelab scale)
 
-**ROI validation:** 3 compromise attempts detected and contained. Estimated damage prevention: $500+ (cryptocurrency theft) + countless hours of remediation.
+**ROI validation:** 3 compromise attempts detected and contained. Damage prevented: honestly, pennies. A miner on a homelab VM earns cents a day, and this one ran for four minutes. The value was not the mining revenue denied — it was learning that a WordPress plugin had given someone code execution on a box that could see the rest of the VLAN + countless hours of remediation.
 
 Time investment: 20 hours setup, 2 hours monthly maintenance.
 

--- a/src/posts/2025-12-24-private-cloud-homelab-proxmox-security.md
+++ b/src/posts/2025-12-24-private-cloud-homelab-proxmox-security.md
@@ -31,17 +31,17 @@ My setup runs on a single Dell R910:
 - 256GB RAM
 - 4x Intel Xeon E7540 (24 cores/48 threads total)
 - ~400GB mixed storage (LVM for OS + ZFS pool for VMs/data)
-- Backed by TrueNAS Core with ~30TB usable storage (RAIDZ2)
+- Backed by TrueNAS SCALE with ~30TB usable storage (RAIDZ2)
 
 This single node handles 30+ VMs and containers comfortably. With 256GB RAM, careful resource allocation is key, but it's more than sufficient for a full-featured homelab. Uptime averages 99.7% - better than some cloud providers I've used.
 
 <figure class="arch-fig">
 <div class="arch" role="group" aria-label="Private cloud physical architecture">
-  <section class="arch-tier" data-label="Dell R910" role="group" aria-label="Dell R910"><span class="arch-chip is-primary"><b>Proxmox VE Host</b><i>4x Xeon E7540, 256GB RAM</i></span><span class="arch-chip">30+ VMs</span><span class="arch-chip">LXC Containers</span><span class="arch-chip">ZFS Pool - OS + VM Storage</span><span class="arch-chip">12TB HDD - Bulk Storage</span></section>
+  <section class="arch-tier" data-label="Dell R910" role="group" aria-label="Dell R910"><span class="arch-chip is-primary"><b>Proxmox VE Host</b><i>4x Xeon E7540, 256GB RAM</i></span><span class="arch-chip">30+ VMs</span><span class="arch-chip">LXC Containers</span><span class="arch-chip">ZFS Pool - OS + VM Storage</span></section>
   <section class="arch-tier" data-label="Network - Ubiquiti" role="group" aria-label="Network - Ubiquiti"><span class="arch-chip is-guard">UDM Pro - Firewall / Router</span><span class="arch-chip">UniFi Switch 24 PoE</span></section>
-  <section class="arch-tier" data-label="Storage Server" role="group" aria-label="Storage Server"><span class="arch-chip is-primary"><b>TrueNAS Core</b><i>~30TB usable, RAIDZ2</i></span></section>
+  <section class="arch-tier" data-label="Storage Server" role="group" aria-label="Storage Server"><span class="arch-chip is-primary"><b>TrueNAS SCALE</b><i>~30TB usable, RAIDZ2</i></span></section>
 </div>
-<figcaption>Proxmox manages compute locally, connects to Ubiquiti for management and VM traffic, and uses TrueNAS over 10GbE iSCSI for shared storage.</figcaption>
+<figcaption>Proxmox manages compute locally, connects to Ubiquiti for management and VM traffic, and uses TrueNAS over iSCSI for shared storage.</figcaption>
 </figure>
 
 ### Storage Architecture That Actually Works
@@ -54,19 +54,19 @@ Proxmox supports multiple storage backends. I tested five configurations over 12
 
 **ZFS over iSCSI:** My current solution. TrueNAS SCALE provides the storage, Proxmox consumes it via iSCSI. Reliable, fast enough, manageable complexity.
 
-**GlusterFS:** Network filesystem that seemed promising. Performance was inconsistent - VMs would randomly stutter during file operations.
+**GlusterFS:** worth noting this option has since gone away — it is archived upstream and no longer appears in the PVE storage table at all. At the time it seemed promising. Performance was inconsistent - VMs would randomly stutter during file operations.
 
-**NFS:** Works but lacks features. No snapshots, limited backup options.
+**NFS:** the most feature-complete of the lot, actually — PVE supports images, containers, templates, ISOs, backups and snippets on it, with snapshots on qcow2 images. It is file-level, so raw-image performance lags block storage.
 
-**Winner:** ZFS over iSCSI. My TrueNAS Core server provides ~30TB usable storage (from 40TB raw) with RAIDZ2 protection. Proxmox sees it as shared block storage, perfect for VM disks and backups.
+**Winner for VM disks:** ZFS over iSCSI. Note its content types are `images, rootdir` only — you cannot put backups, ISOs or templates on it, so you still need a file-level target alongside. My TrueNAS SCALE server provides ~30TB usable storage (from 40TB raw) with RAIDZ2 protection. Proxmox sees it as shared block storage, perfect for VM disks and backups.
 
 <figure class="arch-fig">
 <div class="arch" role="group" aria-label="Proxmox storage architecture">
   <section class="arch-tier" data-label="Proxmox Host" role="group" aria-label="Proxmox Host"><span class="arch-chip is-primary">Proxmox VE</span></section>
-  <section class="arch-tier" data-label="Local Storage" role="group" aria-label="Local Storage"><span class="arch-chip"><b>ZFS Pool</b><i>VM disks, fast</i></span><span class="arch-chip"><b>12TB HDD</b><i>bulk / ISOs</i></span></section>
-  <section class="arch-tier" data-label="Network Storage" role="group" aria-label="Network Storage"><span class="arch-chip is-primary">TrueNAS Core</span><span class="arch-chip is-guard"><b>RAIDZ2 Pool</b><i>40TB raw to 30TB usable</i></span></section>
+  <section class="arch-tier" data-label="Local Storage" role="group" aria-label="Local Storage"><span class="arch-chip"><b>ZFS Pool</b><i>VM disks, fast</i></span></section>
+  <section class="arch-tier" data-label="Network Storage" role="group" aria-label="Network Storage"><span class="arch-chip is-primary">TrueNAS SCALE</span><span class="arch-chip is-guard"><b>RAIDZ2 Pool</b><i>40TB raw to 30TB usable</i></span></section>
 </div>
-<figcaption>Proxmox uses local disks directly and reaches the TrueNAS RAIDZ2 pool over 10GbE iSCSI.</figcaption>
+<figcaption>Proxmox uses local disks directly and reaches the TrueNAS RAIDZ2 pool over iSCSI.</figcaption>
 </figure>
 
 ### Network Segmentation Strategy
@@ -125,18 +125,34 @@ Standard Proxmox installation is reasonably secure. But "reasonably secure" isn'
 ```bash
 # Create admin user
 useradd -m -s /bin/bash proxmox-admin
-usermod -aG sudo proxmox-admin
+install -d -m700 -o proxmox-admin ~proxmox-admin/.ssh
+# Put your public key in ~proxmox-admin/.ssh/authorized_keys BEFORE going on.
+# A fresh account has no password and no key: it cannot log in by either route.
 
-# Disable root SSH
-sed -i 's/PermitRootLogin yes/PermitRootLogin no/' /etc/ssh/sshd_config
-systemctl restart ssh
+# PVE does not ship sudo. usermod against a group with no sudoers entry
+# succeeds silently and grants nothing.
+apt install -y sudo && usermod -aG sudo proxmox-admin
+
+# In a SECOND terminal, prove it works before you close the door:
+#   ssh proxmox-admin@host sudo -v
+
+# Match commented and uncommented forms. A literal 's/PermitRootLogin yes/'
+# no-ops if the directive is commented or lives in an sshd_config.d/ drop-in.
+sed -i 's/^#\?PermitRootLogin.*/PermitRootLogin no/' /etc/ssh/sshd_config
+sshd -t && systemctl restart ssh
 ```
 
 **Enable fail2ban:** Protects against brute force attacks.
 
 ```bash
 apt update && apt install fail2ban
-systemctl enable fail2ban
+systemctl enable --now fail2ban     # without --now it waits for the next boot
+
+# Debian's default jails cover sshd ONLY. The Proxmox web UI on 8006
+# authenticates through pvedaemon and needs its own jail, matching
+#   pvedaemon\[.*authentication failure; rhost=<HOST>
+# Given that this whole setup routes admins to the web UI, that is the one
+# door stock fail2ban is not watching.
 ```
 
 **Configure automatic updates:** Security patches matter more than uptime.
@@ -144,6 +160,17 @@ systemctl enable fail2ban
 ```bash
 apt install unattended-upgrades
 dpkg-reconfigure -plow unattended-upgrades
+
+# Debian's shipped Origins-Pattern matches ONLY the Debian security origin.
+# The Proxmox repos are a different origin, so pve-kernel, pve-manager,
+# qemu-server and pve-qemu-kvm are NEVER upgraded by the default config.
+# Add it explicitly in /etc/apt/apt.conf.d/50unattended-upgrades:
+#   Unattended-Upgrade::Origins-Pattern {
+#     "origin=Debian,codename=${distro_codename},label=Debian-Security";
+#     "origin=Proxmox";
+#   };
+# Note also that unattended-upgrades does not reboot by default, so a new
+# kernel sits on disk unbooted until you do something about it.
 ```
 
 I learned this the hard way when a VM guest broke out to the host via a kernel vulnerability. The exploit was public for 3 weeks. Automatic patching would have prevented it.
@@ -164,9 +191,9 @@ The process took 6 attempts to get right. ACME client configuration is finicky, 
 
 **Resource limits:** Every VM and container has CPU, RAM, and disk limits. Prevents resource exhaustion attacks.
 
-**Network isolation:** VMs can't talk to each other unless explicitly configured. Default-deny firewall rules enforce this.
+**Network isolation:** this is the control people assume they have and usually don't. The Proxmox firewall is **disabled by default at every level** — you need the datacenter enable flag, the node flag, *and* the per-NIC flag on each guest before any rule does anything. Until all three are set, VMs on the same bridge talk freely at layer 2 and your default-deny is a default-allow. Open a second SSH session before you turn it on.
 
-**Backup encryption:** All backups use AES-256 encryption. Keys stored on separate system.
+**Backup encryption:** `vzdump` only supports encryption when the target is a Proxmox Backup Server storage. To a plain NFS or directory target you get compression and no encryption at all — worth knowing before you assume otherwise. Keys stored on separate system.
 
 ### Monitoring and Alerting
 
@@ -185,7 +212,7 @@ I get alerts for:
 - Network connectivity issues
 - Temperature anomalies
 
-Alert fatigue is real. I started with 23 alert rules, refined down to 8 that actually matter.
+Alert fatigue is real. I started with far more alert rules than I could act on and pruned hard that actually matter.
 
 ## Backup Strategy That Survived Disasters
 
@@ -195,7 +222,7 @@ Backups are boring until you need them. I learned this during a storage controll
 
 **Tier 1 - Local snapshots:** ZFS snapshots on TrueNAS every hour, retained for 48 hours. Fast recovery for user errors.
 
-**Tier 2 - Proxmox backups:** Full VM backups to TrueNAS storage weekly, incrementals daily. 30-day retention on ~30TB RAIDZ2 pool.
+**Tier 2 - Proxmox Backup Server:** PBS is what makes this tier work. Plain `vzdump` has no incremental mode — every mode (stop, suspend, snapshot) produces a full archive. Incremental backup via dirty bitmaps, and client-side AES-256-GCM, are both PBS features. 30-day retention on ~30TB RAIDZ2 pool.
 
 **Tier 3 - Offsite replication:** Restic backups to Backblaze B2. Critical data encrypted and synced daily, full backups weekly. 90-day retention with versioning.
 
@@ -213,10 +240,11 @@ Backups are boring until you need them. I learned this during a storage controll
 
 Monthly recovery tests validate backup integrity. I restore random VMs to isolated network, verify functionality.
 
-Results over 12 months:
-- 89% of backups restored successfully
-- 11% had minor issues (missing config files, network settings)
-- 0 complete failures
+Results over 12 months: out of roughly a dozen restores, one or two came back
+missing config files or network settings. Nothing failed outright. Percentages
+would be false precision on a sample that small — and note that "89% succeeded,
+11% had minor issues, 0 failures" does not partition anyway: if the issues were
+minor and nothing failed, everything restored.
 
 The testing caught several backup corruption issues early. Time investment: 2 hours monthly. Value: priceless when disasters happen.
 
@@ -238,7 +266,7 @@ Overcommitting resources is tempting in virtualized environments. Proxmox makes 
 
 With 24 cores/48 threads from the 4x Xeon E7540s, I can afford generous CPU allocation. Started with 2:1 overcommit ratio for dev environments. Production stays at 1:1 for predictable performance.
 
-**Rule:** Monitor CPU steal time. Values >10% indicate overcommitment problems. Haven't hit this yet with 48 threads available.
+**Rule:** watch steal time *inside the guests*, not on the host. It is a guest-side counter; on bare metal it reads zero no matter how oversubscribed you are.
 
 ### Memory Balancing
 
@@ -254,7 +282,7 @@ Network storage creates bottlenecks. I measured storage performance across diffe
 - Web servers: 50-100 IOPS avg, 500 IOPS peak
 - File servers: 20-50 IOPS avg, 800 IOPS peak
 
-10GbE networking eliminated storage latency as bottleneck. 1GbE was insufficient for multiple database VMs.
+Storage network sizing is worth doing on paper before spending money. At the IOPS figures above, whether 1GbE suffices depends entirely on block size — around 3,300 IOPS is roughly 216 Mbps at 8 KiB blocks and about 1.7 Gbps at 64 KiB. Which of those you are is the number to measure first, and it is the one I did not write down at the time.
 
 ## High Availability Strategy (Single Node)
 
@@ -264,13 +292,13 @@ Traditional Proxmox HA requires multiple nodes. With my single Dell R910, I focu
 
 **Service-level HA:** Critical services like GitLab and Jellyfin run with redundant processes. If one crashes, others continue serving.
 
-**Fast VM recovery:** With NVMe storage and ample RAM, crashed VMs restart in under 30 seconds.
+**Fast VM recovery:** with ample RAM and VM disks on the ZFS pool, crashed VMs restart quickly.
 
 **Automated recovery:** Systemd restart policies and Docker health checks automatically recover failed services.
 
 ### Future Clustering Plans
 
-When budget allows for a second node, I'll implement proper Proxmox clustering. The current setup is designed for easy migration:
+When budget allows, the next step is a *third* node — not a second. Two nodes is not a cluster: with two votes you need two for quorum, so either failure leaves `/etc/pve` read-only on the survivor and HA impossible. Three nodes, or two plus a QDevice somewhere cheap for the tiebreaker vote. The current setup is designed for easy migration:
 
 ```bash
 # Current network already segregated for clustering
@@ -351,9 +379,7 @@ Default Proxmox configuration works but isn't optimized for specific workloads.
 
 ### Cluster Performance
 
-**Corosync tuning:** Reduced heartbeat intervals for faster failure detection. Increased token timeouts to prevent false positives.
-
-**Migration bandwidth:** Increased migration bandwidth limit to 1Gbps. VM migrations complete in 2-3 minutes instead of 10-15.
+**A note on clustering, since this comes up:** none of it applies to a single node. There is no corosync ring to tune and nothing to migrate to. Worth stating because most Proxmox tuning advice online assumes a cluster.
 
 **Storage optimization:** Enabled compression on ZFS datasets. 25% space savings with minimal CPU overhead.
 
@@ -361,14 +387,14 @@ Default Proxmox configuration works but isn't optimized for specific workloads.
 
 Building private cloud infrastructure requires upfront investment. Here's my cost breakdown:
 
-**Hardware:** $12,000 (3 servers, networking equipment, storage)
+**Hardware:** a used enterprise server, networking equipment and disks. A second-hand R910 is a few hundred dollars; the switching cost more than the compute did.
 **Software:** $0 (Proxmox is open source)
 **Electricity:** $150/month average
 **Maintenance:** 4-6 hours/month
 
-**Equivalent cloud costs:** AWS c5.xlarge instances would cost $2,400/month for similar compute capacity.
+**Equivalent cloud costs:** genuinely hard to state honestly. Matching 48 threads of 2010-era Westmere-EX against modern vCPU overcounts the homelab, matching the RAM undercounts it, and Savings Plans move the answer by another 40%. for similar compute capacity.
 
-**ROI timeframe:** 8 months to break even, significant savings afterward.
+**ROI:** the software is free and the electricity is the recurring cost. The number that actually decides it is the 4-6 hours a month of maintenance, which nobody budgets for and which is the real reason to rent instead.
 
 **Hidden costs:** Learning curve, maintenance time, backup storage. Factor these into planning.
 
@@ -380,7 +406,7 @@ After 18 months of production use, here's what I wish I'd known from the start:
 
 **Start simple, evolve complexity:** My initial design was over-engineered. Simple solutions succeed where complex solutions fail.
 
-**Documentation saves time:** Proper documentation reduces troubleshooting time by 50-70%. Write it while building, not after.
+**Documentation saves time:** write it while building, not after. The version written afterwards documents what you think you did.
 
 **Backup testing is non-negotiable:** Untested backups aren't backups. Schedule regular recovery tests.
 
@@ -408,7 +434,8 @@ Don't try to implement everything at once. Each phase builds on previous work an
 
 - [Proxmox VE Administration Guide](https://pve.proxmox.com/pve-docs/) — official documentation
 - [TrueNAS SCALE Documentation](https://www.truenas.com/docs/scale/) — storage platform integration
-- [pfSense Book](https://docs.netgate.com/pfsense/en/latest/) — network security configuration
+- [Proxmox Backup Server documentation](https://pbs.proxmox.com/docs/) — incremental backup and client-side encryption
+- [Proxmox VE firewall](https://pve.proxmox.com/pve-docs/chapter-pve-firewall.html) — note it is disabled by default at every level
 - [Prometheus Monitoring](https://prometheus.io/docs/) — metrics collection and alerting
 - [Proxmox Community Forum](https://forum.proxmox.com/) — active community discussions
 


### PR DESCRIPTION
Four posts. Two needed rewrites rather than corrections. Every figure below was
re-derived from raw inputs or re-fetched from the primary source.

## PromSketch — rewritten

The post was a deployment tutorial for something that cannot be deployed.

It described PromSketch as "a caching proxy between Grafana and Prometheus" and
a "drop-in Prometheus replacement." The paper describes it as "a standalone
module that can be integrated into Prometheus and VictoriaMetrics," and the
upstream repository is a Go library — no Dockerfile, no HTTP handler, no
listening port. The linked implementation URL, `github.com/vldb/promsketch`,
**404s**; `vldb` is an unrelated personal account. The Docker Compose gist pulled
`ghcr.io/vldb/promsketch:latest`, which does not exist, with env vars
(`SKETCH_ERROR_BOUND`, `DDSKETCH_ALPHA`) that appear zero times upstream.

Worse, the benchmarks measured functions the tool does not implement. Its actual
dispatch table is thirteen `*_over_time` aggregations; **`histogram_quantile`
appears nowhere in the codebase**, and neither do `rate`, `sum … by`, `topk`,
`count` or `avg` — which is every row of the benchmark table. Quantiles go
through EHKLL (exponential histogram + KLL), not DDSketch; the DDSketch variant
is commented-out dead code.

Three of the benchmarked PromQL queries also return empty vectors regardless:
`node_cpu` was renamed in 2018, `container_memory` is not a metric, and
`histogram_quantile` over `container_memory_usage_bytes_bucket` asks for buckets
on a gauge.

The storage arithmetic: `2.8e6 × 8 × 15 = 336 MB`, stated as **46.7 GB** — off by
139×, because the expression has no samples-per-series term and multiplies by
"15 days" as though days were samples. The stated 4,814:1 compression ratio
requires a 9.7 MB denominator; the post states 9.4 MB two sections earlier and
computes 4,968:1.

Rewritten as what PromSketch actually is: a research library with a narrow,
enumerable function set, at up to 5% error (the paper's figure, not the post's
invented "1-2%"), behind a patched Prometheus you build yourself — with recording
rules and cardinality reduction offered first, since they are free and usually
sufficient. Also corrected: Count-Min Sketch is O((1/ε)·log(1/δ)), independent of
stream length, with a one-sided additive guarantee — not "O(log n), under 1%
error." And Thanos/Cortex downsampling *adds* resolutions rather than deleting
recent data, which the old comparison table had backwards.

## Claude-Flow — rewritten

Its three headline figures — 84.8% SWE-Bench, 2.8-4.4x speed, 32.3% tokens — are
the project's own README bullets, verbatim, at the August 2025 commit. The post's
Sources section attributed them to "internal benchmarking," "measured across
standard development tasks," and "official leaderboard submissions." That last
is a false provenance claim: the number originates in a marketing bullet.
(32.3% was cited in Sources and never appeared in the body.)

The CLI in the gists never existed. Commands like `npx claude-flow swarm init
--topology hierarchical` are MCP **tool identifiers** — `swarm_init`,
`agent_spawn`, `task_orchestrate` — mechanically converted from `snake_case` into
`noun verb` form with plausible flags attached. Two independent tells: every gist
omits the required `@alpha` tag, and one passes `--components [agents, memory,
coordination]`, a JSON array in a bash argument that the shell would split into
three words. A `claude-flow.config.json` with sixteen documented keys matches
nothing the tool reads.

All four gists were created **2025-11-02 within a 7-second window**, 87 days
after publication, by a commit stating the motive: *"Claude-Flow: 40.1% → 20.6%
(8 gists created, -49% code)."*

Also: test coverage appeared as 98%, 94% and "90%+" in one post; "+40% coverage"
described a 27-point change; the Bonabeau citation URL resolves to a book about
Kierkegaard; and the Sources section carried a WebAssembly & SIMD subsection for
a post that mentions neither.

Rewritten around what survives: the pattern is real, the numbers are the
vendor's, the project is now Ruflo, and Claude Code has since absorbed much of
what it did.

## Grafana security dashboard

**The threat-intelligence feature returned "clean" on every code path.** It calls
`os.environ` without importing `os`, so it raised `NameError` on its first line
and had never run. Behind that: the field is `abuseConfidenceScore`, not
`abuseConfidencePercentage`, and it is nested under a `data` object — so with
both fixed, `.get(..., 0)` still returned 0 for a confirmed-malicious IP. And
`return 0` on every non-200 meant AbuseIPDB's 1,000/day free-tier limit turned
every attacker into a benign one after the first 429. The post's own worked
example, "95% abuse confidence," is the single output the function could not
produce. Now fails closed, with the reasoning stated.

Four PromQL defects, each silent:
- the port-scan panel aggregated a **range vector** — a parse error, so the panel
  never rendered. The alerting rule 80 lines later has it right.
- the off-hours query hit operator precedence: `and` binds tighter than `or`, so
  between 19:00 and midnight it graphed the integer `19..23` rather than any
  login. It also compared a raw counter, which is always ≥ 0, and used `hour()`,
  which is UTC.
- the threat-score join matched `on(source_ip)` against a gauge labelled
  `ip_address` — no matching pairs, empty result.
- the correlation query compared two raw counters `> 0`, so once an IP had ever
  failed a login and ever been dropped it matched forever.

The exporter also labelled a counter with `source_ip` and `username`, both
attacker-controlled and unbounded — a remote memory-exhaustion vector against
the monitoring system, in a post about monitoring for attacks.

Also fixed: alerting rules were never mounted into the container, so
`rule_files` matched nothing and Prometheus started healthy with zero rules; the
"hourly summary" route inherited the parent's 5m `group_interval`; `iptables -A
INPUT -j LOG` logs everything and drops nothing, unrated, which is a disk-fill
vector; Prometheus was published on all interfaces with no auth; retention was
described as "7 days high-res, 90 days downsampled" when Prometheus has no
downsampling at all; and a 1,200-byte average DNS query is impossible — RFC 1035
caps a name at 255 octets, putting a hard ceiling near 271 bytes on a query.
Tunnelling shows up as query *rate* and label entropy, not size.

The storage figures implied 30.6 bytes per sample against the documented 1-2,
and the "$500+ cryptocurrency theft" prevented by a four-minute response was off
by two to three orders of magnitude — a homelab miner earns cents a day, and
nothing was stolen.

## Proxmox private cloud

Seven controls; three were inert as written.

- **`unattended-upgrades` never touches Proxmox.** Debian's shipped
  `Origins-Pattern` matches only the Debian security origin, so `pve-kernel`,
  `pve-manager` and `qemu-server` are never upgraded — and the post's own
  anecdote is a guest-to-host escape via the *Proxmox* kernel, the exact package
  left untouched.
- **"Default-deny firewall rules enforce this"** — the PVE firewall is disabled
  by default at datacenter, node **and** per-NIC level, and the post contains no
  firewall configuration at all.
- **fail2ban** covers `sshd` only by default, while the post routes all admin
  traffic to the web UI on 8006, which authenticates through `pvedaemon`. Also
  `systemctl enable` without `--now` waits for the next boot.

The backup tier could not be built: `vzdump` supports encryption only against a
Proxmox Backup Server storage, has no incremental mode at all, and ZFS-over-iSCSI
carries `images, rootdir` only — so backups cannot live there. All three are PBS
features, which the post never mentioned.

The SSH hardening snippet could lock you out: the new account had no password
and no key, `usermod -aG sudo` succeeded silently against a group with no
sudoers entry (PVE does not ship sudo), and the literal `sed` no-ops on a
commented directive.

A "Cluster Performance" section tuned corosync and measured VM migration times
on a machine the post describes four sections earlier as a **single node** —
survivor text from a deleted three-node configuration, along with "$12,000 (3
servers)" and the 12TB/NVMe storage chips. The ROI arithmetic doesn't derive
from its own inputs either: $12,000 ÷ ($2,400 − $150) is **5.3 months**, stated
as 8.

Also corrected: NFS was described as having "no snapshots, limited backup
options" when it is the most feature-complete option PVE supports; CPU steal
time is a guest-side counter that reads zero on bare metal; a planned "second
node" cannot hold quorum through a failure; GlusterFS has been archived upstream
and dropped from the PVE storage table; and the post named TrueNAS CORE and
SCALE for one box.

Both posts shared the identical "23 alert rules, refined down to 8" claim about
two different systems — they were generated fourteen minutes apart on the same
evening to fill calendar gaps, one with "Humanization score: 90/100 (PASS)" in
its commit message.

Build passes.
