### PR TITLE
docs(gists): say these are pseudocode, and add the drift check

### DIFF
--- a/gists/README.md
+++ b/gists/README.md
@@ -1,14 +1,19 @@
 # Blog Code Examples - GitHub Gists
 
-This directory contains all code examples referenced in blog posts as GitHub gists. Each file here corresponds to a gist link in the blog.
+This directory mirrors the code examples that blog posts link to as GitHub gists.
+
+**These are illustrative excerpts, not turnkey scripts.** They are written to be *read* alongside a post — to show the shape of an approach and the parts that matter. Expect placeholders (`<password>`, `10.0.10.11`), elided error handling, and steps that assume a homelab you do not have. Do not paste them into a terminal and expect them to run.
+
+What they *are* held to: every factual claim about a real tool must be correct. A config key that the tool ignores, a CLI flag that does not exist, or a comparison that inverts the security outcome is a defect even in an excerpt, because the reader learns it either way.
 
 ## Purpose
 
 Blog posts maintain <25% code-to-content ratio by linking to full implementations rather than embedding verbose code blocks. This directory serves as:
 
-1. **Source of truth** for all blog code examples
-2. **Local reference** for readers who prefer browsing locally
-3. **Gist sync source** for maintaining GitHub gists
+1. **Local reference** for the published gists (the gists themselves are canonical —
+   if the two disagree, the gist wins)
+2. **Browsable copy** for readers who prefer reading in one place
+3. **Review surface** for auditing the examples as a set
 
 ## Organization
 
@@ -54,22 +59,49 @@ Blog posts include essential snippets (5-10 lines) demonstrating core patterns. 
 
 All code files include:
 
-**Header Format:**
+**Header Format** — use the comment syntax of the file's own language.
+Prescribing one universal header is how fourteen shell scripts ended up
+opening with a Python docstring, which bash reads as a command name.
+
+Python:
 ```python
 """
 Title: [Descriptive name]
 Source: https://williamzujkowski.github.io/posts/[slug]/
-Purpose: [What this does]
-Usage: [How to run]
+Purpose: [What this demonstrates]
+Requires: [What the reader must supply or verify]
 """
 ```
 
-**Quality Standards:**
-- ✅ Tested and working code (extracted from actual homelab)
-- ✅ Descriptive variable names
-- ✅ Inline comments for complex logic
-- ✅ Error handling included
-- ✅ Prerequisites documented
+Shell, YAML, TOML, conf:
+```bash
+#!/bin/bash
+# Title: [Descriptive name]
+# Source: https://williamzujkowski.github.io/posts/[slug]/
+# Purpose: [What this demonstrates]
+# Requires: [What the reader must supply or verify]
+```
+
+Where a reader's intuition about the tool would be wrong, say so in the header.
+The corrected `grype-config.yaml` is the model:
+
+```yaml
+# IMPORTANT: grype ignore rules DO NOT EXPIRE.
+# There is NO `expiration` field. A date written here is silently ignored and
+# the suppression is permanent.
+```
+
+**What these are held to:**
+- Every config key, CLI flag and API parameter exists in the real tool
+- Comparisons, filters and thresholds do what the surrounding prose says
+- Placeholders look like placeholders (`<password>`, not `secure-password`)
+- Destructive steps say so before the command
+- Prerequisites and assumptions are stated in the header
+
+**What they are not:**
+- Tested end to end, or extracted verbatim from a running system
+- Complete — error handling and edge cases are elided on purpose
+- Safe to run unmodified
 
 ## Quick Start by Category
 
@@ -84,9 +116,9 @@ cat README.md
 ```
 
 **Most useful files:**
-- `workflows/security-scan-workflow.yml` - GitHub Actions pipeline
+- `workflows/security-scan-workflow-complete.yml` - GitHub Actions pipeline
 - `configs/grype-config.yaml` - Grype configuration
-- `scripts/scan-comparison.py` - Scan result comparison
+- `scripts/vulnerability-scan-comparison.py` - Scan result comparison
 
 ### MITRE ATT&CK Dashboard
 
@@ -135,35 +167,37 @@ cat README.md
 
 ## Maintenance
 
-### Creating GitHub Gists
+There is no sync automation. Two scripts used to do this
+(`create-gists-from-folder.py`, `update-blog-posts-with-gists.py`); both were
+deleted, and nothing replaced them — which is why five local files have since
+drifted from their published gists without anything noticing.
 
-Use the automation script to create/update GitHub gists from local files:
+### Updating an example
 
-```bash
-python scripts/create-gists-from-folder.py
-```
-
-This generates:
-- Individual GitHub gists for each file
-- `gist-mapping.json` with URLs
-- Updated blog post markdown with real gist links
-
-### Updating Gists
-
-1. Edit files in `/gists` directory
-2. Test changes locally
-3. Run sync script to update GitHub gists
-4. Commit changes to repository
-
-### Syncing Blog Posts
-
-After creating/updating gists:
+The published gist is canonical, so change it there first:
 
 ```bash
-python scripts/update-blog-posts-with-gists.py
+# read what is published
+gh api gists/<id> --jq '.files["<filename>"].content'
+
+# after editing the gist in the browser or via `gh gist edit <id>`,
+# pull the published bytes back into this mirror
+gh api gists/<id> --jq '.files["<filename>"].content' > gists/<path>
 ```
 
-This replaces placeholder URLs with real gist URLs in blog posts.
+Then commit the mirror update. Editing only the local copy leaves the
+published gist — the thing readers actually see — untouched.
+
+### Checking for drift
+
+```bash
+uv run python scripts/gist-drift-check.py
+```
+
+Compares every entry in `gist-mapping.json` against its published gist and
+exits non-zero on any mismatch. All gists are public, so this needs no
+credentials beyond an authenticated `gh` for the rate limit. Worth running
+before touching anything in here.
 
 ## File Inventory
 
@@ -188,13 +222,13 @@ Found an issue or have an improvement?
 
 MIT License - See individual files for details.
 
-All code examples are from real homelab implementations documented in blog posts at [williamzujkowski.github.io](https://williamzujkowski.github.io).
+These examples accompany posts at [williamzujkowski.github.io](https://williamzujkowski.github.io). They are drawn from real homelab work, then trimmed for reading — treat them as illustrations of an approach, not as a distribution.
 
 ## Related Documentation
 
 - **Blog Posts:** [williamzujkowski.github.io/posts](https://williamzujkowski.github.io/posts/)
-- **Architecture:** [ARCHITECTURE.md](../docs/ARCHITECTURE.md)
-- **Standards:** [Standards Submodule](.standards/)
+- **Agent guidance:** [AGENTS.md](../AGENTS.md)
+- **Security posture:** [docs/security-posture.md](../docs/security-posture.md)
 - **Uses Page:** [Hardware/Software Stack](https://williamzujkowski.github.io/uses/)
 
 ---

--- a/gists/security-scanning/configs/grype-config.yaml
+++ b/gists/security-scanning/configs/grype-config.yaml
@@ -1,25 +1,29 @@
-# Grype Vulnerability Scanner Configuration
+# Grype configuration
 # Source: https://williamzujkowski.github.io/posts/2025-10-06-automated-security-scanning-pipeline/
-# Purpose: Configure Grype scanner with ignore rules and severity thresholds
-# Usage: Save as .grype.yaml in project root
+# Usage: save as .grype.yaml in the project root
+#
+# IMPORTANT: grype ignore rules DO NOT EXPIRE.
+# The IgnoreRule struct supports: vulnerability, include-aliases, reason,
+# namespace, fix-state, package, vex-status, vex-justification, match-type.
+# There is NO `expiration` field. A date written here is silently ignored and
+# the suppression is permanent. If you need time-boxed risk acceptance, use
+# OSV-Scanner's `ignoreUntil`, or enforce the review date outside grype.
 
-# Exclude false positives
-ignore:
-  - vulnerability: CVE-2023-12345
-    reason: "Not applicable - feature not used"
-    expiration: 2025-12-31
-
-  - vulnerability: GHSA-xxxx-yyyy-zzzz
-    package:
-      name: "lodash"
-      version: "4.17.20"
-    reason: "Testing environment only"
-
-# Configure severity thresholds
+# Fail the build on high or worse.
 fail-on-severity: high
 
-# Scope what to scan
+# Scan every layer, not just the squashed final filesystem — vulnerable files
+# deleted in a later layer are still present in the image.
 scope: all-layers
 
-# Output formatting
-output: json
+ignore:
+  # Every rule needs a reason. Since these never expire, the reason is the only
+  # thing a future reader has to judge whether it still applies.
+  - vulnerability: GHSA-1234-5678-9abc
+    reason: "Not applicable - the vulnerable feature is not enabled. REVIEW BY 2026-03-01 (not enforced by grype; see note above)."
+
+  - vulnerability: CVE-2024-12345
+    package:
+      name: example-package
+      version: 1.2.3
+    reason: "Test-environment dependency, not present in the production image."

--- a/gists/security-scanning/configs/osv-scanner-config.toml
+++ b/gists/security-scanning/configs/osv-scanner-config.toml
@@ -1,26 +1,32 @@
 # OSV-Scanner Configuration
 # Source: https://williamzujkowski.github.io/posts/2025-10-06-automated-security-scanning-pipeline/
-# Purpose: Configure OSV-Scanner for dependency scanning with ignore rules
-# Usage: Save as osv-scanner.toml in project root
+# Usage: save as osv-scanner.toml in the project root
+#
+# The supported schema is small. It is, in full:
+#   [[IgnoredVulns]]     id, ignoreUntil, reason
+#   [[PackageOverrides]] name, nameIsRegex, version, ecosystem, group,
+#                        ignore, vulnerability.ignore, license.ignore,
+#                        license.override, effectiveUntil, reason
+#   ScanGoModVersion     bool
+#   GoVersionOverride    string
+#
+# There is no worker-count, scan-depth, private-registry or dev-dependency
+# setting. Keys outside the schema above are ignored silently, which is the
+# dangerous part: a config that looks like it is doing something is not.
 
-[ignore]
-# Ignore specific vulnerabilities
-vulnerabilities = [
-  "GHSA-xxxx-yyyy-zzzz"
-]
+# Time-boxed risk acceptance. `ignoreUntil` genuinely expires — once the date
+# passes, the vulnerability reappears in results. This is the only real expiry
+# mechanism across grype/OSV/Trivy, so prefer OSV for accepted risks.
+[[IgnoredVulns]]
+id = "GHSA-1234-5678-9abc"
+ignoreUntil = 2026-03-01
+reason = "Vulnerable code path is not reachable from our entrypoints. Re-evaluate at the date above."
 
-# Ignore packages in devDependencies
-dev_dependencies = true
-
-# Custom package registries
-[[package_repositories]]
-name = "private-npm"
-url = "https://npm.internal.company.com"
-
-[scanning]
-# Skip git directories
-skip_git = true
-
-# Parallel scanning
-max_depth = 10
-workers = 4
+# Suppress findings for a specific package/version rather than a specific CVE.
+[[PackageOverrides]]
+name = "example-package"
+version = "1.2.3"
+ecosystem = "npm"
+ignore = true
+effectiveUntil = 2026-03-01
+reason = "Pinned deliberately pending upstream release; tracked in issue #42."

--- a/gists/security-scanning/configs/trivy-opa-policy.rego
+++ b/gists/security-scanning/configs/trivy-opa-policy.rego
@@ -1,25 +1,47 @@
-# Trivy OPA Policy for Security Scanning
+# Trivy ignore policy
 # Source: https://williamzujkowski.github.io/posts/2025-10-06-automated-security-scanning-pipeline/
-# Purpose: Define security policies using Open Policy Agent (OPA)
-# Usage: Save as policy/security.rego and reference with trivy --policy
+# Usage: trivy image --ignore-policy ./policy/security.rego myapp:latest
+#
+# READ THIS BEFORE WRITING A TRIVY POLICY.
+#
+# The flag is --ignore-policy. There is no --policy flag for this. And the name
+# is the semantics: a Trivy Rego policy FILTERS FINDINGS OUT. It cannot deny,
+# block, or fail a build. A policy written as "deny on critical" is, under the
+# only mechanism Trivy offers, either inert or a rule that SUPPRESSES criticals
+# — the opposite of what its author intended.
+#
+# Two further requirements that make a wrong policy silently no-op:
+#   1. The rule MUST be named `ignore`. A `deny` or `warn` rule is never
+#      evaluated.
+#   2. `input` is a SINGLE DetectedVulnerability object, not a collection.
+#      Iterating `input.Vulnerabilities[_]` never matches anything.
+#
+# To actually fail a build on severity, do not use Rego at all:
+#   trivy image --exit-code 1 --severity HIGH,CRITICAL myapp:latest
 
 package trivy
 
-# Deny images with critical vulnerabilities
-deny[msg] {
-    input.Vulnerabilities[_].Severity == "CRITICAL"
-    msg := sprintf("Critical vulnerability found: %s", [input.Vulnerabilities[_].VulnerabilityID])
+default ignore = false
+
+# Ignore unfixed findings below high severity. There is nothing to action on an
+# unfixed low, and leaving them in the report is how people stop reading it.
+ignore {
+	input.Severity == "LOW"
+	input.FixedVersion == ""
 }
 
-# Deny specific packages
-deny[msg] {
-    input.Packages[_].Name == "log4j"
-    input.Packages[_].Version < "2.17.0"
-    msg := "Log4j version < 2.17.0 detected (Log4Shell vulnerability)"
+ignore {
+	input.Severity == "MEDIUM"
+	input.FixedVersion == ""
 }
 
-# Warn on high severity
-warn[msg] {
-    input.Vulnerabilities[_].Severity == "HIGH"
-    msg := sprintf("High severity vulnerability: %s", [input.Vulnerabilities[_].VulnerabilityID])
+# Ignore a specific vulnerability with a recorded justification.
+ignore {
+	input.VulnerabilityID == "CVE-2024-12345"
+}
+
+# Ignore findings in a package that is present but not reachable at runtime.
+ignore {
+	input.PkgName == "example-package"
+	input.Severity != "CRITICAL"
 }

--- a/gists/security-scanning/workflows/auto-remediate-vulnerabilities.yml
+++ b/gists/security-scanning/workflows/auto-remediate-vulnerabilities.yml
@@ -30,12 +30,17 @@ jobs:
           npm audit fix
           npm update
 
+      - name: Run test suite
+        # Without this the workflow opens a PR claiming fixes are safe when
+        # nothing has verified they are. `npm audit fix` does break things.
+        run: npm test
+
       - name: Re-scan
         run: osv-scanner --lockfile=package-lock.json
 
       - name: Create pull request
         if: steps.scan.outputs.count > 0
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           commit-message: "chore: Update dependencies to fix vulnerabilities"
           title: "🔒 Security: Automated dependency updates"
@@ -49,3 +54,4 @@ jobs:
             Please review the changes and run tests before merging.
           branch: auto-remediate/vulnerabilities
           labels: security,dependencies
+

--- a/gists/security-scanning/workflows/security-scan-workflow-complete.yml
+++ b/gists/security-scanning/workflows/security-scan-workflow-complete.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run OSV-Scanner
-        uses: google/osv-scanner-action@v1.6.2
+        uses: google/osv-scanner-action@6e4298ebc4db23e847df9b2e2de2939d6f066c67 # v2.5.1
         with:
           scan-args: |-
             --lockfile=package-lock.json
@@ -59,7 +59,7 @@ jobs:
         run: docker build -t myapp:${{ github.sha }} .
 
       - name: Run Grype scan
-        uses: anchore/scan-action@v3
+        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
         id: grype
         with:
           image: "myapp:${{ github.sha }}"
@@ -84,7 +84,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -103,11 +103,32 @@ jobs:
     name: Security Quality Gate
     runs-on: ubuntu-latest
     needs: [dependency-scan, container-scan, comprehensive-scan]
+    # `always()` lets this job run even when an upstream job failed, so the gate
+    # can report on all three. It MUST therefore inspect the upstream results
+    # explicitly — without the check below, `always()` makes the gate pass no
+    # matter what the scanners found. That is the trap this file used to have.
     if: always()
 
     steps:
       - name: Evaluate security posture
+        env:
+          DEPS: ${{ needs.dependency-scan.result }}
+          CONTAINER: ${{ needs.container-scan.result }}
+          COMPREHENSIVE: ${{ needs.comprehensive-scan.result }}
         run: |
-          echo "All security scans completed"
-          # Download and analyze all SARIF reports
-          # Make final go/no-go decision
+          echo "dependency-scan:    $DEPS"
+          echo "container-scan:     $CONTAINER"
+          echo "comprehensive-scan: $COMPREHENSIVE"
+
+          failed=0
+          for r in "$DEPS" "$CONTAINER" "$COMPREHENSIVE"; do
+            # 'skipped' and 'cancelled' are not passes. Treat anything that is
+            # not an explicit success as a gate failure.
+            if [ "$r" != "success" ]; then failed=$((failed+1)); fi
+          done
+
+          if [ "$failed" -gt 0 ]; then
+            echo "::error::$failed of 3 security jobs did not succeed. Blocking."
+            exit 1
+          fi
+          echo "All three security jobs succeeded."

--- a/scripts/gist-drift-check.py
+++ b/scripts/gist-drift-check.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Compare each published gist against this repo's local mirror under gists/.
+
+The gists are canonical; gists/ is a browsable copy. Nothing enforced that the
+two agree, and five files silently diverged after the published versions were
+corrected (see gists/README.md). This is that missing mechanism.
+
+All the gists are public, so no credentials are needed beyond an authenticated
+`gh` for the API rate limit.
+
+Usage:
+    uv run python scripts/gist-drift-check.py            # report and exit 1 on drift
+    uv run python scripts/gist-drift-check.py --quiet    # only print problems
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+GISTS_DIR = REPO_ROOT / "gists"
+MAPPING = GISTS_DIR / "gist-mapping.json"
+
+
+def fetch_gist(gist_id: str) -> dict | None:
+    """Return the parsed gist payload, or None if it cannot be read."""
+    proc = subprocess.run(
+        ["gh", "api", f"gists/{gist_id}"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if proc.returncode != 0:
+        return None
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--quiet", action="store_true", help="only print files that need attention"
+    )
+    args = parser.parse_args()
+
+    mapping = json.loads(MAPPING.read_text())
+    entries = [
+        (rel, meta["url"].rsplit("/", 1)[-1])
+        for rel, meta in sorted(mapping.items())
+        if isinstance(meta, dict) and "url" in meta
+    ]
+
+    problems: list[tuple[str, str, str]] = []
+    in_sync = 0
+
+    for rel, gist_id in entries:
+        local = GISTS_DIR / rel
+        gist = fetch_gist(gist_id)
+
+        if gist is None:
+            problems.append((rel, "GIST-UNREADABLE", f"gists/{gist_id}"))
+            continue
+
+        published = gist.get("files", {}).get(local.name)
+        if published is None:
+            names = ", ".join(gist.get("files", {})) or "(none)"
+            problems.append((rel, "FILENAME-MISMATCH", f"gist contains: {names}"))
+            continue
+
+        if not local.exists():
+            problems.append((rel, "LOCAL-MISSING", f"published {gist_id}"))
+            continue
+
+        pub_text = published.get("content", "")
+        if pub_text == local.read_text():
+            in_sync += 1
+            if not args.quiet:
+                print(f"  in-sync   {rel}")
+        else:
+            detail = (
+                f"published {len(pub_text.splitlines())}L "
+                f"vs local {len(local.read_text().splitlines())}L "
+                f"(updated {gist.get('updated_at', '')[:10]})"
+            )
+            problems.append((rel, "DRIFTED", detail))
+
+    print(f"\nchecked {len(entries)} mapped gists: {in_sync} in sync, {len(problems)} need attention")
+
+    if not problems:
+        print("No drift. The mirror matches what is published.\n")
+        return 0
+
+    print()
+    for rel, status, detail in problems:
+        print(f"  {status:18} {rel}")
+        print(f"  {'':18} -> {detail}")
+    print(
+        "\nThe published gist is canonical. To resync a drifted file:\n"
+        "  gh api gists/<id> --jq '.files[\"<name>\"].content' > gists/<path>\n"
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Acts on "the gists should effectively be pseudocode." Closes #513, and does the root-cause half of #512.

## The framing was the defect

`gists/README.md:68` said:

> ✅ Tested and working code (extracted from actual homelab)

That claim is what turned every "this doesn't execute" observation into a defect. Once the gists are stated to be illustrative, most of them stop being defects at all — placeholders like `<password>` are *correct*, elided error handling is *the point*.

So the README now says plainly what these are, and — more importantly — what they are still held to:

> Every factual claim about a real tool must be correct. A config key that the tool ignores, a CLI flag that does not exist, or a comparison that inverts the security outcome is a defect even in an excerpt, because the reader learns it either way.

Pseudocode may be incomplete. It may not be false about how a real tool behaves.

The standard is not invented here — the corrected `grype-config.yaml` already set it on 2026-08-18:

```yaml
# IMPORTANT: grype ignore rules DO NOT EXPIRE.
# There is NO `expiration` field. A date written here is silently ignored and
# the suppression is permanent.
```

Schematic, and every fact about the tool is right. That is quoted in the README as the model.

## The README was also the source of a bug it was blamed for

The "Header Format" section prescribed a Python docstring, under a ```python fence, as the format for **all** code files:

```python
"""
Title: [Descriptive name]
...
"""
```

That is why fourteen shell scripts open with `"""`, which bash reads as a command name. Now gives per-language forms, with a note saying exactly that.

## Other README corrections

- `:3` "contains **all** code examples" — 45 mapping entries vs 93 unique gist URLs in posts.
- `:9` "**Source of truth**" — backwards; the published gists are canonical.
- `:191` "All code examples are from real homelab implementations."
- Two wrong filenames (`security-scan-workflow.yml`, `scan-comparison.py`).
- Two links to files that do not exist (`docs/ARCHITECTURE.md`, `.standards/`).
- A maintenance section documenting two sync scripts deleted in `184ddb8`/`7eb0355`. Nothing replaced them — which is *why* the drift went unnoticed. It now says so and documents the real `gh`-based process.

Every path and link in the file was then mechanically checked. None dangle.

## Drift: measured, fixed, and now enforced (#513)

The README now tells you to check for drift, so it ships with the mechanism — otherwise it would be another stated bar with nothing behind it, which is the defect this whole sweep keeps finding.

`scripts/gist-drift-check.py` compares all 45 mapped gists against the mirror and exits non-zero on mismatch. Before:

```
checked 45 mapped gists: 40 in sync, 5 need attention
  DRIFTED  security-scanning/configs/grype-config.yaml       (updated 2026-08-18)
  DRIFTED  security-scanning/configs/osv-scanner-config.toml (updated 2026-08-18)
  DRIFTED  security-scanning/configs/trivy-opa-policy.rego   (updated 2026-08-18)
  DRIFTED  security-scanning/workflows/auto-remediate-vulnerabilities.yml
  DRIFTED  security-scanning/workflows/security-scan-workflow-complete.yml
```

After resyncing from the published versions:

```
checked 45 mapped gists: 45 in sync, 0 need attention
```

**The direction matters and is easy to get backwards:** published was *correct*, the mirror was stale. Among other things this repo was still carrying a Rego rule gating Log4Shell with a lexicographic string compare:

```
log4j 2.3.0   -> ALLOWED  (vulnerable, waved through)
log4j 2.9.0   -> ALLOWED  (vulnerable, waved through)
log4j 10.0.0  -> DENIED   (patched, blocked)
```

The published version dropped that rule entirely. Verified after resync: the compare is gone, grype carries the DO-NOT-EXPIRE warning, and osv-scanner uses the real `[[IgnoredVulns]]` schema instead of the fabricated `[ignore]`/`[scanning]` tables.

## Deliberately not in this PR

The nine **wrong-fact** defects in #512 — files that are byte-identical to what is published, so they are live for readers:

- `mdns-reflector-config.conf` — reflector keys under `[server]`; avahi treats an unknown key as fatal and exits 255 (verified against `man 5 avahi-daemon.conf` and upstream `load_config_file`)
- `pihole-vlan-filtering.sh` — `bogus-nxdomain` rewrites *replies*, it does not block egress, and it NXDOMAINs `dns.google` network-wide
- the Pi-hole blocklist path nothing reads
- EdgeOS `configure`/`vif`/`commit` on a UDM Pro, which runs UniFi OS
- invalid Cisco private-VLAN `host-association` syntax
- `ha-manager --type=ipmilan` flags that do not exist (PVE uses watchdog self-fencing)
- `nfdump -T all`, now a documented no-op
- `rclone sync` vs the documented 30-day offsite retention
- missing `permissions:` in the security-scanning workflows (the resync did *not* fix this one — I checked)

Those need the **published gist** edited, not just this mirror — de-linking a post does not retract the artifact, and all three currently-unlinked gists are still public. That is your call, so I left it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AvTumDxQ2ntLDwsSefHtf
