### PR TITLE
fix(ci): make the gates fail closed

### DIFF
--- a/.github/workflows/audits.yml
+++ b/.github/workflows/audits.yml
@@ -96,6 +96,11 @@ jobs:
         run: cd astro-site && pnpm check
       - name: Lint (eslint)
         run: cd astro-site && pnpm lint
+      # 7 unit tests covering src/lib/rehype-sidenotes.mjs — 356 lines of
+      # custom AST manipulation applied to every post. They passed, and no
+      # workflow had ever run them (issue #497). Runs in ~70ms.
+      - name: Unit tests (rehype-sidenotes)
+        run: cd astro-site && pnpm test:unit
 
   # Token-drift check against the installed remarque-tokens package
   # (remarque#47/#48 — consensus-armed now that 2+ sites consume the

--- a/.github/workflows/link-monitor.yml
+++ b/.github/workflows/link-monitor.yml
@@ -276,10 +276,22 @@ jobs:
           # batch-link-fixer.py reads links.json from the working directory;
           # it travels inside the reports/ artifact (see check-links job).
           cp reports/links.json links.json
+          # SAFETY STOPGAP (issue #495): --dry-run until the write path is
+          # fixed. batch-link-fixer._replace_url does a blanket substring
+          # replace outside markdown links, so it rewrites URLs inside code
+          # fences, inline code and blockquotes; it also prefix-collides
+          # (repairing ex.com/a rewrites ex.com/abc), and the extractor
+          # truncates URLs containing parentheses, which produces mangled
+          # prose when repaired. All three are reproduced in #495.
+          #
+          # This job has never actually opened a repair PR, so nothing is
+          # lost by holding it here. Remove --dry-run once #495 lands a
+          # code-span-aware replacer and its golden-file test.
           uv run python scripts/link-validation/batch-link-fixer.py \
             --repairs reports/repairs.json \
             --confidence-threshold 95 \
             --apply \
+            --dry-run \
             --posts-dir src/posts
         else
           echo "No repairs.json found; nothing to apply"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,3 +34,11 @@ jobs:
 
       - name: Run link-validation regression tests
         run: uv run --with pytest python -m pytest scripts/link-validation/tests/ -q
+
+      # ruff was declared in pyproject.toml and configured with seven rule
+      # families, but nothing ever invoked it (issue #497). At the time it was
+      # wired up it reported 224 violations; those are now at zero, so this
+      # step is a ratchet — it fails on the first regression rather than
+      # accumulating another 224.
+      - name: Lint (ruff)
+        run: uv run --with ruff ruff check scripts/

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -4,22 +4,34 @@ title = "williamzujkowski.github.io gitleaks config"
 [extend]
 useDefault = true
 
-# Global allowlist for tutorial-default credentials that appear in
-# example commands in blog posts (Wazuh admin:admin, etc). These are
-# documented defaults from upstream project quickstarts, not real
-# secrets. Allowlist is intentionally narrow — if a post adds a real
-# credential by mistake, it will not match these patterns.
+# Allowlist for values that LOOK like credentials but are not.
+#
+# There is deliberately NO `paths` entry here. gitleaks combines `paths` and
+# `regexes` within one allowlist as an OR, not an AND -- so a `paths` entry
+# exempts every finding in those files regardless of the regexes. A previous
+# version of this file allowlisted `src/posts/.*\.md$`, which silently
+# disabled secret scanning for every blog post: exactly the place where
+# terminal transcripts and homelab configs get pasted. Verified with a
+# three-arm test (default ruleset / this config / this config minus `paths`).
+#
+# Every entry below matches a specific published value, so it stays narrow
+# and survives the line moving. One-off historical findings in deleted files
+# are pinned by fingerprint in .gitleaksignore instead.
 [allowlist]
-  description = "Tutorial-default credentials in blog post examples"
-  paths = [
-    '''src/posts/.*\.md$''',
-  ]
+  description = "Published non-secrets: tutorial defaults, placeholders, public keys"
   regexes = [
-    # Documented project defaults
+    # Documented project defaults from upstream quickstarts
     '''admin:admin''',
     '''root:root''',
     '''user:password''',
     '''test:test''',
     # Generic shell-variable placeholders ($VAR, ${VAR})
     '''-u\s+[A-Za-z_][A-Za-z0-9_]*:\$\{?[A-Za-z_][A-Za-z0-9_]*\}?''',
+    # Obvious placeholder tokens (ghp_xxxxxxxx...) -- zero entropy by design
+    '''(?i)gh[pousr]_x{16,}''',
+    # TLS named group, not a key: post-quantum key_share value
+    '''X25519MLKEM768''',
+    # dnscrypt-proxy resolver signing key -- a PUBLIC minisign key (RW prefix),
+    # published upstream so clients can verify the resolver list.
+    '''RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3''',
   ]

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,37 @@
+# gitleaks fingerprint allowlist -- one-off HISTORICAL findings only.
+#
+# Recurring/published non-secrets belong in .gitleaks.toml's regex
+# allowlist instead, so they survive the line moving. This file is
+# strictly for findings pinned to a specific commit in a file that no
+# longer exists, which is why the full-history (scheduled) scan sees
+# them and the per-push range scan does not.
+#
+# Format: <commit>:<path>:<rule-id>:<line>
+
+# ---------------------------------------------------------------
+# Lighthouse report JSON (deleted in a later commit). The 'AWS access
+# token' matches are 'AKIA'-shaped substrings occurring by chance
+# inside base64-encoded JPEG filmstrip screenshots:
+#   "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgAB..."
+# Not credentials. Verified by reading the surrounding JSON.
+# ---------------------------------------------------------------
+9d7fd0c80576e26df676d189190ae205abd8ef04:docs/lighthouse-homepage-1758606456367.json:aws-access-token:128
+9d7fd0c80576e26df676d189190ae205abd8ef04:docs/lighthouse-blog-post-1758606469264.json:aws-access-token:138
+9d7fd0c80576e26df676d189190ae205abd8ef04:docs/lighthouse-blog-post-1758606469264.json:aws-access-token:143
+9d7fd0c80576e26df676d189190ae205abd8ef04:docs/lighthouse-blog-post-1758606469264.json:aws-access-token:148
+9d7fd0c80576e26df676d189190ae205abd8ef04:docs/lighthouse-blog-post-1758606469264.json:aws-access-token:153
+9d7fd0c80576e26df676d189190ae205abd8ef04:docs/lighthouse-blog-post-1758606469264.json:aws-access-token:158
+9d7fd0c80576e26df676d189190ae205abd8ef04:docs/lighthouse-blog-post-1758606469264.json:aws-access-token:163
+9d7fd0c80576e26df676d189190ae205abd8ef04:docs/lighthouse-blog-post-1758606469264.json:aws-access-token:178
+
+# ---------------------------------------------------------------
+# src/pages/about.md (Eleventy-era page, deleted in d1bbfec #112).
+# The 'linkedin-client-secret' match is the author's own handle sitting in
+# a YAML contact block, on a line of the form "<platform>: <username>".
+# (Deliberately not quoted verbatim here -- the default rule matches that
+# shape wherever it appears, including inside this file's own comments,
+# which is exactly how the first version of this fix failed CI.)
+# Not a secret. This single finding is why every SCHEDULED run of
+# compliance-monitor.yml failed while every push run passed.
+# ---------------------------------------------------------------
+f14c193dc0d123a29cbbd78d35e4c0bb2a0ab261:src/pages/about.md:linkedin-client-secret:123

--- a/astro-site/package.json
+++ b/astro-site/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "astro dev",
-    "build": "astro build && npx pagefind --site dist",
+    "build": "NODE_ENV=production astro build && npx pagefind --site dist",
     "preview": "astro preview",
     "astro": "astro",
     "check": "astro check",

--- a/astro-site/package.json
+++ b/astro-site/package.json
@@ -17,7 +17,7 @@
     "format:check": "prettier --check 'src/**/*.{astro,svelte,ts,js,css}'",
     "test:e2e": "npx playwright test",
     "test:e2e:headed": "npx playwright test --headed",
-    "test:unit": "node --test '../tests/unit/**/*.test.mjs'",
+    "test:unit": "node scripts/run-unit-tests.mjs",
     "audit:remarque": "node scripts/run-remarque-audit.mjs",
     "audit:typography": "node scripts/typography-audit.mjs",
     "audit:colors": "node scripts/color-token-audit.mjs",

--- a/astro-site/scripts/run-remarque-audit.mjs
+++ b/astro-site/scripts/run-remarque-audit.mjs
@@ -52,6 +52,28 @@ const result = spawnSync('npx', ['remarque-audit', ...args], {
 const output = `${result.stdout || ''}${result.stderr || ''}`;
 const lines = output.split('\n');
 
+// The tool must be proven to have RUN before a zero-failure count means
+// anything. Without this, a spawn failure (registry outage, renamed bin, a
+// blocking `npx` prompt) produces empty output, which parses as zero failures
+// and reports a pass — the gate fails open on exactly the cases where it is
+// least able to tell you so.
+if (result.error) {
+  console.error(`\nremarque-audit could not be spawned: ${result.error.message}\n`);
+  process.exit(1);
+}
+
+// Every check the tool performs prints a "  ✓" or "  ✗" line. Zero of them
+// means it never got as far as auditing anything, whatever its exit code says.
+const checksPerformed = lines.filter((l) => l.startsWith('  ✓') || l.startsWith('  ✗')).length;
+if (checksPerformed === 0) {
+  console.error(output);
+  console.error(
+    `\nremarque-audit performed 0 checks (exit ${result.status}) — treating as a FAILURE, ` +
+      'not a pass. An empty result is not a clean result.\n',
+  );
+  process.exit(1);
+}
+
 let realFailures = 0;
 let suppressed = 0;
 
@@ -100,6 +122,16 @@ console.log(
 
 if (realFailures > 0) {
   console.error('\nremarque-audit FAILED (after baseline suppression).\n');
+  process.exit(1);
+}
+
+// A non-zero exit we did not account for as a parsed failure is still a
+// failure — the tool is telling us something this parser doesn't understand.
+if (result.status !== 0) {
+  console.error(
+    `\nremarque-audit exited ${result.status} but no failure line was parsed. ` +
+      'Failing closed rather than trusting the parse.\n',
+  );
   process.exit(1);
 }
 console.log('\nremarque-audit passed (contrast + gamut clean; all source-scan findings are reviewed, baselined false positives) ✓\n');

--- a/astro-site/scripts/run-unit-tests.mjs
+++ b/astro-site/scripts/run-unit-tests.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+/**
+ * Wrapper around `node --test` for the unit suite.
+ *
+ * Why this exists: `node --test` with a glob that matches nothing prints
+ *
+ *   # tests 0
+ *   # pass 0
+ *   # fail 0
+ *
+ * and exits 0. A renamed directory, a changed glob, or a moved test file
+ * would therefore turn this gate green by removing its own subject —
+ * exactly the failure mode run-remarque-audit.mjs had (issue #492), where
+ * an empty result was indistinguishable from a clean one.
+ *
+ * So: run the suite, then require that it actually ran at least
+ * MIN_TESTS of them. Raise the floor when tests are added; it is a ratchet,
+ * not a target.
+ */
+import { spawnSync } from 'node:child_process';
+
+const MIN_TESTS = 7;
+const GLOB = '../tests/unit/**/*.test.mjs';
+
+const result = spawnSync(process.execPath, ['--test', GLOB], {
+  encoding: 'utf8',
+  stdio: ['ignore', 'pipe', 'pipe'],
+});
+
+const output = `${result.stdout || ''}${result.stderr || ''}`;
+process.stdout.write(output);
+
+if (result.error) {
+  console.error(`\nunit tests could not be spawned: ${result.error.message}\n`);
+  process.exit(1);
+}
+
+const match = output.match(/^# tests (\d+)$/m);
+const ran = match ? Number(match[1]) : 0;
+
+if (ran < MIN_TESTS) {
+  console.error(
+    `\nunit tests: ran ${ran}, expected at least ${MIN_TESTS}. ` +
+      'A suite that matches no files is not a passing suite — check the glob ' +
+      `(${GLOB}) and that tests/unit/ still exists.\n`,
+  );
+  process.exit(1);
+}
+
+if (result.status !== 0) {
+  process.exit(result.status ?? 1);
+}
+
+console.log(`\nunit tests: ${ran} ran, all passed (floor ${MIN_TESTS}) ✓\n`);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ testpaths = ["scripts/link-validation/tests"]
 [tool.ruff]
 line-length = 100
 target-version = "py311"
+
+[tool.ruff.lint]
 select = [
     "E",   # pycodestyle errors
     "W",   # pycodestyle warnings
@@ -48,8 +50,14 @@ ignore = [
     "C901",  # too complex
 ]
 
-[tool.ruff.per-file-ignores]
-"__init__.py" = ["F401"]
+[tool.ruff.lint.per-file-ignores]
+# One-shot corpus-analysis scripts, written to be read top-to-bottom as a
+# single pass rather than imported. The compressed `if x: return` /
+# `a = 1; b = 2` style is deliberate there and rewriting it would obscure
+# the analysis without making anything safer. Everything else under
+# scripts/ is held to the full rule set.
+"scripts/corpus-audit/*.py" = ["E701", "E702", "E402"]
+
 
 [build-system]
 requires = ["hatchling"]

--- a/scripts/blog-audit/batch.py
+++ b/scripts/blog-audit/batch.py
@@ -40,10 +40,13 @@ THRESHOLDS:
     threshold rationale.
 """
 
-import argparse, json, re, statistics, sys
-from pathlib import Path
+import argparse
+import json
+import re
+import statistics
+import sys
 from collections import defaultdict
-
+from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent.parent
 DEFAULT_GLOB = "src/posts/*.md"
@@ -231,7 +234,7 @@ def audit_post(post_path, all_signals):
             continue
         line_no_code = strip_code(raw)
         for pat, name in PHRASAL:
-            for m in re.finditer(pat, line_no_code, re.IGNORECASE):
+            for _ in re.finditer(pat, line_no_code, re.IGNORECASE):
                 phrasal_hits.append((ln_idx, name))
 
     # Em-dash count (raw — classification is for the SKILL.md author judgment)
@@ -268,7 +271,7 @@ def audit_post(post_path, all_signals):
              "with as be by from has have not".split())
 
     def to_set(s):
-        return set(w.lower() for w in re.findall(r"\b[a-zA-Z]{3,}\b", s)) - sw
+        return {w.lower() for w in re.findall(r"\b[a-zA-Z]{3,}\b", s)} - sw
 
     first_para = []
     for ln in body_lines:
@@ -323,7 +326,7 @@ def audit_post(post_path, all_signals):
     target_sigs = overlap_signals(body, fm)
     target_tags = set(fm.get("tags") or [])
     overlap_results = []
-    for other_path, other_sigs, other_tags, other_text in all_signals:
+    for other_path, other_sigs, other_tags, _other_text in all_signals:
         if other_path == post_path:
             continue
         score = jaccard_weighted(target_sigs, other_sigs)
@@ -352,7 +355,7 @@ def audit_post(post_path, all_signals):
             "trailing_jaccard": round(jaccard, 2),
         },
         "findings": findings,
-        "overlap": [(round(s, 2), n, l) for s, n, l in overlap_results],
+        "overlap": [(round(s, 2), n, linked) for s, n, linked in overlap_results],
     }
 
 
@@ -398,7 +401,7 @@ def main():
     print("\n=== Per-post HIGH/MED findings ===")
     any_findings = False
     for r in results:
-        if r["findings"]["H"] or r["findings"]["M"] or any(not l for _, _, l in r["overlap"]):
+        if r["findings"]["H"] or r["findings"]["M"] or any(not linked for _, _, linked in r["overlap"]):
             any_findings = True
             print(f"\n{r['name']}:")
             for name, line in r["findings"]["H"]:

--- a/scripts/blog-audit/pages.py
+++ b/scripts/blog-audit/pages.py
@@ -45,7 +45,10 @@ USAGE:
     python3 scripts/blog-audit/pages.py --json
 """
 
-import argparse, json, re, statistics, sys
+import argparse
+import json
+import re
+import sys
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent.parent
@@ -167,7 +170,7 @@ def audit_page(page_path):
     # Phrasal patterns (HIGH severity)
     for ln_idx, line in prose_lines:
         for pat, name in PHRASAL:
-            for m in re.finditer(pat, line, re.IGNORECASE):
+            for _ in re.finditer(pat, line, re.IGNORECASE):
                 findings["H"].append((name, ln_idx, line[:80]))
 
     # Em-dash count (raw)

--- a/scripts/blog-audit/standardize-sources.py
+++ b/scripts/blog-audit/standardize-sources.py
@@ -8,7 +8,6 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
-
 POST_DIR = Path("src/posts")
 STANDARD_HEADING = "## Sources"
 

--- a/scripts/corpus-audit/grim_check.py
+++ b/scripts/corpus-audit/grim_check.py
@@ -10,7 +10,11 @@ v3 binds each figure to its own immediate neighbour only:
 Nothing else counts.
 """
 from __future__ import annotations
-import re, sys, glob, json
+
+import glob
+import json
+import re
+import sys
 from pathlib import Path
 
 FENCE=re.compile(r"```.*?```",re.S); INLINE=re.compile(r"`[^`]+`"); HTML=re.compile(r"<[^>]+>")

--- a/scripts/corpus-audit/provenance.py
+++ b/scripts/corpus-audit/provenance.py
@@ -1,8 +1,12 @@
 """Which model created each post, and what objective defect markers did it carry
 BEFORE the audit corrected them."""
-import subprocess, re, json, glob
-from pathlib import Path
+import glob
+import json
+import re
+import subprocess
 from datetime import date
+from pathlib import Path
+
 
 def sh(*a):
     return subprocess.run(a, capture_output=True, text=True, cwd="/home/william/git/williamzujkowski.github.io").stdout
@@ -54,6 +58,7 @@ for p in sorted(glob.glob("/tmp/grim/pre/src/posts/*.md")):
 
 Path("/tmp/grim/prov.json").write_text(json.dumps(rows, indent=1))
 from collections import Counter
+
 print("posts:", len(rows))
 print("\nby creating model:")
 for m, c in Counter(r["model"] for r in rows).most_common():

--- a/scripts/lib/logging_config.py
+++ b/scripts/lib/logging_config.py
@@ -19,8 +19,6 @@ Usage:
 import logging
 import sys
 from pathlib import Path
-from datetime import datetime
-from typing import Optional
 
 
 class ColoredFormatter(logging.Formatter):
@@ -46,7 +44,7 @@ class ColoredFormatter(logging.Formatter):
 def setup_logger(
     name: str,
     level: int = logging.INFO,
-    log_file: Optional[Path] = None,
+    log_file: Path | None = None,
     quiet: bool = False
 ) -> logging.Logger:
     """

--- a/scripts/link-validation/batch-link-fixer.py
+++ b/scripts/link-validation/batch-link-fixer.py
@@ -42,15 +42,15 @@ RELATED_SCRIPTS:
 MANIFEST_REGISTRY: scripts/batch-link-fixer.py
 """
 
+import argparse
 import json
 import re
 import shutil
-import argparse
 import subprocess
-from pathlib import Path
-from typing import Dict, List, Tuple
-from datetime import datetime
 import sys
+from datetime import datetime
+from pathlib import Path
+
 from tqdm import tqdm
 
 # Path setup for logging import
@@ -70,7 +70,7 @@ class BatchLinkFixer:
         self.backups_created = []
 
     @staticmethod
-    def _replace_url(content: str, old_url: str, new_url: str) -> Tuple[str, int]:
+    def _replace_url(content: str, old_url: str, new_url: str) -> tuple[str, int]:
         """Replace a URL in markdown links first, then bare prose URLs."""
         markdown_exact = re.compile(r"(\[[^\]]+\]\()" + re.escape(old_url) + r"(?=\))")
         markdown_link = re.compile(r"\[[^\]]+\]\((?:[^()]|\([^()]*\))*\)")
@@ -165,7 +165,7 @@ class BatchLinkFixer:
             logger.error(f"\n❌ Pipeline failed: {e}")
             return 1
 
-    def _run_command(self, cmd: List[str]) -> bool:
+    def _run_command(self, cmd: list[str]) -> bool:
         """Run a command and return success status"""
         try:
             result = subprocess.run(cmd, capture_output=True, text=True, check=True)
@@ -192,7 +192,7 @@ class BatchLinkFixer:
             return
 
         # Load repairs
-        with open(repairs_file, 'r', encoding='utf-8') as f:
+        with open(repairs_file, encoding='utf-8') as f:
             repairs_data = json.load(f)
 
         repairs = repairs_data.get('repairs', [])
@@ -220,10 +220,10 @@ class BatchLinkFixer:
         for file_path, file_repairs in tqdm(repairs_by_file.items(), desc="Fixing files"):
             self._apply_file_repairs(file_path, file_repairs)
 
-    def _group_repairs_by_file(self, repairs: List[Dict]) -> Dict[str, List[Dict]]:
+    def _group_repairs_by_file(self, repairs: list[dict]) -> dict[str, list[dict]]:
         """Group repairs by source file"""
         # Load links data to map repairs to files
-        with open('links.json', 'r', encoding='utf-8') as f:
+        with open('links.json', encoding='utf-8') as f:
             links_data = json.load(f)
 
         # Create URL to file mapping
@@ -242,7 +242,7 @@ class BatchLinkFixer:
 
         return repairs_by_file
 
-    def _apply_file_repairs(self, file_path: str, repairs: List[Dict]):
+    def _apply_file_repairs(self, file_path: str, repairs: list[dict]):
         """Apply repairs to a single file"""
         file_path = Path(file_path)
 
@@ -256,7 +256,7 @@ class BatchLinkFixer:
             self.backups_created.append((file_path, backup_path))
 
         # Read file content
-        with open(file_path, 'r', encoding='utf-8') as f:
+        with open(file_path, encoding='utf-8') as f:
             content = f.read()
 
         original_content = content
@@ -279,8 +279,16 @@ class BatchLinkFixer:
                     'repair_type': repair.get('repair_type', 'unknown')
                 })
 
-        # Write changes
-        if changes > 0 and not self.dry_run:
+        # Write changes. `original_content` guards the write: a non-zero
+        # `changes` count with byte-identical content means a repair matched
+        # but produced no edit, which is a bug in _replace_url rather than a
+        # fix worth committing.
+        if changes > 0 and content == original_content:
+            logger.warning(
+                f"⚠️  {file_path.name}: {changes} repair(s) reported but content is "
+                "unchanged; refusing to write. This indicates a _replace_url defect."
+            )
+        elif changes > 0 and not self.dry_run:
             with open(file_path, 'w', encoding='utf-8') as f:
                 f.write(content)
             logger.info(f"✅ Fixed {changes} links in {file_path.name}")
@@ -291,7 +299,7 @@ class BatchLinkFixer:
         shutil.copy2(file_path, backup_path)
         return backup_path
 
-    def _show_planned_changes(self, repairs: List[Dict]):
+    def _show_planned_changes(self, repairs: list[dict]):
         """Show what changes would be made"""
         logger.info("\nPlanned changes:")
         logger.info("-" * 60)
@@ -328,14 +336,14 @@ class BatchLinkFixer:
         for repair_type, count in sorted(by_type.items()):
             logger.info(f"  {repair_type}: {count}")
 
-        logger.info(f"\nFiles modified: {len(set(c['file'] for c in self.changes_made))}")
+        logger.info(f"\nFiles modified: {len({c['file'] for c in self.changes_made})}")
 
         if self.backups_created:
             logger.info(f"\nBackups created: {len(self.backups_created)}")
 
     def generate_review_queue(self, repairs_file: Path, output_file: Path):
         """Generate manual review queue for low-confidence repairs"""
-        with open(repairs_file, 'r', encoding='utf-8') as f:
+        with open(repairs_file, encoding='utf-8') as f:
             repairs_data = json.load(f)
 
         # Filter low-confidence repairs
@@ -345,7 +353,7 @@ class BatchLinkFixer:
         ]
 
         # Load links data for context
-        with open('links.json', 'r', encoding='utf-8') as f:
+        with open('links.json', encoding='utf-8') as f:
             links_data = json.load(f)
 
         # Create URL to context mapping
@@ -370,7 +378,7 @@ class BatchLinkFixer:
             review.append(f"**Notes:** {repair.get('notes', 'N/A')}")
 
             if context:
-                review.append(f"\n**Context:**")
+                review.append("\n**Context:**")
                 review.append(f"> {context.get('context_before', '')[:200]}...")
                 review.append(f"> **[{context.get('text', 'link')}]**")
                 review.append(f"> {context.get('context_after', '')[:200]}...")

--- a/scripts/link-validation/citation-repair.py
+++ b/scripts/link-validation/citation-repair.py
@@ -42,18 +42,17 @@ RELATED_SCRIPTS:
 MANIFEST_REGISTRY: scripts/citation-repair.py
 """
 
+import argparse
+import asyncio
 import json
 import re
-import asyncio
-import aiohttp
-import argparse
 import sys
-from pathlib import Path
-from typing import Dict, List, Optional, Tuple
-from dataclasses import dataclass, asdict
+from dataclasses import asdict, dataclass
 from datetime import datetime
-from urllib.parse import unquote, urlparse, quote
-import hashlib
+from pathlib import Path
+from urllib.parse import quote, unquote, urlparse
+
+import aiohttp
 
 # Path setup for centralized logging
 sys.path.insert(0, str(Path(__file__).parent.parent / "lib"))
@@ -116,7 +115,7 @@ class CitationRepair:
         self.repair_cache = {}
 
     @classmethod
-    def _extract_doi(cls, text: str) -> Optional[str]:
+    def _extract_doi(cls, text: str) -> str | None:
         match = cls.DOI_RE.search(text or '')
         if not match:
             return None
@@ -127,7 +126,7 @@ class CitationRepair:
         return doi.lower()
 
     @staticmethod
-    def _domain_path(url: str) -> Tuple[str, str]:
+    def _domain_path(url: str) -> tuple[str, str]:
         parsed = urlparse(url)
         return parsed.netloc.lower().removeprefix('www.'), parsed.path.rstrip('/')
 
@@ -151,7 +150,7 @@ class CitationRepair:
         return self._same_live_target(original_url, archived_url)
 
     @staticmethod
-    def _relevance_supports_replacement(relevance: Optional[Dict]) -> bool:
+    def _relevance_supports_replacement(relevance: dict | None) -> bool:
         if not relevance:
             return False
 
@@ -167,7 +166,7 @@ class CitationRepair:
         return isinstance(score, (int, float)) and score >= 0.8
 
     def _cap_confidence(self, confidence: float, original_url: str, suggested_url: str,
-                        repair_type: str, relevance: Optional[Dict] = None,
+                        repair_type: str, relevance: dict | None = None,
                         is_archived: bool = False) -> float:
         """Keep high confidence only for identity-preserving repairs.
 
@@ -196,8 +195,8 @@ class CitationRepair:
         if self.session:
             await self.session.close()
 
-    async def find_repairs(self, links_data: Dict, validation_data: Dict,
-                          relevance_data: Dict) -> List[RepairSuggestion]:
+    async def find_repairs(self, links_data: dict, validation_data: dict,
+                          relevance_data: dict) -> list[RepairSuggestion]:
         """Find repairs for all broken links"""
         repairs = []
 
@@ -220,8 +219,8 @@ class CitationRepair:
 
         return repairs
 
-    def _identify_broken_links(self, links_data: Dict, validation_data: Dict,
-                              relevance_data: Dict) -> List[Dict]:
+    def _identify_broken_links(self, links_data: dict, validation_data: dict,
+                              relevance_data: dict) -> list[dict]:
         """Identify links that need repair"""
         broken = []
 
@@ -262,7 +261,7 @@ class CitationRepair:
 
         return broken
 
-    async def _find_replacement(self, link_info: Dict) -> Optional[RepairSuggestion]:
+    async def _find_replacement(self, link_info: dict) -> RepairSuggestion | None:
         """Find replacement for a single broken link"""
         link = link_info['link']
         url = link['url']
@@ -293,7 +292,7 @@ class CitationRepair:
 
         return suggestion
 
-    async def _repair_academic_citation(self, link_info: Dict) -> Optional[RepairSuggestion]:
+    async def _repair_academic_citation(self, link_info: dict) -> RepairSuggestion | None:
         """Repair academic citations"""
         link = link_info['link']
         url = link['url']
@@ -324,8 +323,8 @@ class CitationRepair:
 
         return None
 
-    async def _search_arxiv(self, paper_info: Dict, original_url: str,
-                            relevance: Optional[Dict] = None) -> Optional[RepairSuggestion]:
+    async def _search_arxiv(self, paper_info: dict, original_url: str,
+                            relevance: dict | None = None) -> RepairSuggestion | None:
         """Search arXiv for paper"""
         if not paper_info.get('title'):
             return None
@@ -368,8 +367,8 @@ class CitationRepair:
 
         return None
 
-    async def _search_crossref(self, paper_info: Dict, original_url: str,
-                               relevance: Optional[Dict] = None) -> Optional[RepairSuggestion]:
+    async def _search_crossref(self, paper_info: dict, original_url: str,
+                               relevance: dict | None = None) -> RepairSuggestion | None:
         """Search CrossRef for DOI"""
         if not paper_info.get('title'):
             return None
@@ -410,16 +409,16 @@ class CitationRepair:
 
         return None
 
-    async def _search_semantic_scholar(self, paper_info: Dict,
+    async def _search_semantic_scholar(self, paper_info: dict,
                                       original_url: str,
-                                      relevance: Optional[Dict] = None) -> Optional[RepairSuggestion]:
+                                      relevance: dict | None = None) -> RepairSuggestion | None:
         """Search Semantic Scholar"""
         # Simplified - would need API key for production
         return None
 
-    async def _check_doi_resolution(self, paper_info: Dict,
+    async def _check_doi_resolution(self, paper_info: dict,
                                    original_url: str,
-                                   relevance: Optional[Dict] = None) -> Optional[RepairSuggestion]:
+                                   relevance: dict | None = None) -> RepairSuggestion | None:
         """Check if DOI can be resolved"""
         doi = paper_info.get('doi')
         if not doi:
@@ -449,14 +448,14 @@ class CitationRepair:
 
         return None
 
-    async def _find_pmc_version(self, paper_info: Dict,
+    async def _find_pmc_version(self, paper_info: dict,
                                original_url: str,
-                               relevance: Optional[Dict] = None) -> Optional[RepairSuggestion]:
+                               relevance: dict | None = None) -> RepairSuggestion | None:
         """Find PubMed Central open access version"""
         # Simplified - would use PMC API
         return None
 
-    async def _repair_documentation_link(self, link_info: Dict) -> Optional[RepairSuggestion]:
+    async def _repair_documentation_link(self, link_info: dict) -> RepairSuggestion | None:
         """Repair broken documentation links"""
         link = link_info['link']
         url = link['url']
@@ -479,7 +478,7 @@ class CitationRepair:
 
         return None
 
-    async def _repair_with_wayback(self, link_info: Dict) -> Optional[RepairSuggestion]:
+    async def _repair_with_wayback(self, link_info: dict) -> RepairSuggestion | None:
         """Try to find archived version in Wayback Machine"""
         url = link_info['link']['url']
 
@@ -521,7 +520,7 @@ class CitationRepair:
 
         return None
 
-    async def _validate_redirect(self, link_info: Dict) -> Optional[RepairSuggestion]:
+    async def _validate_redirect(self, link_info: dict) -> RepairSuggestion | None:
         """Validate and suggest accepting redirects"""
         validation = link_info.get('validation', {})
         final_url = validation.get('final_url')
@@ -562,7 +561,7 @@ class CitationRepair:
 
         return None
 
-    async def _find_open_access_version(self, link_info: Dict) -> Optional[RepairSuggestion]:
+    async def _find_open_access_version(self, link_info: dict) -> RepairSuggestion | None:
         """Find open access version of paywalled content"""
         # Would use Unpaywall API or similar
         # For now, try arXiv as fallback
@@ -599,7 +598,7 @@ class CitationRepair:
 
         return False
 
-    def _extract_paper_info(self, context: str, url: str) -> Dict:
+    def _extract_paper_info(self, context: str, url: str) -> dict:
         """Extract paper information from context"""
         info = {}
 
@@ -633,7 +632,7 @@ class CitationRepair:
 
         return info
 
-    def save_results(self, repairs: List[RepairSuggestion], output_file: Path):
+    def save_results(self, repairs: list[RepairSuggestion], output_file: Path):
         """Save repair suggestions"""
         data = {
             'repair_date': datetime.now().isoformat(),
@@ -682,13 +681,13 @@ Examples:
 
     try:
         # Load input data
-        with open(args.links, 'r') as f:
+        with open(args.links) as f:
             links_data = json.load(f)
 
-        with open(args.validation, 'r') as f:
+        with open(args.validation) as f:
             validation_data = json.load(f)
 
-        with open(args.relevance, 'r') as f:
+        with open(args.relevance) as f:
             relevance_data = json.load(f)
 
         # Initialize repair tool
@@ -709,7 +708,7 @@ Examples:
         sys.exit(0)
     except FileNotFoundError as e:
         logger.error(f"Error: File not found: {e}")
-        logger.error(f"Expected files: links.json, validation.json, relevance.json")
+        logger.error("Expected files: links.json, validation.json, relevance.json")
         logger.info("Tip: Run link extraction and validation first")
         sys.exit(2)
     except Exception as e:

--- a/scripts/link-validation/citation-report.py
+++ b/scripts/link-validation/citation-report.py
@@ -40,13 +40,11 @@ DEPENDENCIES:
 MANIFEST_REGISTRY: scripts/link-validation/citation-report.py
 """
 
-import json
 import argparse
+import json
 import sys
-from pathlib import Path
 from collections import defaultdict
-from typing import Dict, List
-from datetime import datetime
+from pathlib import Path
 
 # Add lib directory to path for logging_config
 sys.path.insert(0, str(Path(__file__).parent.parent / "lib"))
@@ -55,7 +53,7 @@ from logging_config import setup_logger
 logger = setup_logger(__name__)
 
 
-def generate_citation_report(validation_data: Dict, links_data: Dict) -> str:
+def generate_citation_report(validation_data: dict, links_data: dict) -> str:
     """Generate markdown report for broken citation links"""
 
     # Map validation results by URL
@@ -301,11 +299,11 @@ def main() -> int:
 
         # Load data
         logger.debug(f"Loading validation results from {args.input}")
-        with open(args.input, 'r', encoding='utf-8') as f:
+        with open(args.input, encoding='utf-8') as f:
             validation_data = json.load(f)
 
         logger.debug(f"Loading link data from {args.links}")
-        with open(args.links, 'r', encoding='utf-8') as f:
+        with open(args.links, encoding='utf-8') as f:
             links_data = json.load(f)
 
         if args.verbose:

--- a/scripts/link-validation/link-extractor.py
+++ b/scripts/link-validation/link-extractor.py
@@ -42,15 +42,14 @@ RELATED_SCRIPTS:
 MANIFEST_REGISTRY: scripts/link-extractor.py
 """
 
-import re
-import json
 import argparse
-import sys
-from pathlib import Path
-from typing import Dict, List, Tuple
-from dataclasses import dataclass, asdict
-from datetime import datetime
 import hashlib
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
 
 # Setup logging
 sys.path.insert(0, str(Path(__file__).parent.parent / "lib"))
@@ -118,7 +117,7 @@ class LinkExtractor:
             'by_domain': {}
         }
 
-    def extract_all(self) -> List[LinkContext]:
+    def extract_all(self) -> list[LinkContext]:
         """Extract links from all markdown files"""
         md_files = list(self.posts_dir.glob('*.md'))
         self.stats['total_files'] = len(md_files)
@@ -219,7 +218,7 @@ class LinkExtractor:
         return url
 
     def _add_link(self, url: str, text: str, file_path: Path,
-                  line_number: int, position: int, lines: List[str],
+                  line_number: int, position: int, lines: list[str],
                   line_idx: int):
         """Add a link with its context"""
         url = self._clean_trailing_punct(url)
@@ -254,7 +253,7 @@ class LinkExtractor:
         if domain:
             self.stats['by_domain'][domain] = self.stats['by_domain'].get(domain, 0) + 1
 
-    def _get_context(self, lines: List[str], center_idx: int,
+    def _get_context(self, lines: list[str], center_idx: int,
                      line_offset: int, word_limit: int) -> str:
         """Get context around a line"""
         if line_offset < 0:

--- a/scripts/link-validation/link-report-generator.py
+++ b/scripts/link-validation/link-report-generator.py
@@ -42,14 +42,13 @@ RELATED_SCRIPTS:
 MANIFEST_REGISTRY: scripts/link-report-generator.py
 """
 
-import json
-import csv
 import argparse
+import csv
+import json
 import sys
-from pathlib import Path
-from typing import Dict, List
-from datetime import datetime
 from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
 
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent / "lib"))
@@ -63,8 +62,8 @@ class ReportGenerator:
     def __init__(self):
         self.stats = defaultdict(int)
 
-    def generate_all_reports(self, links_data: Dict, validation_data: Dict,
-                           relevance_data: Dict, repairs_data: Dict,
+    def generate_all_reports(self, links_data: dict, validation_data: dict,
+                           relevance_data: dict, repairs_data: dict,
                            output_dir: Path):
         """Generate all report formats"""
         output_dir.mkdir(parents=True, exist_ok=True)
@@ -90,8 +89,8 @@ class ReportGenerator:
             output_dir / 'action_plan.md'
         )
 
-    def generate_summary_report(self, links_data: Dict, validation_data: Dict,
-                               relevance_data: Dict, repairs_data: Dict,
+    def generate_summary_report(self, links_data: dict, validation_data: dict,
+                               relevance_data: dict, repairs_data: dict,
                                output_file: Path):
         """Generate markdown summary report"""
         # Calculate statistics
@@ -144,8 +143,8 @@ class ReportGenerator:
 
         logger.info(f"Summary report saved to {output_file}")
 
-    def generate_detailed_csv(self, links_data: Dict, validation_data: Dict,
-                             relevance_data: Dict, repairs_data: Dict,
+    def generate_detailed_csv(self, links_data: dict, validation_data: dict,
+                             relevance_data: dict, repairs_data: dict,
                              output_file: Path):
         """Generate detailed CSV report"""
         # Map results by URL
@@ -187,8 +186,8 @@ class ReportGenerator:
 
         logger.info(f"Detailed CSV saved to {output_file}")
 
-    def generate_manual_review_queue(self, links_data: Dict, validation_data: Dict,
-                                    relevance_data: Dict, repairs_data: Dict,
+    def generate_manual_review_queue(self, links_data: dict, validation_data: dict,
+                                    relevance_data: dict, repairs_data: dict,
                                     output_file: Path):
         """Generate manual review queue"""
         # Map results
@@ -263,12 +262,10 @@ class ReportGenerator:
 
         logger.info(f"Manual review queue saved to {output_file}")
 
-    def generate_action_plan(self, links_data: Dict, validation_data: Dict,
-                            relevance_data: Dict, repairs_data: Dict,
+    def generate_action_plan(self, links_data: dict, validation_data: dict,
+                            relevance_data: dict, repairs_data: dict,
                             output_file: Path):
         """Generate action plan for fixes"""
-        repairs_map = {r['original_url']: r for r in repairs_data.get('repairs', [])}
-
         # Group repairs by confidence
         high_confidence = []
         medium_confidence = []
@@ -326,8 +323,8 @@ class ReportGenerator:
 
         logger.info(f"Action plan saved to {output_file}")
 
-    def _calculate_statistics(self, links_data: Dict, validation_data: Dict,
-                             relevance_data: Dict, repairs_data: Dict) -> Dict:
+    def _calculate_statistics(self, links_data: dict, validation_data: dict,
+                             relevance_data: dict, repairs_data: dict) -> dict:
         """Calculate comprehensive statistics"""
         stats = {
             'total_links': len(links_data.get('links', [])),
@@ -429,16 +426,16 @@ Examples:
 
     try:
         # Load all data
-        with open(args.links, 'r') as f:
+        with open(args.links) as f:
             links_data = json.load(f)
 
-        with open(args.validation, 'r') as f:
+        with open(args.validation) as f:
             validation_data = json.load(f)
 
-        with open(args.relevance, 'r') as f:
+        with open(args.relevance) as f:
             relevance_data = json.load(f)
 
-        with open(args.repairs, 'r') as f:
+        with open(args.repairs) as f:
             repairs_data = json.load(f)
 
         # Generate reports
@@ -451,7 +448,7 @@ Examples:
         sys.exit(0)
     except FileNotFoundError as e:
         print(f"Error: File not found: {e}", file=sys.stderr)
-        print(f"Expected files: links.json, validation.json, relevance.json, repairs.json", file=sys.stderr)
+        print("Expected files: links.json, validation.json, relevance.json, repairs.json", file=sys.stderr)
         print("Tip: Run link extraction, validation, and repair first", file=sys.stderr)
         sys.exit(2)
     except Exception as e:

--- a/scripts/link-validation/link-validator.py
+++ b/scripts/link-validation/link-validator.py
@@ -42,26 +42,25 @@ RELATED_SCRIPTS:
 MANIFEST_REGISTRY: scripts/link-validator.py
 """
 
-import json
-import asyncio
 import argparse
-import re
-import sys
+import asyncio
+import json
 import logging
-from pathlib import Path
-from typing import Dict, List, Optional, Tuple
-from dataclasses import dataclass, asdict
-from datetime import datetime
-import hashlib
+import re
 import ssl
+import sys
 import time
-from urllib.parse import urlparse, urljoin
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from urllib.parse import urlparse
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from lib.logging_config import setup_logger
 
 try:
-    from playwright.async_api import async_playwright, TimeoutError as PlaywrightTimeout
+    from playwright.async_api import TimeoutError as PlaywrightTimeout
+    from playwright.async_api import async_playwright
     PLAYWRIGHT_AVAILABLE = True
 except ImportError:
     PLAYWRIGHT_AVAILABLE = False
@@ -70,18 +69,19 @@ except ImportError:
 import aiohttp
 import certifi
 
+
 @dataclass
 class ValidationResult:
     """Result of link validation"""
     url: str
     status: str  # valid, broken, restricted, redirect, timeout, error
-    status_code: Optional[int]
-    final_url: Optional[str]
-    issue_type: Optional[str]  # 404, 403, http_401, timeout, wrong_content, paywall, redirect, ssl_error
-    error_message: Optional[str]
+    status_code: int | None
+    final_url: str | None
+    issue_type: str | None  # 404, 403, http_401, timeout, wrong_content, paywall, redirect, ssl_error
+    error_message: str | None
     response_time: float
-    content_type: Optional[str]
-    page_title: Optional[str]
+    content_type: str | None
+    page_title: str | None
     requires_js: bool
     ssl_valid: bool
     validation_time: str
@@ -206,7 +206,7 @@ class LinkValidator:
             return 'restricted', f'http_{status_code}'
         return 'restricted', f'http_{status_code}'
 
-    async def validate_batch(self, links: List[Dict]) -> List[ValidationResult]:
+    async def validate_batch(self, links: list[dict]) -> list[ValidationResult]:
         """Validate a batch of links"""
         results = []
 
@@ -219,7 +219,7 @@ class LinkValidator:
             domain_groups[domain].append(link)
 
         # Process each domain group with rate limiting
-        for domain, domain_links in domain_groups.items():
+        for _domain, domain_links in domain_groups.items():
             for link_data in domain_links:
                 result = await self.validate_link(link_data['url'])
                 results.append(result)
@@ -351,7 +351,7 @@ class LinkValidator:
                     retry_count=retry + 1
                 )
 
-        except asyncio.TimeoutError:
+        except TimeoutError:
             return ValidationResult(
                 url=url,
                 status='timeout',
@@ -508,10 +508,10 @@ class LinkValidator:
         try:
             parsed = urlparse(url)
             return parsed.netloc
-        except:
+        except ValueError:
             return 'unknown'
 
-    async def save_results(self, results: List[ValidationResult], output_file: Path, logger=None):
+    async def save_results(self, results: list[ValidationResult], output_file: Path, logger=None):
         """Save validation results to JSON"""
         data = {
             'validation_date': datetime.now().isoformat(),
@@ -562,7 +562,7 @@ async def main():
         return 1
 
     # Load links
-    with open(args.input, 'r', encoding='utf-8') as f:
+    with open(args.input, encoding='utf-8') as f:
         data = json.load(f)
 
     links = data['links']

--- a/scripts/link-validation/simple-validator.py
+++ b/scripts/link-validation/simple-validator.py
@@ -42,15 +42,15 @@ RELATED_SCRIPTS:
 MANIFEST_REGISTRY: scripts/simple-validator.py
 """
 
-import json
-import asyncio
-import aiohttp
-import sys
-from pathlib import Path
-from typing import Dict, List, Optional
-from datetime import datetime
 import argparse
+import asyncio
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
 from urllib.parse import urlparse
+
+import aiohttp
 
 # Setup logging
 sys.path.insert(0, str(Path(__file__).parent.parent / "lib"))
@@ -97,8 +97,8 @@ class SimpleValidator:
             'error': 0,
             'needs_manual': 0,
         }
-        self._domain_locks: Dict[str, asyncio.Lock] = {}
-        self._domain_last: Dict[str, float] = {}
+        self._domain_locks: dict[str, asyncio.Lock] = {}
+        self._domain_last: dict[str, float] = {}
 
     async def __aenter__(self):
         timeout = aiohttp.ClientTimeout(total=20)
@@ -144,13 +144,13 @@ class SimpleValidator:
         msg = str(exc).lower()
         return 'name or service not known' in msg or 'nodename nor servname' in msg
 
-    def _record(self, result: Dict, status: str, issue_type: Optional[str] = None):
+    def _record(self, result: dict, status: str, issue_type: str | None = None):
         result['status'] = status
         result['issue_type'] = issue_type
         self.stats[status] = self.stats.get(status, 0) + 1
         return result
 
-    async def validate_url(self, url: str) -> Dict:
+    async def validate_url(self, url: str) -> dict:
         """Validate a single URL.
 
         HEAD first (cheap); on any non-final code, retry with a ranged GET using
@@ -183,7 +183,7 @@ class SimpleValidator:
             status, issue_type = self.classify_status(code)
             self._record(result, status, issue_type)
 
-        except asyncio.TimeoutError:
+        except TimeoutError:
             self._record(result, 'timeout', 'timeout')
             result['notes'] = 'Request timed out'
         except aiohttp.ClientError as e:
@@ -207,7 +207,7 @@ class SimpleValidator:
                 url, allow_redirects=True, headers={'Range': 'bytes=0-0'}
             ) as gr:
                 return gr.status, str(gr.url)
-        except (aiohttp.ClientError, asyncio.TimeoutError):
+        except (TimeoutError, aiohttp.ClientError):
             return code, final_url
 
     async def _retry_after(self, url, domain, code, final_url):
@@ -219,10 +219,10 @@ class SimpleValidator:
                 url, allow_redirects=True, headers={'Range': 'bytes=0-0'}
             ) as gr:
                 return gr.status, str(gr.url)
-        except (aiohttp.ClientError, asyncio.TimeoutError):
+        except (TimeoutError, aiohttp.ClientError):
             return code, final_url
 
-    async def validate_batch(self, urls: List[str], batch_size: int = 10, quiet: bool = False) -> List[Dict]:
+    async def validate_batch(self, urls: list[str], batch_size: int = 10, quiet: bool = False) -> list[dict]:
         """Validate URLs in batches"""
         results = []
         unique_urls = list(set(urls))
@@ -240,11 +240,11 @@ class SimpleValidator:
         self.results = results
         return results
 
-    def get_broken_links(self) -> List[Dict]:
+    def get_broken_links(self) -> list[dict]:
         """Get all broken links"""
         return [r for r in self.results if r['status'] == 'broken']
 
-    def get_redirects(self) -> List[Dict]:
+    def get_redirects(self) -> list[dict]:
         """Get all redirected links"""
         return [r for r in self.results if r['status'] == 'redirect']
 
@@ -260,7 +260,7 @@ class SimpleValidator:
             json.dump(data, f, indent=2)
 
         if not quiet:
-            logger.info(f"\n✅ Validation complete!")
+            logger.info("\n✅ Validation complete!")
             logger.info(f"  Total: {self.stats['total']}")
             logger.info(f"  Valid: {self.stats['valid']}")
             logger.info(f"  Broken: {self.stats['broken']}")
@@ -293,11 +293,11 @@ Examples:
     if not args.links.exists():
         logger.error(f"Error: File not found: {args.links}")
         logger.error(f"Expected: {args.links.absolute()}")
-        logger.error(f"Tip: Run from repository root or provide absolute path")
+        logger.error("Tip: Run from repository root or provide absolute path")
         sys.exit(2)
 
     # Load links
-    with open(args.links, 'r') as f:
+    with open(args.links) as f:
         links_data = json.load(f)
 
     urls = [link['url'] for link in links_data.get('links', [])]

--- a/scripts/link-validation/tests/test_batch_link_fixer.py
+++ b/scripts/link-validation/tests/test_batch_link_fixer.py
@@ -1,7 +1,6 @@
 """Regression tests for batch-link-fixer.py URL substitution."""
 
 import pytest
-
 from conftest import load_script
 
 blf = load_script("batch-link-fixer.py")

--- a/scripts/link-validation/tests/test_link_extractor.py
+++ b/scripts/link-validation/tests/test_link_extractor.py
@@ -4,7 +4,6 @@ Guards the trailing-punctuation bug that produced hundreds of false-positive
 404s and broke the link/citation workflows on every run.
 """
 import pytest
-
 from conftest import load_script
 
 le = load_script("link-extractor.py")

--- a/scripts/link-validation/tests/test_link_validator.py
+++ b/scripts/link-validation/tests/test_link_validator.py
@@ -17,7 +17,6 @@ publisher, not a dead citation, and classifying it as broken feeds live sources
 into the auto-repair queue.
 """
 import pytest
-
 from conftest import load_script
 
 lv = load_script("link-validator.py")

--- a/scripts/link-validation/tests/test_simple_validator.py
+++ b/scripts/link-validation/tests/test_simple_validator.py
@@ -4,7 +4,6 @@ Locks in the rule that bot-blocking / soft codes are 'needs_manual', NOT
 'broken' -- only 404/410 and DNS failures are broken (issue #240).
 """
 import pytest
-
 from conftest import load_script
 
 sv = load_script("simple-validator.py")

--- a/scripts/theme-deck/generate.py
+++ b/scripts/theme-deck/generate.py
@@ -94,12 +94,12 @@ SYNTAX_SLOTS = {
 
 # --- oklch -> sRGB (standard Björn Ottosson matrices) ---------------------
 
-def oklch_to_linear_srgb(l, c, h):
+def oklch_to_linear_srgb(lightness, c, h):
     a = c * math.cos(math.radians(h))
     b = c * math.sin(math.radians(h))
-    l_ = (l + 0.3963377774 * a + 0.2158037573 * b) ** 3
-    m_ = (l - 0.1055613458 * a - 0.0638541728 * b) ** 3
-    s_ = (l - 0.0894841775 * a - 1.2914855480 * b) ** 3
+    l_ = (lightness + 0.3963377774 * a + 0.2158037573 * b) ** 3
+    m_ = (lightness - 0.1055613458 * a - 0.0638541728 * b) ** 3
+    s_ = (lightness - 0.0894841775 * a - 1.2914855480 * b) ** 3
     r = +4.0767416621 * l_ - 3.3077115913 * m_ + 0.2309699292 * s_
     g = -1.2684380046 * l_ + 2.6097574011 * m_ - 0.3413193965 * s_
     bl = -0.0041960863 * l_ - 0.7034186147 * m_ + 1.7076147010 * s_
@@ -118,7 +118,7 @@ def contrast(lch1, lch2):
 
 
 def mix(lch_a, lch_b, share_a):
-    """Approximate color-mix(in oklch, A share%, B) — linear l/c, shortest-arc hue."""
+    """Approximate color-mix(in oklch, A share%, B) — linear L/C, shortest-arc hue."""
     la, ca, ha = lch_a
     lb, cb, hb = lch_b
     t = share_a
@@ -127,13 +127,13 @@ def mix(lch_a, lch_b, share_a):
 
 
 def css(lch):
-    l, c, h = lch
-    return f"oklch({l:.4f} {c:.4f} {h:.1f})"
+    lightness, c, h = lch
+    return f"oklch({lightness:.4f} {c:.4f} {h:.1f})"
 
 
 def rounded(lch):
-    l, c, h = lch
-    return (round(l, 4), round(c, 4), round(h % 360, 1))
+    lightness, c, h = lch
+    return (round(lightness, 4), round(c, 4), round(h % 360, 1))
 
 
 def as_lch(color):
@@ -166,7 +166,7 @@ def solve_contrast_lch(lch, backgrounds, floor):
 
     bg_lum = sum(luminance(bg) for bg in backgrounds) / len(backgrounds)
     lighten = bg_lum < 0.5
-    l, c, h = lch
+    lightness, c, h = lch
     target = floor + CONTRAST_MARGIN
 
     def passes(value):
@@ -190,7 +190,7 @@ def solve_contrast_lch(lch, backgrounds, floor):
         c = lo_c
 
     if lighten:
-        lo, hi = l, 1.0
+        lo, hi = lightness, 1.0
         for _ in range(48):
             mid = (lo + hi) / 2
             trial = rounded((mid, c, h))
@@ -200,7 +200,7 @@ def solve_contrast_lch(lch, backgrounds, floor):
                 lo = mid
         return rounded((hi, c, h))
 
-    lo, hi = 0.0, l
+    lo, hi = 0.0, lightness
     for _ in range(48):
         mid = (lo + hi) / 2
         trial = rounded((mid, c, h))


### PR DESCRIPTION
Phase 1 of the review sweep epic (#509). The consensus vote chose gate integrity first, 6–1; the dissent argued the auto-repair stopgap should not wait behind it, and four approvers agreed, so that rides along here.

Closes #492, #493, #494, #497, #507. Mitigates #495 (stopgap only — the write-path fix stays open).

## Why these first

Every serious finding in the sweep was the same shape: **a mechanism that reports success without having done its job.** These are the ones guarding merge and deploy, so nothing else can be verified until they work.

Each fix ships with a negative control — a planted failure proving the check now fires. That is the property all of these were missing.

## #492 — the only required check failed open

`remarque` is the sole entry in `required_status_checks.contexts`. Its wrapper never read `spawnSync`'s `result.status` or `result.error`, and its only failure signal was counting lines starting with `  ✗`. Empty output → zero failures → *"remarque-audit passed ✓"* → exit 0.

Four-arm verification after the fix:

| arm | expected | result |
|---|---|---|
| clean tree, real tool | 0 | **0** |
| planted `font-size:10px; color:#ff0000` | 1 | **1** |
| tool cannot be spawned (`npx` exits 1, no output) | 1 | **1** |
| tool exits 0 but emits no check lines | 1 | **1** |

## #493 — gitleaks was blind to every blog post

```toml
[allowlist]
  paths = ['''src/posts/.*\.md$''']    # removed
```

gitleaks combines `paths` and `regexes` as an **OR**, so this exempted every finding in every post regardless of the regexes — in the one directory where terminal transcripts and homelab configs get pasted. The file's own comment claimed the opposite.

Three-arm test that established it: default ruleset **4** planted findings → repo config **2** (posts suppressed) → same config minus only the `paths` entry → **4** again.

The four tutorial-default regexes (`admin:admin`, `root:root`, …) matched nothing anywhere in the corpus. The genuine false positives are now allowlisted **by value**, so they survive the line moving:

- `X25519MLKEM768` — a TLS named group, not a key
- `gh[pousr]_x{16,}` — zero-entropy placeholders (the `.env.example` hit had **1 unique character** across 37)
- the dnscrypt-proxy resolver key — a **public** minisign key (`RW` prefix), published so clients can verify

Verified both directions:

```
ARM A: full-history scan of the real repo   -> exit 0, no leaks found
ARM B: planted PAT + AWS key in src/posts/  -> exit 1, 2 findings
```

Arm B is the one that matters. A config that is merely green proves nothing.

## #494 — the daily cron was red on every scheduled run

A `linkedin-client-secret` match on `linkedin: williamzujkowski` in `src/pages/about.md`, deleted in `d1bbfec`. Push runs scan a commit range and passed; scheduled runs scan full history and failed — training alarm-blindness on the only step in `security-scan` that can fail (Trivy has no `exit-code`, pip-audit is `|| true` *and* `continue-on-error`).

`.gitleaksignore` pins that finding plus 8 `AKIA`-shaped substrings occurring by chance inside base64 JPEG filmstrips in deleted Lighthouse JSON. **Fingerprints, not path globs** — a path glob is what caused #493.

All 13 historical findings were triaged individually; none is a real credential.

## #495 — stopgap only

`--dry-run` on the apply step. `_replace_url` does a blanket substring replace outside markdown links, so it rewrites URLs inside code fences, inline code and blockquotes; prefix-collides (repairing `ex.com/a` also rewrites `ex.com/abc`); and mangles prose when the extractor truncates a parenthesised URL. All three reproduced in #495.

The job has run daily and **has never opened a repair PR**, so nothing is lost by holding it. Control-tested: `--apply` alone writes the file, `--apply --dry-run` does not.

## #497 — three bars nothing enforced

**ruff** — configured with seven rule families, never invoked, **224 violations**. Config migrated off ruff's deprecated top-level keys to `[tool.ruff.lint]` (it would not have applied as written), 192 auto-fixed, the rest by hand, with an `E701/E702/E402` exemption scoped to the one-shot `corpus-audit` scripts and a comment saying why. Now **0**, wired into `tests.yml` as a ratchet.

Three hand fixes worth reading:

- a bare `except:` in `link-validator.py`
- a dead `repairs_map` in one method of `link-report-generator.py` — the other three copies are live. My first attempt removed all four; **ruff itself caught it** (`F821` ×3), which is a decent argument for the whole change.
- `original_content` in `batch-link-fixer.py` was assigned and never read. It now guards the write, refusing to commit a repair that reports changes but produces byte-identical content.

**`pnpm test:unit`** — 7 passing tests covering `rehype-sidenotes.mjs`, 356 lines of AST manipulation applied to every post, that no workflow had ever run. Wired into `audits.yml`. 70ms.

## #507 — NODE_ENV was not pinned

With `NODE_ENV=development` exported, `pnpm build` silently produced a dev-mode bundle: **+24.7% client JS** and a `server-render-time` attribute in every `astro-island`. CI was safe (`deploy.yml` sets it explicitly); local builds and the pre-commit hook were not.

Verified: building with `NODE_ENV=development` still exported now leaves **0** files carrying the dev attribute.

This also corrects the record — **the production build is reproducible.** Two clean builds differ in exactly one file, `feed.xml`'s `lastBuildDate`; font-fallback metrics are byte-identical. The variation reported earlier in the sweep was this NODE_ENV leak, not Astro nondeterminism.

## Verification

```
PASS  pytest link-validation (62 tests)
PASS  ruff check scripts/ clean
PASS  all 32 .py compile
PASS  all 7 link-validation CLIs respond
PASS  pnpm test:unit (newly wired)
PASS  pnpm check (astro check)
PASS  pnpm lint (eslint)
PASS  pnpm run audit (5 design audits)
PASS  remarque gate fails closed when tool can't run
PASS  gitleaks: repo history clean
PASS  dev-mode leak absent despite NODE_ENV=development
11 passed, 0 failed
```

Plus a differential test proving the `l` → `lightness` rename in `theme-deck/generate.py` is behaviour-preserving across **420** function outputs with all dict-key literals unchanged — the regex had silently rewritten `o["l"]` to `o["lightness"]`, which the diff review caught.

## Not in this PR

`enforce_admins` is `false` and only `remarque` is a required context. Adding `axe`, `check-lint` and `pytest` to the required set is a repo-settings change, not a file change — **your call**, tracked in #492.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AvTumDxQ2ntLDwsSefHtf
