### PR TITLE
docs: add blog-artifact-check to the pre-publish gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,6 +168,7 @@ The Layer-1 skills are author-local tooling in `~/.claude/skills/blog-*/`
 │     blog-nda-check      → contextual NDA-compliance               │
 │     blog-argument-shape → thesis + evidence + falsifiability      │
 │     blog-visuals        → zine doodle, diagram a11y, tokens       │
+│     blog-artifact-check → gist provenance, keys vs upstream       │
 │                                                                   │
 │   blog-deep-review (separate, deliberate, expensive):             │
 │     4 parallel adversarial reviewers — reason-to-exist,           │
@@ -219,6 +220,7 @@ The Layer-1 skills are author-local tooling in `~/.claude/skills/blog-*/`
 | Topic overlap with prior posts | Layer 1 (`blog-overlap`) | Author decides refinement vs new arg |
 | Thesis / evidence / falsifiability | Layer 1 (`blog-argument-shape`) | Author-time editorial judgment |
 | Visual coverage, diagram a11y, design tokens | Layer 1 (`blog-visuals`) | The prose audits all pass on a wall of text |
+| Linked artifacts: gist provenance, config keys, CLI flags | Layer 1 (`blog-artifact-check`) | Machine-generated config is *plausible* and parses clean, so no CI check can see an ignored key. Needs the tool's upstream schema fetched and compared key by key |
 | Unanswered objections, uncited prior art, self-flattering arithmetic, claims that outlived their evidence | Layer 1 (`blog-deep-review`) | Needs adversarial judgment and a web search; too expensive per-commit. **Reviewers are confidently wrong — recompute every challenged number from raw inputs before accepting a correction.** |
 | Build correctness | Layer 2 (pre-commit) | Fast, blocks bad commits |
 | Astro design tokens | Layer 3 (`audits.yml`) | Per-commit, blocks broken design |


### PR DESCRIPTION
Adds a sixth Layer-1 audit and documents it in the pipeline diagram and the concern-ownership table.

**The gap it fills.** Auditing ninety agent-assisted posts, the highest-yield defect was never a wrong sentence. It was an artifact the post pointed *at*: a config file the tool silently ignores, a flag that does not exist, a gist created in a 21-second batch weeks after the post that presents it as working notes.

`blog-factcheck` verifies claims against cited sources. Nothing verified the config against the tool that has to accept it.

**Why it needs to be Layer 1 rather than CI.** Machine-generated config is plausible by construction, and every format forgives it:

```python
tomllib.loads('[scanning]\nworkers = 4\n')   # parses clean
yaml.safe_load('expiration: 2025-12-31')      # parses clean
```

No parser errors. No test covers it, because a test would have to assert the tool *read* the key rather than that the file parsed. CI cannot see a key that is silently ignored. Catching it requires fetching the upstream schema and comparing key by key, which is judgement, not a grep.

**What it checks:**

1. **Provenance** — gist creation timestamps against the post date, batch-creation spans, line counts against stated counts, and `git log -S` for a commit message that states the motive.
2. **Every key against upstream** — one at a time, from the struct definition or CLI reference, including semantics. A flag can exist and do the opposite.
3. **Does the artifact match the prose** — a job named as a gate that never exits non-zero, claimed parallelism with no matrix, "validates tests pass" with no test step, error paths that return empty/zero/false.
4. **Provenance of the prose** — commit bodies that state an optimisation target, and the corollary that hedges written in the same pass as the numbers they disclaim are not evidence of care.

Calibrated on real findings from the audit: a grype `expiration` absent from `IgnoreRule`; an entire `osv-scanner.toml` of invented keys; `trivy --policy`, whose real counterpart filters findings out rather than denying.

The strongest single signal is a **measurement attached to an invented key**. "`workers = 4` is 40% faster" cannot have been measured if the key has never existed, and it means the surrounding numbers should be treated as generated too.