### PR TITLE
posts: run GRIM for real, and measure the corpus over time

### DIFF
--- a/scripts/corpus-audit/README.md
+++ b/scripts/corpus-audit/README.md
@@ -1,0 +1,46 @@
+# Corpus audit scripts
+
+Measurement code behind [Nobody Ran It](../../src/posts/2026-08-18-checks-that-pass-for-the-wrong-reason.md).
+Both are here so the numbers in that post can be reproduced or refuted.
+
+## `grim_check.py` — GRIM-style arithmetic check
+
+Tests whether a stated percentage is reachable on its stated denominator.
+
+```bash
+python3 scripts/corpus-audit/grim_check.py 'src/posts/*.md'
+```
+
+**Result on this corpus: 10 tightly-bound pairs, 0 violations** — the same
+before and after the 2026 audit. This is a negative result and the script is
+kept as evidence for it.
+
+Two earlier versions are described in the post and are *not* kept, because both
+were wrong in instructive ways: a proximity heuristic that flagged 309 of 619
+pairs (reading the `7` in "Mistral 7B" as a denominator), and an "of"-binding
+version that cross-paired figures within a sentence. Only bind a figure to its
+immediate neighbour.
+
+The reason the check finds nothing: in this corpus the denominator is usually
+*derived* from a described experiment rather than stated. "12 participants × 10
+videos" never appears as "120" anywhere on the page.
+
+## `provenance.py` — model attribution and defect markers
+
+Reads the creating commit for each post, extracts the model from the
+`Co-Authored-By` trailer, and computes objective markers: numeric claims per
+citation, placeholder identifiers, and citations dated after the post.
+
+```bash
+git archive <pre-audit-sha> src/posts | tar -x -C /tmp/pre
+python3 scripts/corpus-audit/provenance.py
+```
+
+Run it against a **pre-audit** tree. Against the current tree the corrections
+have already removed what it looks for.
+
+**Caveat that matters more than the output:** model version is perfectly
+confounded with calendar time in this corpus — every 2025 post carries an
+unversioned trailer, every 2026 post a versioned one. Tooling and author
+practice changed over the same window. The script measures a difference between
+cohorts; it cannot attribute one.

--- a/scripts/corpus-audit/grim_check.py
+++ b/scripts/corpus-audit/grim_check.py
@@ -1,0 +1,59 @@
+"""GRIM-style check, tightly bound.
+
+v1 paired any % with any nearby integer (50% hit rate, all noise).
+v2 required an explicit "of" link but cross-paired ratios and percentages within
+a sentence, so "14 of 15 (93%) ... 12 of 15 (80%)" produced four bogus flags.
+
+v3 binds each figure to its own immediate neighbour only:
+  A. "K of N (P%)"  -- percentage in the parenthetical directly after the ratio
+  B. "P% of N"      -- denominator directly after the percentage
+Nothing else counts.
+"""
+from __future__ import annotations
+import re, sys, glob, json
+from pathlib import Path
+
+FENCE=re.compile(r"```.*?```",re.S); INLINE=re.compile(r"`[^`]+`"); HTML=re.compile(r"<[^>]+>")
+# A: "12 of 34 CVEs (35%)" / "18 of them (36%)" — % must be in the parenthetical right after
+A = re.compile(r"\b(\d{1,5})\s+of\s+(?:the\s+|them\s+|these\s+)?(\d{1,5})?\s*[\w\s-]{0,28}?\((\d{1,3}(?:\.\d{1,2})?)\s?%\)")
+# B: "73% of 50 videos"
+B = re.compile(r"(\d{1,3}(?:\.\d{1,2})?)\s?(?:%|percent)\s+of\s+(?:the\s+|my\s+|these\s+|those\s+|all\s+)?(\d{1,5})\b", re.I)
+
+def clean(t): return HTML.sub(" ", INLINE.sub(" ", FENCE.sub(" ", t)))
+def reachable(p,n,tol=0.5): return any(abs(100.0*k/n-p)<=tol for k in range(n+1))
+def ok(n): return 3 <= n <= 5000 and not (1900 <= n <= 2100)
+
+def analyse(path):
+    t = clean(path.read_text(encoding="utf-8", errors="ignore"))
+    out, pairs = [], 0
+    for m in A.finditer(t):
+        k, n, p = int(m.group(1)), m.group(2), float(m.group(3))
+        if n is None: continue
+        n = int(n)
+        if k > n or not ok(n): continue
+        pairs += 1
+        actual = 100.0*k/n
+        if abs(actual - p) > 1.0:
+            out.append({"form":"A","file":path.name,"k":k,"n":n,"stated":p,
+                        "actual":round(actual,2),"ctx":m.group(0)[:110]})
+    for m in B.finditer(t):
+        p, n = float(m.group(1)), int(m.group(2))
+        if not (0 < p < 100) or not ok(n): continue
+        pairs += 1
+        if not reachable(p, n):
+            out.append({"form":"B","file":path.name,"stated":p,"n":n,
+                        "implies":round(p*n/100,2),"ctx":m.group(0)[:110]})
+    return out, pairs
+
+if __name__ == "__main__":
+    allf, tot, nf = [], 0, 0
+    for f in sorted(glob.glob(sys.argv[1])):
+        r, pr = analyse(Path(f)); allf += r; tot += pr; nf += 1
+    print(f"files={nf}  tightly-bound pairs={tot}  inconsistent={len(allf)}\n")
+    Path("/tmp/grim/tight.json").write_text(json.dumps(allf, indent=1))
+    for x in allf:
+        if x["form"]=="A":
+            print(f"  [A] {x['file'][:44]:46} {x['k']}/{x['n']} = {x['actual']}%  stated {x['stated']}%")
+        else:
+            print(f"  [B] {x['file'][:44]:46} {x['stated']}% of {x['n']} = {x['implies']} items")
+        print(f"        …{x['ctx']}…")

--- a/scripts/corpus-audit/provenance.py
+++ b/scripts/corpus-audit/provenance.py
@@ -1,0 +1,60 @@
+"""Which model created each post, and what objective defect markers did it carry
+BEFORE the audit corrected them."""
+import subprocess, re, json, glob
+from pathlib import Path
+from datetime import date
+
+def sh(*a):
+    return subprocess.run(a, capture_output=True, text=True, cwd="/home/william/git/williamzujkowski.github.io").stdout
+
+def model_of(body: str) -> str:
+    m = re.search(r"Co-[Aa]uthored-[Bb]y:\s*(Claude[^<\n]*)", body)
+    if m:
+        s = m.group(1).strip()
+        s = re.sub(r"\s*\(1M context\)", "", s).strip()
+        return s if s != "Claude" else "Claude (unversioned)"
+    for pat, name in [(r"codex", "codex"), (r"gemini", "gemini")]:
+        if re.search(pat, body, re.I): return name
+    return "unlabelled"
+
+rows = []
+for p in sorted(glob.glob("/tmp/grim/pre/src/posts/*.md")):
+    name = Path(p).name
+    # creating commit for this path
+    log = sh("git", "log", "--diff-filter=A", "--format=%H|%ad", "--date=short",
+             "--follow", "--", f"src/posts/{name}")
+    if not log.strip(): continue
+    sha, cdate = log.strip().split("\n")[-1].split("|")
+    body = sh("git", "log", "-1", "--format=%s%n%b", sha)
+    text = Path(p).read_text(errors="ignore")
+
+    # frontmatter date
+    fm = re.search(r"^date:\s*(\d{4}-\d{2}-\d{2})", text, re.M)
+    pdate = fm.group(1) if fm else cdate
+
+    body_only = re.sub(r"```.*?```", " ", text, flags=re.S)
+    nums = len(re.findall(r"(?<![\w.])\d{1,3}(?:\.\d+)?%|(?<![\w.$])\b\d{2,}\b", body_only))
+    cites = len(re.findall(r"https?://", body_only))
+    placeholders = len(re.findall(r"X{4,}|xxxx|CVE-\d{4}-X", text))
+    # citations dated after the post
+    future = 0
+    for m in re.finditer(r"/(20\d{2})/(\d{2})/(\d{2})/|arxiv\.org/abs/(\d{2})(\d{2})\.", text):
+        try:
+            if m.group(1):
+                if date(int(m.group(1)), int(m.group(2)), int(m.group(3))) > date.fromisoformat(pdate): future += 1
+            elif m.group(4):
+                yy, mm = 2000+int(m.group(4)), int(m.group(5))
+                if date(yy, mm, 1) > date.fromisoformat(pdate): future += 1
+        except Exception: pass
+
+    rows.append({"post": name, "created": cdate, "post_date": pdate,
+                 "model": model_of(body), "nums": nums, "cites": cites,
+                 "ratio": round(nums/max(cites,1), 1),
+                 "placeholders": placeholders, "future_cites": future})
+
+Path("/tmp/grim/prov.json").write_text(json.dumps(rows, indent=1))
+from collections import Counter
+print("posts:", len(rows))
+print("\nby creating model:")
+for m, c in Counter(r["model"] for r in rows).most_common():
+    print(f"  {m:28} {c}")

--- a/src/posts/2026-08-18-checks-that-pass-for-the-wrong-reason.md
+++ b/src/posts/2026-08-18-checks-that-pass-for-the-wrong-reason.md
@@ -133,7 +133,23 @@ The defect class appeared in the middle of a task specifically instructed to gua
 
 **Make the parser strict, and check whether it already is.** `serde`'s `deny_unknown_fields`, Pydantic's `extra='forbid'`, Go's `DisallowUnknownFields` (on `Decoder` only, not `json.Unmarshal`). Kubernetes made server-side field validation the default in **v1.27** — its motivating incident was a Service silently breaking because `containerPort` had been renamed `targetPort` and the server accepted the stale key. The tracking issue stayed open for seven years. The defaults are permissive, and they are changing.
 
-**Check the arithmetic against the sample size.** Psychology has a mechanical test for this — [GRIM](https://en.wikipedia.org/wiki/GRIM_test), which exploits the fact that a mean of N integers must be expressible with denominator N. In its original application, **36 of 71 testable papers contained at least one impossible value.** My archive was full of the same thing: "73% accuracy" on a stated corpus of 50 items requires 36.5 items. I have not seen anyone point GRIM at model output, and it costs nothing.
+**Check the arithmetic against the sample size — except this one didn't work, and the failure is instructive.**
+
+Psychology has a mechanical test for exactly this. [GRIM](https://en.wikipedia.org/wiki/GRIM_test) exploits the fact that a mean of N integers must be expressible with denominator N; in its original application, 36 of 71 testable papers contained at least one impossible value. My archive was full of what looked like the same thing — "73% accuracy" on a stated corpus of 50 items requires 36.5 items. So I wrote that nobody seemed to have pointed GRIM at model output, and that it costs nothing.
+
+Then I pointed it at my own corpus, and it found nothing. Three times, in three different ways.
+
+The first version paired every percentage with every nearby integer. It flagged **309 of 619 candidate pairs** — a 50% hit rate, which should have been the tell. It was reading the *7* in "Mistral 7B" as a denominator for "87% on my reasoning tests," and the *11* in "from 11GB to 7GB" as a sample size for "reduced memory by 35%."
+
+The second version required an explicit "of" between the figure and its denominator. Eighteen flags, every one an artifact of my own code cross-pairing within a sentence: given *"Slither detected 14 of 15 (93%)… GPT-4 caught 12 of 15 (80%)"*, it dutifully checked 14/15 against 80%.
+
+The third version bound each figure to its immediate neighbour only. Across 92 posts it found **10 tightly-bound pairs and zero violations** — and the same on the pre-audit corpus, before any of my corrections. The check is clean and the corpus is clean, and neither fact means anything, because the two never met.
+
+Here is why. I went back to five impossible percentages I had found by hand and asked where each denominator actually lived. One was in the same sentence. One was in the frontmatter, 762 characters from its denominator in the body. **Three were never stated at all** — they had to be derived from the described experiment. "58% average accuracy" was impossible because 12 participants × 10 videos = 120 judgments and 58% of 120 is 69.6, and *nothing in the post says 120*. You get there by reading the design and doing the multiplication.
+
+GRIM works on psychology papers because a results table reports the mean and the N side by side. Prose does not. It states a number in one paragraph and its denominator three paragraphs earlier, or never, and the check that found these was a reader holding the design in their head.
+
+So: a technique I recommended in this post, on the strength of it sounding right, and which does not survive being run. Which is the post's own thesis arriving to collect.
 
 **Check provenance, not just content.** `gh api gists/<id> --jq .created_at` against the post date. Eleven artifacts created in a 21-second burst are not working notes. `git log -S` on the artifact, and read the commit body — a pass that states its optimisation target is telling you what its numbers are for.
 
@@ -142,6 +158,48 @@ The defect class appeared in the middle of a task specifically instructed to gua
 **And be careful what you cite for any of this.** The most-quoted number in code review — "a review of 200-400 LOC over 60 to 90 minutes should yield 70-90% defect discovery" — is widely attributed to the Cisco/SmartBear study. It is not in the Cisco data. In the book it sits in a different chapter, by a different author, about personal reviews under the SEI's TSP, with no data behind it. The Cisco chapter explicitly declines the claim: *"we don't know how each of these reviews would have fared with a different process."* The vendor's own page states the 400-LOC finding with a Cisco attribution and then the 70-90% figure in the next sentence, unsourced. Nobody wrote a false sentence. The number acquired its authority by proximity.
 
 Which is the same mechanism as everything above, in the literature about checking.
+
+## Has it got better?
+
+Two years of posts, written with whatever model was current at the time. Git
+records which: `Co-Authored-By` trailers name unversioned "Claude" through 2025,
+then Opus 4.6, 4.7, 4.8 and Fable 5 across 2026. So there is a natural
+experiment sitting in the history, and it is worth asking whether any of this
+improved on its own.
+
+I measured one thing that is objective and needs no judgement: **numeric claims
+per citation.** Count the figures in a post, count the sources, divide. It is a
+crude proxy for "how much of this is asserted rather than sourced," it can be
+computed mechanically on every post, and — importantly — I measured it on the
+corpus *as it stood before my audit*, so my own corrections cannot manufacture
+the result.
+
+| cohort | n | median numbers per citation | placeholder IDs | citations dated after the post |
+|---|---:|---:|---:|---:|
+| 2025, unversioned | 70 | **5.8** | 16 | 11 |
+| 2026, versioned models | 19 | **2.8** | 0 | 0 |
+
+The density of unsourced figures roughly halved (Mann-Whitney z = −3.75). The
+literal `CVE-2023-XXXXX` placeholders and the citations dated after their own
+post — the two crudest fabrication artifacts — go to zero and stay there.
+
+The obvious objection is that the October 2025 humanisation pass is sitting
+inside the 2025 cohort inflating it. So I dropped all 45 posts it touched and
+re-ran: median 4.5 against 2.8, z = −2.60. Weaker, still there.
+
+**And I cannot tell you what caused it.** Every 2025 post carries an unversioned
+trailer and every 2026 post a versioned one, so model generation is perfectly
+confounded with calendar time. Over the same period I also built a pre-publish
+gate, changed what I write about — later posts describe my own repositories,
+which are checkable in a way that survey posts are not — and got considerably
+more suspicious. Four variables, one direction, no way to separate them from 19
+posts.
+
+What I can say is narrower and still worth having: the recent cohort is
+measurably better sourced, by a large margin, on a metric computed without my
+involvement. Whether that is the models, the tooling, the topics or me is not
+answerable from this data, and anyone who tells you otherwise from a corpus this
+size is doing the thing this post is about.
 
 ## What I changed
 


### PR DESCRIPTION
You suggested actually running GRIM against the corpus. I did, and it does not work — which turned out to be more useful than if it had.

## The GRIM recommendation was wrong, and it was mine

The live post recommended GRIM and said it "costs nothing." I had not run it. That is an untested recommendation stated confidently, in a post about untested claims stated confidently, so it had to go.

Three iterations, all instructive:

| version | pairs | flagged | verdict |
|---|---:|---:|---|
| proximity heuristic | 619 | **309** | all noise — read the `7` in "Mistral 7B" as a denominator |
| explicit "of" binding | 32 | 18 | all cross-pairing: checked `14 of 15` against a different clause's `80%` |
| immediate-neighbour binding | 10 | **0** | clean |

Zero on the current corpus **and zero on the pre-audit corpus**, so this is not my corrections hiding the evidence.

**Why it fails.** I traced five impossible percentages I had found by hand back to their denominators. One was in the same sentence. One sat in the frontmatter, 762 characters from its denominator. **Three were never stated at all** — "58% average accuracy" is impossible because 12 participants × 10 videos = 120 judgments, and nothing in the post says 120. GRIM works on psychology papers because a results table prints the mean and the N side by side. Prose doesn't.

That a check produced 309 confident findings for entirely the wrong reason is the post's own thesis arriving to collect, and it is now written up that way.

## The over-time analysis

Git records model provenance in `Co-Authored-By` trailers — unversioned "Claude" through 2025, then Opus 4.6/4.7/4.8 and Fable 5 in 2026. Measured on the **pre-audit** corpus so my corrections cannot manufacture the result:

| cohort | n | median numbers/citation | placeholder IDs | citations dated after the post |
|---|---:|---:|---:|---:|
| 2025, unversioned | 70 | **5.8** | 16 | 11 |
| 2026, versioned | 19 | **2.8** | 0 | 0 |

Mann-Whitney z = −3.75. Excluding all 45 humanisation-cohort posts, in case that pass was driving it: 4.5 vs 2.8, z = −2.60. Weaker, still there.

**What I explicitly do not claim.** Model version is perfectly confounded with calendar time — every 2025 post is unversioned, every 2026 post versioned. Over the same window I built the pre-publish gate, shifted toward writing about my own repositories (checkable in a way survey posts are not), and got more suspicious. Four variables moving together, 19 posts in the recent cohort. The post says the improvement is real and that attributing it would be the thing this post is about.

A per-model comparison is not possible either: n = 7, 6, 4, 2 across the versioned models. I'd rather say that than rank them.

## Reproducibility

Both scripts are in `scripts/corpus-audit/` with a README covering the two wrong GRIM versions and the confound. The numbers in the post can be re-run or refuted.

Build passes.