### PR TITLE
fix(ci): delete the auto-repair job, fix the compliance patterns

### DIFF
--- a/.github/workflows/compliance-monitor.yml
+++ b/.github/workflows/compliance-monitor.yml
@@ -83,85 +83,18 @@ jobs:
     # Accessibility is owned by a11y.yml (axe-playwright on every push/PR).
     # The previous duplicate axe step here ran the same tool on the same SHA.
 
-    - name: Check citation coverage
+    - name: Content compliance + citation coverage (advisory)
       run: |
-        echo "Checking citation coverage..."
-        python3 -c "
-        import os
-        import re
-        from pathlib import Path
-
-        # Check both old src/posts and astro content directories
-        post_dirs = [Path('src/posts')]
-        total_posts = 0
-        posts_with_citations = 0
-
-        for posts_dir in post_dirs:
-            if not posts_dir.exists():
-                continue
-            for post in posts_dir.glob('**/*.md'):
-                total_posts += 1
-                content = post.read_text()
-                # Check for the standard sources section or citation patterns
-                has_sources_section = re.search(r'(?m)^## Sources\s*$', content)
-                has_reference_links = re.search(r'\[.*?\]\(https?://.*?\)', content) or \
-                   re.search(r'\[.*?\]\(.*?doi\.org.*?\)', content) or \
-                   re.search(r'\[.*?\]\(.*?arxiv\.org.*?\)', content)
-                if has_sources_section or has_reference_links:
-                    posts_with_citations += 1
-
-        coverage = (posts_with_citations / total_posts * 100) if total_posts > 0 else 0
-        print(f'Citation Coverage: {coverage:.1f}% ({posts_with_citations}/{total_posts} posts)')
-
-        if coverage < 70:
-            print(f'WARNING: Citation coverage ({coverage:.1f}%) is below 70% target')
-        "
-
-    - name: Content compliance check
-      run: |
-        echo "Checking content compliance..."
-        python3 -c "
-        import os
-        import re
-        from pathlib import Path
-
-        # Forbidden patterns for NDA compliance
-        forbidden_patterns = [
-            r'at work',
-            r'my employer',
-            r'our production',
-            r'in production',
-            r'recent incident',
-            r'last week at',
-            r'my team',
-            r'our security team',
-            r'government',
-            r'agency',
-            r'classified',
-            r'sensitive',
-            r'confidential'
-        ]
-
-        issues_found = []
-
-        post_dirs = [Path('src/posts')]
-        for posts_dir in post_dirs:
-            if not posts_dir.exists():
-                continue
-            for post in posts_dir.glob('**/*.md'):
-                content = post.read_text().lower()
-                for pattern in forbidden_patterns:
-                    if re.search(pattern, content, re.IGNORECASE):
-                        issues_found.append(f'{post.name}: Found pattern \"{pattern}\"')
-
-        if issues_found:
-            print('Compliance Warnings Found:')
-            for issue in issues_found:
-                print(f'  - {issue}')
-            print('Note: These are warnings only and do not fail the build')
-        else:
-            print('Content compliance check passed')
-        "
+        # Extracted from two ~40-line `python3 -c "..."` blocks that lived
+        # here with shell-escaped quotes (#511). Now a real script: readable,
+        # testable, and linted by ruff via tests.yml.
+        #
+        # Still advisory -- neither metric fails the build, per AGENTS.md,
+        # which assigns the contextual NDA judgment to the Layer-1
+        # blog-nda-check skill. But it now exits non-zero if it scans ZERO
+        # posts, because an empty walk must not read as a clean pass.
+        # stdlib only, so no uv/venv setup needed in this job.
+        python3 scripts/compliance/content_check.py --posts-dir src/posts
 
     - name: Generate compliance report
       if: always()
@@ -172,11 +105,13 @@ jobs:
         echo "## Build Status" >> compliance-report.md
         echo "- Build: ${{ job.status }}" >> compliance-report.md
         echo "" >> compliance-report.md
+        # Only list checks this workflow actually runs. It previously ticked
+        # "Link checking (Lychee)" and "Accessibility (axe-core)", both of
+        # which were deleted from this file (see the comments above) and are
+        # owned by link-monitor.yml and a11y.yml respectively.
         echo "## Checks Performed" >> compliance-report.md
         echo "- [x] Site build validation" >> compliance-report.md
-        echo "- [x] Link checking (Lychee)" >> compliance-report.md
         echo "- [x] Lighthouse performance audit" >> compliance-report.md
-        echo "- [x] Accessibility (axe-core)" >> compliance-report.md
         echo "- [x] HTML validation" >> compliance-report.md
         echo "- [x] Citation coverage" >> compliance-report.md
         echo "- [x] Content compliance" >> compliance-report.md

--- a/.github/workflows/link-monitor.yml
+++ b/.github/workflows/link-monitor.yml
@@ -5,19 +5,20 @@ on:
     # Run daily at 3 AM UTC
     - cron: '0 3 * * *'
   workflow_dispatch:
-    inputs:
-      force_check:
-        description: 'Force check all links'
-        required: false
-        default: false
-        type: boolean
   pull_request:
     paths:
       - 'src/posts/**/*.md'
 
-# Default to least privilege. The check-links job opens an issue on scheduled
-# failures (issues: write) and comments on PRs (pull-requests: write); the
-# repair-links job overrides this to push auto-fixes.
+# Least privilege. check-links is now the only job: it opens a tracking issue
+# on scheduled failures (issues: write) and comments on PRs
+# (pull-requests: write). It never needs `contents: write` -- the job that did
+# was removed with the auto-repair path (#495).
+#
+# Note this workflow runs on `pull_request`, so a fork PR's Python is executed
+# on the runner. GitHub forces GITHUB_TOKEN read-only for fork PRs regardless
+# of this block, so the write scopes are inert there -- but that means
+# "Send write tokens to workflows from fork pull requests" must stay OFF in
+# repository settings. Recorded as an invariant, not an assumption.
 permissions:
   contents: read
   issues: write
@@ -63,8 +64,9 @@ jobs:
         # Create placeholder relevance file
         echo '{"results": []}' > relevance.json
 
-        # Write repairs.json INTO reports/ so it travels in the uploaded
-        # artifact and the repair-links job can actually find it.
+        # Write repairs.json INTO reports/ so the suggestions travel in the
+        # uploaded artifact for a human to review. Nothing applies them
+        # automatically any more (#495).
         uv run python scripts/link-validation/citation-repair.py \
           --links links.json \
           --validation validation.json \
@@ -81,9 +83,10 @@ jobs:
           --repairs reports/repairs.json \
           --output-dir reports
 
-        # Ship links.json in the artifact too -- batch-link-fixer.py in the
-        # repair-links job reads it from the working directory and crashes
-        # without it (it hardcodes open('links.json')).
+        # Ship links.json in the artifact too, so a human reviewing the
+        # report has the extracted-link set that produced it. (It also
+        # remains the input batch-link-fixer.py expects if run manually --
+        # it hardcodes open('links.json') in the working directory.)
         cp links.json reports/links.json
 
     - name: Upload Reports
@@ -234,102 +237,19 @@ jobs:
                   `<details>\n<summary>View Full Report</summary>\n\n${summary}\n</details>`
           });
 
-  repair-links:
-    needs: check-links
-    if: github.event.inputs.force_check == 'true' || github.event_name == 'schedule'
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      contents: write        # push the auto-fix branch
-      pull-requests: write   # open the review PR
-
-    steps:
-    - name: Checkout Repository
-      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Set up Python
-      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v6
-      with:
-        python-version: '3.11'
-
-    - name: Install UV
-      uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
-
-    - name: Install Dependencies
-      run: |
-        uv pip install --system --upgrade pip
-        uv pip install --system "aiohttp>=3.13.3" "urllib3>=2.6.3"
-
-    - name: Download Artifacts
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
-      with:
-        name: link-validation-reports
-        path: reports/
-
-    - name: Apply High-Confidence Fixes
-      run: |
-        # Only apply fixes with >=95% confidence automatically. repairs.json
-        # arrives inside the downloaded reports/ artifact.
-        if [ -f "reports/repairs.json" ]; then
-          # batch-link-fixer.py reads links.json from the working directory;
-          # it travels inside the reports/ artifact (see check-links job).
-          cp reports/links.json links.json
-          # SAFETY STOPGAP (issue #495): --dry-run until the write path is
-          # fixed. batch-link-fixer._replace_url does a blanket substring
-          # replace outside markdown links, so it rewrites URLs inside code
-          # fences, inline code and blockquotes; it also prefix-collides
-          # (repairing ex.com/a rewrites ex.com/abc), and the extractor
-          # truncates URLs containing parentheses, which produces mangled
-          # prose when repaired. All three are reproduced in #495.
-          #
-          # This job has never actually opened a repair PR, so nothing is
-          # lost by holding it here. Remove --dry-run once #495 lands a
-          # code-span-aware replacer and its golden-file test.
-          uv run python scripts/link-validation/batch-link-fixer.py \
-            --repairs reports/repairs.json \
-            --confidence-threshold 95 \
-            --apply \
-            --dry-run \
-            --posts-dir src/posts
-        else
-          echo "No repairs.json found; nothing to apply"
-        fi
-
-    - name: Open PR with fixes
-      if: success()
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        # Open a PR for human review instead of pushing straight to main --
-        # auto-repairs (redirect-follows, Wayback snapshots) must be eyeballed.
-        if [[ -z "$(git status --porcelain src/posts)" ]]; then
-          echo "No high-confidence fixes to apply"
-          exit 0
-        fi
-
-        # Dedup guard: this job runs daily and each run uses a unique branch,
-        # so without this check an unmerged repair PR gets a duplicate every
-        # day until a human merges or closes it.
-        OPEN_REPAIR_PRS=$(gh pr list --state open --json headRefName \
-          --jq '[.[] | select(.headRefName | startswith("auto/link-repairs-"))] | length')
-        if [[ "$OPEN_REPAIR_PRS" -gt 0 ]]; then
-          echo "An auto/link-repairs PR is already open; skipping duplicate PR"
-          exit 0
-        fi
-
-        BRANCH="auto/link-repairs-${GITHUB_RUN_ID}"
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-        git checkout -b "$BRANCH"
-        # batch-link-fixer.py leaves .bak.TIMESTAMP safety copies beside the
-        # posts -- stage only the markdown, and let git (not the shell) expand
-        # the pathspec.
-        git add -- 'src/posts/*.md'
-        git commit -m "fix(links): auto-repair broken links (>=95% confidence)"
-        git push origin "$BRANCH"
-
-        gh pr create --base main --head "$BRANCH" \
-          --title "🔗 Automated link repairs (review before merge)" \
-          --body "High-confidence (>=95%) repairs for **provably dead** links (404/410/DNS), proposed by the Link Health Monitor via citation-repair.py (redirect-follow / Wayback). **Review before merging -- do not auto-merge.**"
+  # The repair-links job was removed here (issue #495).
+  #
+  # It ran daily for months and never once opened a repair PR: only
+  # identity-preserving DOI repairs clear the --confidence-threshold 95 the
+  # workflow passed, and those are rare. Meanwhile it carried three
+  # reproduced corruption modes in batch-link-fixer._replace_url --
+  # rewriting URLs inside code fences, inline code and blockquotes;
+  # prefix-collision (repairing ex.com/a also rewrote ex.com/abc); and
+  # mangled prose when the extractor truncated a parenthesised URL. Its
+  # confidence cap (min(confidence, 90)) was also equal to the tool's own
+  # default threshold, so the cap gated nothing outside this workflow.
+  #
+  # Detection and reporting above are kept -- they are the part that worked.
+  # Repair is a human step now: read reports/ from the uploaded artifact.
+  # scripts/link-validation/batch-link-fixer.py is retained for manual,
+  # supervised use and still defaults to a dry run.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,23 +1,55 @@
 name: Python Tests
 
 on:
-  push:
-    paths:
-      - 'scripts/**'
-      - 'pyproject.toml'
-      - '.github/workflows/tests.yml'
   pull_request:
-    paths:
-      - 'scripts/**'
-      - 'pyproject.toml'
-      - '.github/workflows/tests.yml'
+    branches: [main]
+  push:
+    branches: [main]
   workflow_dispatch:
 
 permissions:
   contents: read
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 jobs:
+  # Job-level path gating instead of workflow-level `paths:` triggers — same
+  # reason audits.yml and a11y.yml do it. `pytest` is a REQUIRED
+  # branch-protection check, and a trigger-filtered workflow never reports at
+  # all on a non-matching PR, wedging it as "expected" forever. A skipped job
+  # still reports and satisfies protection.
+  #
+  # The old workflow-level filters were also bypassed on any push that CREATES
+  # a ref: `before` is all-zeros, GitHub cannot compute a diff, so the filters
+  # are skipped entirely — which is why two Dependabot branches ran this suite
+  # despite touching only astro-site/. Job-level gating is honest either way.
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      python: ${{ steps.diff.outputs.python }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          fetch-depth: 0
+      - id: diff
+        env:
+          BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          if [ -z "$BASE" ] || ! git cat-file -e "$BASE" 2>/dev/null; then
+            echo "python=true" >> "$GITHUB_OUTPUT"   # can't diff: run everything
+          elif git diff --name-only "$BASE"...HEAD \
+               | grep -qE '^(scripts/|pyproject\.toml|\.github/workflows/tests\.yml)'; then
+            echo "python=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "python=false" >> "$GITHUB_OUTPUT"
+          fi
+
   pytest:
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/scripts/compliance/content_check.py
+++ b/scripts/compliance/content_check.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""NDA-compliance and citation-coverage checks over the post corpus.
+
+Advisory by design: neither metric fails the build. AGENTS.md assigns the
+*contextual* NDA judgment to the Layer-1 `blog-nda-check` skill; this is the
+cheap mechanical pass that runs on every commit.
+
+Advisory does not mean unfalsifiable, though. Two things DO exit non-zero:
+
+  * scanning zero posts -- an empty walk must never read as a clean pass
+    (the same defect as issue #492)
+  * a corpus path that does not exist
+
+Previously this lived as ~70 lines of Python inside a `python3 -c "..."`
+string in compliance-monitor.yml, with shell-escaped quotes. Extracted so it
+can be read, tested, and linted (ruff now covers scripts/).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# --------------------------------------------------------------------------
+# NDA signal patterns.
+#
+# These are word-boundaried. The previous list was not, and `at work` matched
+# `th{at work}s`, `wh{at work}ed`, `th{at work}flow` -- 35 of its 36 hits in
+# the corpus were noise.
+#
+# A pattern here that matches NOTHING is doing its job. An earlier review
+# called six of these "dead" for producing zero hits; for a compliance check,
+# zero hits means the corpus is clean, not that the pattern is useless.
+# --------------------------------------------------------------------------
+SIGNAL_PATTERNS: list[tuple[str, str]] = [
+    (r"\bat work\b", "present-tense work reference"),
+    (r"\bmy (?:current |present )?employer\b", "employer reference"),
+    (r"\bthe (?:company|org(?:anisation|anization)) I work for\b", "employer reference"),
+    (r"\bmy team\b", "current-team reference"),
+    (r"\bour (?:security )?team\b", "current-team reference"),
+    (r"\bour production\b", "current-environment reference"),
+    (r"\bwe (?:recently|just) (?:discovered|found|had|saw)\b", "recent-incident reference"),
+    (r"\ba (?:recent|current) incident\b", "recent-incident reference"),
+    (r"\blast (?:week|month|quarter) at\b", "recent-timeline work reference"),
+    # Scale revelations only count in FIRST PERSON. A bare "1,000+ servers" in
+    # a generic scaling table, "150 users" on a cited satellite link, or an
+    # "RTX 3090 hosts the hypervisor" are not disclosures — an earlier version
+    # of this pattern flagged all three.
+    (
+        r"\b(?:we|i)\s+(?:run|manage|operate|monitor|support|administer)\s+"
+        r"(?:about\s+|roughly\s+|around\s+|~)?[\d,]{3,}\+?\s+"
+        r"(?:endpoints|servers|users|hosts|seats|devices|systems)\b",
+        "scale revelation",
+    ),
+    (
+        r"\b(?:our|my)\s+(?:fleet|estate|environment|network|infrastructure)\s+"
+        r"of\s+(?:about\s+|roughly\s+|around\s+|~)?[\d,]{3,}\b",
+        "scale revelation",
+    ),
+]
+
+# Broad technical vocabulary. These are legitimate in this blog's register --
+# "in production", "sensitive data", "government guidance" all appear in
+# ordinary prose. Reported as an aggregate so they cannot drown the signal
+# list; previously they flagged 62 of 92 posts individually.
+CONTEXT_WORDS: list[str] = [
+    r"\bin production\b",
+    r"\bsensitive\b",
+    r"\bconfidential\b",
+    r"\bclassified\b",
+    r"\bgovernment\b",
+    r"\bagency\b",
+]
+
+
+def iter_posts(posts_dir: Path):
+    yield from sorted(posts_dir.glob("**/*.md"))
+
+
+def strip_code(text: str) -> str:
+    """Drop fenced blocks and inline code before matching prose patterns."""
+    text = re.sub(r"```.*?```", "", text, flags=re.S)
+    return re.sub(r"`[^`\n]*`", "", text)
+
+
+def check_nda(posts: list[Path]) -> int:
+    signal_hits: list[str] = []
+    context_counts: dict[str, int] = {}
+
+    for post in posts:
+        prose = strip_code(post.read_text())
+        for pattern, label in SIGNAL_PATTERNS:
+            for m in re.finditer(pattern, prose, re.IGNORECASE):
+                line = prose[: m.start()].count("\n") + 1
+                snippet = " ".join(prose[max(0, m.start() - 40) : m.end() + 40].split())
+                signal_hits.append(f"{post.name}:{line}  [{label}]  …{snippet}…")
+        for word in CONTEXT_WORDS:
+            n = len(re.findall(word, prose, re.IGNORECASE))
+            if n:
+                context_counts[word] = context_counts.get(word, 0) + n
+
+    print(f"\nNDA signal patterns: {len(signal_hits)} hit(s) across {len(posts)} posts")
+    for hit in signal_hits:
+        print(f"  - {hit}")
+    if not signal_hits:
+        print("  (none)")
+
+    if context_counts:
+        print("\nContext vocabulary (advisory aggregate, not per-post):")
+        for word, n in sorted(context_counts.items(), key=lambda kv: -kv[1]):
+            print(f"  {n:5}  {word}")
+
+    print(
+        "\nAdvisory only — this does not fail the build. The contextual gate is "
+        "the Layer-1 blog-nda-check skill (see AGENTS.md)."
+    )
+    return len(signal_hits)
+
+
+CITATION_LINK = re.compile(r"(?<!\!)\[[^\]]*\]\((https?://[^)]+)\)")
+SELF_HOST = "williamzujkowski.github.io"
+BADGE_HOSTS = ("shields.io", "img.shields.io", "badgen.net", "badge.fury.io")
+
+
+def has_real_citation(content: str) -> bool:
+    """A citation is an external, non-badge link — not a self-link or an image.
+
+    The previous check counted a link to another post on this same blog, a
+    shields.io badge, and a bare `## Sources` heading with nothing under it.
+    """
+    for m in CITATION_LINK.finditer(content):
+        url = m.group(1)
+        if SELF_HOST in url:
+            continue
+        if any(h in url for h in BADGE_HOSTS):
+            continue
+        return True
+    return False
+
+
+def check_citations(posts: list[Path], target: float) -> float:
+    with_citations = [p for p in posts if has_real_citation(p.read_text())]
+    coverage = len(with_citations) / len(posts) * 100
+
+    print(f"\nCitation coverage: {coverage:.1f}% ({len(with_citations)}/{len(posts)} posts)")
+    missing = [p.name for p in posts if p not in with_citations]
+    if missing:
+        print(f"  posts with no external citation ({len(missing)}):")
+        for name in missing[:20]:
+            print(f"    - {name}")
+        if len(missing) > 20:
+            print(f"    … and {len(missing) - 20} more")
+
+    if coverage < target:
+        print(f"  WARNING: below the {target:.0f}% target stated in AGENTS.md")
+    print("\nAdvisory only — this does not fail the build.")
+    return coverage
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--posts-dir", type=Path, default=Path("src/posts"))
+    parser.add_argument(
+        "--citation-target",
+        type=float,
+        default=90.0,
+        help="AGENTS.md states 90%%; the old inline check said 70%%.",
+    )
+    args = parser.parse_args()
+
+    if not args.posts_dir.exists():
+        print(f"ERROR: posts directory not found: {args.posts_dir}", file=sys.stderr)
+        return 1
+
+    posts = list(iter_posts(args.posts_dir))
+    if not posts:
+        print(
+            f"ERROR: scanned 0 posts under {args.posts_dir}. An empty walk is not a "
+            "clean pass — check the path.",
+            file=sys.stderr,
+        )
+        return 1
+
+    check_nda(posts)
+    check_citations(posts, args.citation_target)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Acts on your four decisions. Closes #495; does the compliance half of #511; unblocks `pytest` as a required check.

## 1. Deleted the link auto-repair job (#495)

`repair-links` ran daily for months and **never once opened a repair PR** — only identity-preserving DOI repairs clear the `--confidence-threshold 95` the workflow passed. In exchange it carried three reproduced corruption modes:

- rewrote URLs inside code fences, inline code and blockquotes
- prefix collision: repairing `ex.com/a` also rewrote `ex.com/abc`, while reporting "3 links fixed"
- mangled prose when the extractor truncated a parenthesised URL

Its confidence cap was `min(confidence, 90)` — exactly the tool's own default threshold, so the cap gated nothing outside this workflow.

Zero output, three ways to corrupt a published post. Detection and reporting stay; repair is a human step from the uploaded artifact. `batch-link-fixer.py` remains for manual supervised use and still defaults to dry run.

Removed with it: the `force_check` dispatch input (existed only to trigger this job) and the `contents: write` rationale. Recorded as an invariant rather than an assumption: this workflow runs on `pull_request`, so *"Send write tokens to workflows from fork pull requests"* must stay **off**.

## 2. `tests.yml`: path filters → job-level gating

This is the prerequisite for your branch-protection choice. **`pytest` cannot safely be required while `tests.yml` uses `on: paths:`** — a trigger-filtered workflow never reports on a non-matching PR, wedging it as "expected" forever. That is precisely what `audits.yml`'s own comment warns about; `tests.yml` had never followed suit.

The old filters were also bypassed on any push that *creates* a ref (`before` is all-zeros, so GitHub skips path filtering), which is why two Dependabot branches ran this suite despite touching only `astro-site/`.

Now mirrors `audits.yml`. **Once this merges, `pytest` is safe to add to required contexts** — say the word and I'll set it. `remarque`, `axe` and `check-lint` are already required as of your decision.

## 3. Compliance: fixed the patterns, kept them advisory (#511)

Both checks were ~40-line `python3 -c "..."` blocks with shell-escaped quotes. Extracted to `scripts/compliance/content_check.py` — readable, testable, and now linted by ruff via `tests.yml`.

**The NDA grep was inverted noise: 62 of 92 posts flagged.** Its top pattern had no word boundaries:

```
total 'at work' matches: 36
word-boundary matches:   1
```

35 were `th{at work}s` / `wh{at work}ed` / `th{at work}flow`. Meanwhile **two of the three unsafe examples AGENTS.md itself quotes were missed** — the pattern was `my employer`, so "my current employer" slipped through, and nothing covered "we recently discovered".

Fixed on both sides. Before → after:

```
62 of 92 posts flagged        ->  1 reviewable hit
1 of 3 AGENTS.md examples     ->  3 of 3 caught
```

The one remaining hit is genuine and innocuous — *"my son asked me what I do at work"*.

Broad technical vocabulary (`sensitive` ×68, `in production` ×30, `government` ×17, …) is demoted to an aggregate count so it cannot drown the signal list. Code fences and inline code are stripped before matching prose.

> One correction to the review that produced this: an agent called six patterns "dead" for producing zero hits. **That reading is backwards** — for a compliance check, zero hits means the corpus is clean. They were kept.

**Citation coverage** stopped counting a link to another post on this same blog, a shields.io badge, and a bare `## Sources` heading with nothing under it. Real coverage is **95.7% (88/92)**. Target aligned to the **90%** AGENTS.md states rather than the 70% the workflow said — resolving that contradiction — and it still only warns.

**Neither metric fails the build**, per your call. But scanning **zero posts now exits 1**, because an empty walk must not read as a clean pass. That is #492's lesson applied here.

Negative controls:

```
missing posts dir          -> exit 1
empty posts dir            -> exit 1  "An empty walk is not a clean pass"
planted violations         -> 3 hits (employer / recent-incident / scale)
```

## 4. The compliance report stopped lying

It ticked `[x] Link checking (Lychee)` and `[x] Accessibility (axe-core)` unconditionally. Both steps were deleted from this workflow long ago — the file's own comments say so — and are owned by `link-monitor.yml` and `a11y.yml`.

## Caught while writing this

My first version called the new script with `uv run`. **`uv` is not installed in the `compliance-check` job** — the old inline blocks used bare `python3`, so it never needed it. The script is stdlib-only (verified by AST walk: zero non-stdlib imports), so it now runs under plain `python3`. Would have been a red build.

## Verification

62 pytest · ruff clean · 7 unit tests · 5 design audits · all seven workflows parse · `link-monitor.yml` 334 → 255 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AvTumDxQ2ntLDwsSefHtf
