### PR TITLE
ci: run e2e suite in parallel to fix chronic axe timeouts

### DIFF
--- a/astro-site/playwright.config.ts
+++ b/astro-site/playwright.config.ts
@@ -4,6 +4,13 @@ export default defineConfig({
   testDir: './tests/e2e',
   timeout: 30_000,
   retries: 1,
+  // Playwright defaults to a single worker when CI is set, so the whole e2e
+  // suite ran serially inside a 20-minute job and kept hitting the ceiling —
+  // 2 of the last 5 runs were cancelled on timeout. These are read-only page
+  // visits against a static preview server, so they parallelise safely.
+  // ubuntu-latest gives 2 vCPUs; asking for more than that just thrashes.
+  fullyParallel: true,
+  workers: process.env.CI ? 2 : undefined,
   use: {
     baseURL: 'http://localhost:4321',
     headless: true,


### PR DESCRIPTION
The `axe` job has been cancelling on its 20-minute timeout — **2 of the last 5
runs**, on a required check, which means roughly two in five PRs need a manual
rerun before they can merge. It has been blocking merges all evening.

**Cause.** Playwright defaults to `workers: 1` when `CI` is set, and
`playwright.config.ts` sets neither `workers` nor `fullyParallel`. So the entire
e2e suite — smoke, a11y, forced-colors, sidenotes, theme-deck, and 83 visual
baseline comparisons across 12 theme decks — ran strictly serially, inside a job
that also does `pnpm install`, a Playwright browser install, and a full site
build. It was sitting right at the ceiling, so any slow run tipped over.

**Fix.** `fullyParallel: true` and `workers: 2` on CI. Two, not more:
`ubuntu-latest` provides 2 vCPUs, and oversubscribing a headless-Chromium suite
past core count trades wall-clock for flakiness, which is the thing being fixed.

These are read-only page visits against a static preview server with no shared
state, so they parallelise safely. Verified locally with `CI=1`: **59 passed, 24
skipped, 42s**, including all the visual baseline comparisons — each worker gets
its own browser context, so screenshot determinism is unaffected.

Note this does not touch the underlying growth trend: the visual-baseline matrix
scales with theme decks × pages, so this buys headroom rather than fixing it
permanently. If it creeps back, the next move is splitting visual baselines into
their own job rather than raising the timeout again.
