### PR TITLE
fix(audits): make the checkers able to fail

### DIFF
--- a/astro-site/scripts/accent-font-audit.mjs
+++ b/astro-site/scripts/accent-font-audit.mjs
@@ -19,7 +19,7 @@
  *     (`cssVariable: '--font-accent'`). Lives outside src/ so a plain
  *     `src/` walk never sees it; checked explicitly for completeness.
  */
-import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
 import { join, extname, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
@@ -29,8 +29,28 @@ const siteRoot = resolve(here, '..');
 const srcRoot = resolve(siteRoot, 'src');
 
 const TOKEN = /--font-accent\b/;
+
+/**
+ * Blank out comments while preserving line numbers. Without this, a comment
+ * that merely MENTIONS .hand-note and contains a brace opened the allowlist
+ * gate for everything after it (issue #511):
+ *
+ *     /* .hand-note styling below { *\/
+ *     p { font-family: var(--font-accent); }   <- silently allowed
+ */
+function stripComments(src) {
+  let out = src.replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '));
+  return out.replace(/(^|[^:])\/\/[^\n]*/g, (m, p1) => p1 + ' '.repeat(m.length - p1.length));
+}
+
+// The token is one way in; naming the family directly is the other, and it
+// achieves the exact outcome the token restriction exists to prevent.
+// src/og/** is exempt: satori loads the .ttf itself and has no CSS cascade,
+// so the OG card's hand-note kicker cannot go through --font-accent.
+const DIRECT_FAMILY = /font-family\s*:[^;{}]*shantell/i;
 const exts = new Set(['.css', '.astro', '.svelte', '.ts', '.tsx', '.js', '.mjs']);
 const violations = [];
+let filesScanned = 0;
 
 function walk(dir) {
   for (const entry of readdirSync(dir)) {
@@ -45,12 +65,13 @@ function walk(dir) {
 // Generic scan: every `--font-accent` occurrence is a violation unless a
 // file-specific exception below says otherwise.
 function scanGeneric(file) {
+  filesScanned += 1;
   const rel = relative(siteRoot, file).replace(/\\/g, '/');
   const src = readFileSync(file, 'utf8');
   const lines = src.split('\n');
 
   if (rel === 'src/styles/zine.css') {
-    scanZineCss(rel, lines);
+    scanZineCss(rel, stripComments(src).split('\n'), lines);
     return;
   }
   if (rel === 'src/layouts/BaseLayout.astro') {
@@ -58,15 +79,23 @@ function scanGeneric(file) {
     return;
   }
 
-  lines.forEach((line, i) => {
+  const stripped = stripComments(src).split('\n');
+  stripped.forEach((line, i) => {
     if (TOKEN.test(line)) {
-      violations.push({ file: rel, line: i + 1, snippet: line.trim() });
+      violations.push({ file: rel, line: i + 1, snippet: (lines[i] ?? line).trim() });
+    } else if (DIRECT_FAMILY.test(line) && !rel.startsWith('src/og/')) {
+      violations.push({
+        file: rel,
+        line: i + 1,
+        snippet: (lines[i] ?? line).trim(),
+        note: 'names the accent family directly, bypassing --font-accent',
+      });
     }
   });
 }
 
 // zine.css: allow --font-accent only while inside a `.hand-note` rule block.
-function scanZineCss(rel, lines) {
+function scanZineCss(rel, lines, rawLines) {
   let depth = 0;
   let handNoteDepth = -1; // brace depth at which the current .hand-note block opened
 
@@ -76,7 +105,7 @@ function scanZineCss(rel, lines) {
     if (TOKEN.test(line)) {
       const insideHandNote = handNoteDepth !== -1 && depth >= handNoteDepth;
       if (!insideHandNote) {
-        violations.push({ file: rel, line: i + 1, snippet: line.trim() });
+        violations.push({ file: rel, line: i + 1, snippet: (rawLines[i] ?? line).trim() });
       }
     }
 
@@ -127,16 +156,27 @@ function checkAstroConfig() {
   });
 }
 
+if (!existsSync(srcRoot)) {
+  console.error(`Accent-Font Audit\n\n  Source root not found: ${srcRoot}`);
+  process.exit(1);
+}
 walk(srcRoot);
 checkAstroConfig();
 
 console.log('Accent-Font Audit (--font-accent restricted to .hand-note)\n');
+
+// An empty walk is not a clean pass — it means the scan never happened.
+if (filesScanned === 0) {
+  console.error(`  Scanned 0 files under ${srcRoot}. That is a broken audit, not a clean one.\n`);
+  process.exit(1);
+}
+
 if (violations.length === 0) {
-  console.log('  --font-accent usage is confined to the approved allowlist.');
+  console.log(`  --font-accent usage is confined to the approved allowlist. (${filesScanned} files scanned)`);
   process.exit(0);
 }
 for (const v of violations) {
-  console.log(`  [FAIL] ${v.file}:${v.line}`);
+  console.log(`  [FAIL] ${v.file}:${v.line}${v.note ? ` — ${v.note}` : ''}`);
   console.log(`         ${v.snippet}`);
 }
 console.error(`\n${violations.length} --font-accent usage(s) found outside the allowlist.`);

--- a/astro-site/scripts/apca-audit.mjs
+++ b/astro-site/scripts/apca-audit.mjs
@@ -67,6 +67,20 @@ function parseTheme(blockRegex) {
 const light = parseTheme(/:root\s*\{[^}]+\}/);
 const dark = parseTheme(/:root\.dark\s*\{[^}]+\}/);
 
+// This audit's FINDINGS are advisory (WCAG 3 is still a draft), but failing to
+// resolve any tokens means it measured nothing — and a report over zero tokens
+// must not read like a clean one (issue #511). Previously that surfaced as a
+// raw TypeError from spreading `undefined`.
+for (const [name, theme] of [['light', light], ['dark', dark]]) {
+  if (Object.keys(theme).length === 0) {
+    console.error(
+      `APCA audit: parsed 0 --color-* tokens for the ${name} theme from global.css.\n` +
+      'That is a broken run, not a clean one.',
+    );
+    process.exit(1);
+  }
+}
+
 // text on bg (polarity matters for APCA — text is first, bg is second)
 const pairs = [
   ['light', 'fg', 'bg', 75, 'body copy'],

--- a/astro-site/scripts/color-token-audit.mjs
+++ b/astro-site/scripts/color-token-audit.mjs
@@ -1,16 +1,34 @@
 #!/usr/bin/env node
 /**
  * Remarque color-token audit.
- * Flags hardcoded hex / rgb() / rgba() / hsl() / named colors in CSS-ish
+ * Flags hardcoded hex / rgb() / hsl() / oklch() / named colors in CSS-ish
  * contexts. All colors MUST come from --color-* tokens.
  *
  * Allowed escape hatches:
- *   - `transparent`, `currentColor`, `inherit`
- *   - Inside @font-face / SVG url() data strings
- *   - Within a comment
- *   - Explicit allowlist comment: / * allow-raw-color * /
+ *   - `transparent`, `currentColor`, `inherit`, `unset`, `initial`, `none`
+ *   - Inside a comment
+ *   - Explicit allowlist comment: allow-raw-color
+ *
+ * Four blind spots were found by a negative-control audit (issue #511) and
+ * are fixed here. Each had a live instance in the tree:
+ *
+ *   1. `var(--color-x, #hex)` — the old early-return skipped the whole
+ *      declaration the moment it saw `var(--color-`, so a hardcoded fallback
+ *      was invisible. Three shipped in PizzaOps.svelte.
+ *   2. `.ts` was not scanned, so the six constants colouring every social
+ *      card in src/og/card.ts were structurally unauditable. (The typography
+ *      audit *did* scan .ts — the two disagreed about what "source" means.)
+ *   3. A line starting with `*` was treated as a comment continuation, so a
+ *      universal-selector rule (`* { color: red }`) was skipped. Comments are
+ *      now stripped properly, preserving line numbers, instead of guessed at
+ *      per line.
+ *   4. The header claimed "named colors" were flagged; nothing implemented
+ *      it. Now implemented.
+ *
+ * And: an empty walk used to print "All color values use var(--color-*)
+ * tokens" and exit 0. Scanning zero files is now a failure, not a pass.
  */
-import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
 import { join, extname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
@@ -18,17 +36,59 @@ import { dirname, resolve } from 'node:path';
 const here = dirname(fileURLToPath(import.meta.url));
 const root = resolve(here, '../src');
 
-const exts = new Set(['.css', '.astro', '.svelte']);
+const exts = new Set(['.css', '.astro', '.svelte', '.ts']);
 const violations = [];
+let filesScanned = 0;
 
 // Properties where hardcoded colors are forbidden
-const COLOR_PROPS = /\b(color|background(-color)?|border(-[\w-]+)?-color|border(-[\w-]+)?|fill|stroke|outline(-color)?|text-decoration-color|caret-color|box-shadow|text-shadow|accent-color)\s*:/;
+const COLOR_PROPS =
+  /\b(color|background(-color)?|border(-[\w-]+)?-color|border(-[\w-]+)?|fill|stroke|outline(-color)?|text-decoration-color|caret-color|box-shadow|text-shadow|accent-color)\s*:/;
 
-// Hex, rgb(), rgba(), hsl(), hsla(), oklch() outside token definitions
 const HEX = /#[0-9a-fA-F]{3,8}\b/;
-const FUNC_COLOR = /\b(rgb|rgba|hsl|hsla|oklch)\s*\(/;
+// color-mix() is deliberately absent: it COMPOSES colors, and its arguments
+// are checked on their own merits. `color-mix(in oklch, var(--color-accent)
+// 60%, transparent)` is correct usage, not a hardcoded color.
+const FUNC_COLOR = /\b(rgb|rgba|hsl|hsla|oklch|lab|lch)\s*\(/;
 
-const ALLOWED = new Set(['transparent', 'currentColor', 'inherit', 'unset', 'initial', 'none']);
+const ALLOWED = new Set([
+  'transparent', 'currentColor', 'currentcolor', 'inherit', 'unset', 'initial', 'none',
+]);
+
+// CSS named colors. `transparent`/`currentColor` are handled by ALLOWED above.
+const NAMED_COLORS = new Set([
+  'aliceblue','antiquewhite','aqua','aquamarine','azure','beige','bisque','black',
+  'blanchedalmond','blue','blueviolet','brown','burlywood','cadetblue','chartreuse',
+  'chocolate','coral','cornflowerblue','cornsilk','crimson','cyan','darkblue','darkcyan',
+  'darkgoldenrod','darkgray','darkgreen','darkgrey','darkkhaki','darkmagenta',
+  'darkolivegreen','darkorange','darkorchid','darkred','darksalmon','darkseagreen',
+  'darkslateblue','darkslategray','darkslategrey','darkturquoise','darkviolet','deeppink',
+  'deepskyblue','dimgray','dimgrey','dodgerblue','firebrick','floralwhite','forestgreen',
+  'fuchsia','gainsboro','ghostwhite','gold','goldenrod','gray','green','greenyellow','grey',
+  'honeydew','hotpink','indianred','indigo','ivory','khaki','lavender','lavenderblush',
+  'lawngreen','lemonchiffon','lightblue','lightcoral','lightcyan','lightgoldenrodyellow',
+  'lightgray','lightgreen','lightgrey','lightpink','lightsalmon','lightseagreen',
+  'lightskyblue','lightslategray','lightslategrey','lightsteelblue','lightyellow','lime',
+  'limegreen','linen','magenta','maroon','mediumaquamarine','mediumblue','mediumorchid',
+  'mediumpurple','mediumseagreen','mediumslateblue','mediumspringgreen','mediumturquoise',
+  'mediumvioletred','midnightblue','mintcream','mistyrose','moccasin','navajowhite','navy',
+  'oldlace','olive','olivedrab','orange','orangered','orchid','palegoldenrod','palegreen',
+  'paleturquoise','palevioletred','papayawhip','peachpuff','peru','pink','plum','powderblue',
+  'purple','rebeccapurple','red','rosybrown','royalblue','saddlebrown','salmon','sandybrown',
+  'seagreen','seashell','sienna','silver','skyblue','slateblue','slategray','slategrey','snow',
+  'springgreen','steelblue','tan','teal','thistle','tomato','turquoise','violet','wheat',
+  'white','whitesmoke','yellow','yellowgreen',
+]);
+
+/**
+ * Blank out /* *​/ and // comments while preserving line count and columns, so
+ * reported line numbers stay accurate. Replaces guessing per line, which
+ * mistook `* { … }` rule lines for comment continuations.
+ */
+function stripComments(src) {
+  let out = src.replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '));
+  out = out.replace(/(^|[^:])\/\/[^\n]*/g, (m, p1) => p1 + ' '.repeat(m.length - p1.length));
+  return out;
+}
 
 function walk(dir) {
   for (const entry of readdirSync(dir)) {
@@ -40,54 +100,95 @@ function walk(dir) {
   }
 }
 
-function scan(file) {
-  const src = readFileSync(file, 'utf8');
-  const lines = src.split('\n');
+// A hex string literal assigned in JS/TS is a colour definition even though
+// it is not a CSS declaration — src/og/card.ts holds the palette for every
+// social card the site emits. satori has no CSS cascade, so var() cannot
+// resolve there and literals are structurally required; the point of scanning
+// them is that the exemption must be WRITTEN DOWN, not implicit.
+const TS_HEX_LITERAL = /=\s*['"`]#[0-9a-fA-F]{3,8}['"`]/;
 
-  lines.forEach((raw, i) => {
-    const line = raw;
-    // Allow raw colors on lines that DEFINE a --color-* token (inside :root blocks)
+function scan(file) {
+  filesScanned += 1;
+  const raw = readFileSync(file, 'utf8');
+  const lines = stripComments(raw).split('\n');
+  const rawLines = raw.split('\n');
+  const isTs = extname(file) === '.ts';
+
+  lines.forEach((line, i) => {
+    if (isTs && TS_HEX_LITERAL.test(line)) {
+      if (!/allow-raw-color/.test(rawLines[i] ?? '')) {
+        violations.push({
+          file: file.replace(root + '/', ''),
+          line: i + 1,
+          offense: line.match(/#[0-9a-fA-F]{3,8}/)[0],
+          snippet: (rawLines[i] ?? '').trim(),
+        });
+      }
+      return;
+    }
+    // Lines that DEFINE a --color-* token may hold raw values.
     if (/^\s*--color-[\w-]+\s*:/.test(line)) return;
-    // Skip comment lines
-    if (/^\s*(\/\/|\*|\/\*)/.test(line)) return;
-    // Explicit allowlist
-    if (/allow-raw-color/.test(line)) return;
-    // Only scan lines with a color property
+    // Explicit, reviewed escape hatch (checked against the ORIGINAL line so a
+    // marker inside a trailing comment still counts).
+    if (/allow-raw-color/.test(rawLines[i] ?? '')) return;
     if (!COLOR_PROPS.test(line)) return;
-    // Extract the value portion
-    const vIdx = line.indexOf(':');
-    const value = line.slice(vIdx + 1);
-    // Skip if already using a token
-    if (/var\(--color-/.test(value)) return;
-    // Skip allowed keywords
-    const trimmed = value.trim().replace(/;.*$/, '').trim();
+
+    const value = line.slice(line.indexOf(':') + 1);
+
+    // Strip only the TOKEN NAME out of any var() reference, leaving the
+    // fallback behind. `var(--color-error, #c0392b)` -> `var( #c0392b)`.
+    const bare = value.replace(/var\(\s*--[\w-]+\s*/g, 'var(');
+
+    const trimmed = bare.trim().replace(/;.*$/, '').trim();
     if (ALLOWED.has(trimmed)) return;
 
     let offense = null;
-    if (HEX.test(value)) offense = value.match(HEX)[0];
-    else if (FUNC_COLOR.test(value)) offense = value.match(FUNC_COLOR)[0] + '…)';
+    if (HEX.test(bare)) offense = bare.match(HEX)[0];
+    else if (FUNC_COLOR.test(bare)) offense = bare.match(FUNC_COLOR)[0] + '…)';
+    else {
+      // Whole CSS identifiers only. Matching substrings made `white-space:
+      // nowrap` look like the colour `white`. Case-sensitive lowercase, so a
+      // JS constant like `stroke: BLUE` in a .ts file is not mistaken for the
+      // CSS keyword `blue`.
+      for (const m of bare.matchAll(/(?<![\w-])([a-z]{3,})(?![\w-])/g)) {
+        if (NAMED_COLORS.has(m[1])) { offense = m[1]; break; }
+      }
+    }
 
     if (offense) {
       violations.push({
         file: file.replace(root + '/', ''),
         line: i + 1,
         offense,
-        snippet: line.trim(),
+        snippet: (rawLines[i] ?? '').trim(),
       });
     }
   });
 }
 
+if (!existsSync(root)) {
+  console.error(`Remarque Color-Token Audit\n\n  Source root not found: ${root}`);
+  process.exit(1);
+}
 walk(root);
 
 console.log('Remarque Color-Token Audit\n');
+
+// An empty walk is not a clean pass — it means the scan never happened.
+if (filesScanned === 0) {
+  console.error(
+    `  Scanned 0 files under ${root}. That is a broken audit, not a clean one.\n`,
+  );
+  process.exit(1);
+}
+
 if (violations.length === 0) {
-  console.log('  All color values use var(--color-*) tokens.');
+  console.log(`  All color values use var(--color-*) tokens. (${filesScanned} files scanned)`);
   process.exit(0);
 }
 for (const v of violations) {
   console.log(`  [FAIL] ${v.file}:${v.line} → ${v.offense}`);
   console.log(`         ${v.snippet}`);
 }
-console.error(`\n${violations.length} hardcoded color(s) found.`);
+console.error(`\n${violations.length} hardcoded color(s) found in ${filesScanned} files.`);
 process.exit(1);

--- a/astro-site/scripts/grain-contrast-audit.mjs
+++ b/astro-site/scripts/grain-contrast-audit.mjs
@@ -458,9 +458,12 @@ async function measureTheme(page, theme) {
 async function main() {
   if (!existsSync(distDir)) {
     console.error(
-      `grain-contrast-audit: dist/ not found at ${distDir} — run \`pnpm build\` first. Skipping (advisory).`
+      `grain-contrast-audit: dist/ not found at ${distDir} — run \`pnpm build\` first.\n` +
+      'This is a BROKEN run, not a clean one: an audit that samples zero pixels\n' +
+      'must not be indistinguishable from one that found no problems (#511).\n' +
+      'Contrast FINDINGS remain advisory; being unable to look does not.'
     );
-    process.exit(0);
+    process.exit(1);
   }
 
   const deckThemes = JSON.parse(await readFile(themeDeckPath, 'utf8'));
@@ -556,7 +559,11 @@ async function main() {
   process.exit(0);
 }
 
+// A crash is a broken run. The findings this audit reports are advisory
+// (pending the design decision on solarized-dark-higher-contrast), but an
+// exception means it never measured anything — which previously exited 0
+// and read as a pass.
 main().catch((err) => {
-  console.error('grain-contrast-audit: unexpected error (advisory, non-blocking):', err);
-  process.exit(0);
+  console.error(`grain-contrast-audit failed to run: ${err?.stack || err}`);
+  process.exit(1);
 });

--- a/astro-site/scripts/typography-audit.mjs
+++ b/astro-site/scripts/typography-audit.mjs
@@ -5,11 +5,23 @@
  *   - body text ≥ 17px (1.0625rem)
  *   - small/meta text ≥ 14px (0.875rem)
  *   - micro (timestamps) ≥ 13px (0.8125rem) — hard floor
- * Flags absolute font-size values (px/rem) under the floor. Relative values
+ * Flags absolute font-size values (px/pt/rem) under the floor. Relative values
  * (em, %) are exempt because they scale with their parent's size — decorative
  * supers like ↗ indicators or chip counts (<1em) are legitimate.
+ *
+ * A negative-control audit (issue #511) got five evasions past the old
+ * per-line `line.match(...)`, each of which has a shape that occurs in real
+ * CSS:
+ *   - only the FIRST font-size on a line was tested, so
+ *     `.a{font-size:16px} .b{font-size:8px}` passed
+ *   - the `font:` shorthand (`font: 10px/1.2 serif`) was not matched at all
+ *   - `clamp(9px, 1vw, 12px)` was invisible; 11 real clamp() declarations
+ *     ship, so the floor was unenforced for the whole fluid-type system
+ *   - a rule line starting with `*` was treated as a comment continuation
+ *   - units were matched case-sensitively, so `10PX` passed, and `pt` was
+ *     not a recognised unit at all (6pt = 8px)
  */
-import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
 import { join, extname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
@@ -20,6 +32,7 @@ const root = resolve(here, '../src');
 const FLOOR_PX = 13;
 const exts = new Set(['.css', '.astro', '.svelte', '.ts', '.tsx', '.mdx']);
 const violations = [];
+let filesScanned = 0;
 
 function walk(dir) {
   for (const entry of readdirSync(dir)) {
@@ -32,40 +45,81 @@ function walk(dir) {
 
 function toPx(value, unit) {
   const v = parseFloat(value);
-  if (unit === 'px') return v;
-  if (unit === 'rem') return v * 16;
-  return null; // em/% exempt (relative to parent)
+  switch (unit.toLowerCase()) {
+    case 'px': return v;
+    case 'rem': return v * 16;
+    case 'pt': return (v * 96) / 72;
+    default: return null; // em/%/vw exempt (relative to parent or viewport)
+  }
 }
 
+/**
+ * Blank out comments while preserving line numbers. Replaces the old
+ * per-line guess, which mistook `* { … }` rule lines for comment
+ * continuations — global.css has four of them.
+ */
+function stripComments(src) {
+  let out = src.replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '));
+  return out.replace(/(^|[^:])\/\/[^\n]*/g, (m, p1) => p1 + ' '.repeat(m.length - p1.length));
+}
+
+// `font-size: X` and the `font:` shorthand, whose size slot precedes an
+// optional `/line-height`. Also reaches inside clamp()/min()/max(), where
+// every absolute argument must clear the floor.
+const SIZE_RE =
+  /(?:font-size\s*:|font\s*:(?:[^;{}]*?\s)?)\s*[^;{}]*?(\d*\.?\d+)\s*(px|rem|pt)\b/gi;
+const FUNC_ARG_RE = /(\d*\.?\d+)\s*(px|rem|pt)\b/gi;
+
 function scan(file) {
-  const src = readFileSync(file, 'utf8');
-  const lines = src.split('\n');
+  filesScanned += 1;
+  const raw = readFileSync(file, 'utf8');
+  const lines = stripComments(raw).split('\n');
+  const rawLines = raw.split('\n');
+
   lines.forEach((line, i) => {
-    // skip comments
-    if (/^\s*(\/\/|\*|\/\*)/.test(line)) return;
-    // match font-size: N(px|rem|em)
-    const m = line.match(/font-size:\s*([\d.]+)(px|rem)\b/);
-    if (!m) return;
-    const px = toPx(m[1], m[2]);
-    if (px === null) return;
-    if (px < FLOOR_PX) {
-      violations.push({
-        file: file.replace(root + '/', ''),
-        line: i + 1,
-        value: `${m[1]}${m[2]}`,
-        px: px.toFixed(1),
-        snippet: line.trim(),
-      });
+    // Every size declaration on the line, not just the first.
+    for (const decl of line.matchAll(/(?:font-size|font)\s*:[^;{}]*/gi)) {
+      const text = decl[0];
+      // clamp()/min()/max(): check every absolute argument, since the
+      // smallest one is what a narrow viewport actually renders.
+      const args = text.match(/\b(?:clamp|min|max)\s*\([^)]*\)/i);
+      const candidates = args
+        ? [...args[0].matchAll(FUNC_ARG_RE)]
+        : [...text.matchAll(SIZE_RE)].map((m) => [m[0], m[1], m[2]]);
+
+      for (const c of candidates) {
+        const px = toPx(c[1], c[2]);
+        if (px === null || px >= FLOOR_PX) continue;
+        violations.push({
+          file: file.replace(root + '/', ''),
+          line: i + 1,
+          value: `${c[1]}${c[2]}`,
+          px: px.toFixed(1),
+          snippet: (rawLines[i] ?? '').trim(),
+        });
+        break;
+      }
     }
   });
 }
 
+if (!existsSync(root)) {
+  console.error(`USWDS Typography Floor Audit\n\n  Source root not found: ${root}`);
+  process.exit(1);
+}
 walk(root);
 
 console.log('USWDS Typography Floor Audit\n');
 console.log(`  Floor: ${FLOOR_PX}px (Remarque --text-micro)\n`);
+
+// An empty walk is not a clean pass — it means the scan never happened.
+if (filesScanned === 0) {
+  console.error(`  Scanned 0 files under ${root}. That is a broken audit, not a clean one.\n`);
+  process.exit(1);
+}
+
 if (violations.length === 0) {
-  console.log('  No violations found.');
+  console.log(`  No violations found. (${filesScanned} files scanned)`);
   process.exit(0);
 }
 for (const v of violations) {

--- a/astro-site/src/components/PizzaOps.svelte
+++ b/astro-site/src/components/PizzaOps.svelte
@@ -359,9 +359,9 @@
   }
   .po-lights { display: flex; gap: 0.4rem; }
   .po-light { width: 0.72rem; height: 0.72rem; border-radius: 50%; opacity: 0.85; }
-  .po-light--r { background: var(--color-error, #c0392b); }
-  .po-light--y { background: var(--color-accent-hover, #d4a017); }
-  .po-light--g { background: var(--color-accent, #2e8b57); }
+  .po-light--r { background: var(--color-error); }
+  .po-light--y { background: var(--color-accent-hover); }
+  .po-light--g { background: var(--color-accent); }
   .po-appname { font-weight: 600; letter-spacing: 0.02em; }
   .po-health {
     margin-left: auto; display: inline-flex; align-items: center; gap: 0.4rem;

--- a/astro-site/src/components/Search.svelte
+++ b/astro-site/src/components/Search.svelte
@@ -356,7 +356,7 @@
   .search-esc {
     display: none;
     /* font-family: mono — shared machine-voice rule in global.css (#274) */
-    font-size: var(--text-micro, 0.75rem);
+    font-size: var(--text-micro);
     padding: 0.125rem 0.375rem;
     border: 1px solid var(--color-border);
     border-radius: 0.25rem;

--- a/astro-site/src/components/ThemeDeck.astro
+++ b/astro-site/src/components/ThemeDeck.astro
@@ -86,7 +86,7 @@ const lightThemes = themes.filter((t) => !t.isDark);
 <style>
   .theme-deck {
     /* font-family: mono — shared machine-voice rule in global.css (#274) */
-    font-size: var(--text-micro, 0.75rem);
+    font-size: var(--text-micro);
     margin-top: 0.75rem;
   }
 

--- a/astro-site/src/og/card.ts
+++ b/astro-site/src/og/card.ts
@@ -30,12 +30,19 @@ const shantell = readFileSync(resolve(fontDir, 'ShantellSans.ttf'));
 const grainTile = readFileSync(resolve(assetDir, 'grain-tile.png'));
 const grainDataUri = `data:image/png;base64,${grainTile.toString('base64')}`;
 
-const BG = '#1a1f2e';
-const BLUE = '#3b82f6';
-const AMBER = '#f0a828';
-const TITLE = '#f8fafc';
-const SUB = '#94a3b8';
-const FOOT = '#64748b';
+// Social-card palette. These are literals on purpose: satori renders an
+// object tree straight to SVG at build time with no CSS cascade and no
+// :root, so var(--color-*) cannot resolve here. The colour-token audit does
+// see these lines (issue #511) — the allow-raw-color markers are what
+// exempts them, so the exemption is reviewed rather than structural. If this
+// palette should track the site tokens, it has to be resolved in JS and
+// passed in; it cannot be done with CSS custom properties.
+const BG = '#1a1f2e'; // allow-raw-color: satori has no CSS cascade
+const BLUE = '#3b82f6'; // allow-raw-color: satori has no CSS cascade
+const AMBER = '#f0a828'; // allow-raw-color: satori has no CSS cascade
+const TITLE = '#f8fafc'; // allow-raw-color: satori has no CSS cascade
+const SUB = '#94a3b8'; // allow-raw-color: satori has no CSS cascade
+const FOOT = '#64748b'; // allow-raw-color: satori has no CSS cascade
 
 type Node = { type: string; props: Record<string, unknown> };
 function div(style: Record<string, unknown>, children?: unknown): Node {

--- a/astro-site/tests/e2e/a11y.spec.ts
+++ b/astro-site/tests/e2e/a11y.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from 'playwright/test';
-import type { Page } from 'playwright/test';
+import type { Page, Response } from 'playwright/test';
 import AxeBuilder from '@axe-core/playwright';
 
 // Key pages covering each layout archetype
@@ -40,6 +40,24 @@ const PAGES = [
  *    list, so a future post that introduces the same bug still fails here
  *    instead of being silently masked site-wide.
  */
+/**
+ * Liveness precondition — run BEFORE axe on every scan.
+ *
+ * `expect(results.violations).toEqual([])` is vacuously true for a page that
+ * does not exist: axe on the preview server's bare 404 body finds nothing to
+ * violate, so the whole suite passed green against an empty `dist/`
+ * (18 passed, exit 0). A scan that cannot fail is not a test. This asserts
+ * the page actually rendered — HTTP 200 and a visible `<main>` landmark,
+ * which every page in PAGES has exactly one of — so a broken or missing
+ * build fails here instead of being reported as "no accessibility
+ * violations".
+ */
+async function assertPageIsLive(page: Page, response: Response | null, path: string) {
+  expect(response, `no navigation response for ${path}`).not.toBeNull();
+  expect(response!.status(), `${path} must return HTTP 200 before axe runs`).toBe(200);
+  await expect(page.locator('main'), `${path} must render a <main> landmark`).toBeVisible();
+}
+
 async function runAxe(page: Page, extraExcludes: string[] = []) {
   const builder = new AxeBuilder({ page })
     .withTags(['wcag2a', 'wcag2aa', 'wcag21aa', 'wcag22aa'])
@@ -66,14 +84,16 @@ for (const { path, name } of PAGES) {
   const extraExcludes = EXTRA_EXCLUDES[name] ?? [];
 
   test(`a11y: ${name} (${path}) — light`, async ({ page }) => {
-    await page.goto(path);
+    const response = await page.goto(path);
+    await assertPageIsLive(page, response, path);
     const results = await runAxe(page, extraExcludes);
     expect(results.violations, JSON.stringify(results.violations, null, 2)).toEqual([]);
   });
 
   test(`a11y: ${name} (${path}) — dark`, async ({ page }) => {
     await page.emulateMedia({ colorScheme: 'dark' });
-    await page.goto(path);
+    const response = await page.goto(path);
+    await assertPageIsLive(page, response, path);
     const results = await runAxe(page, extraExcludes);
     expect(results.violations, JSON.stringify(results.violations, null, 2)).toEqual([]);
   });

--- a/astro-site/tests/e2e/sidenotes.spec.ts
+++ b/astro-site/tests/e2e/sidenotes.spec.ts
@@ -7,6 +7,21 @@ import AxeBuilder from '@axe-core/playwright';
 // converted from inline citations — see rehype-sidenotes.mjs.
 const PILOT_POST = '/posts/2025-10-29-post-quantum-cryptography-homelab/';
 
+/**
+ * Liveness precondition for the assertions that are satisfied by ABSENCE —
+ * `toHaveCount(0)` and axe's `violations).toEqual([])`. Those pass against a
+ * page that was never built (an empty `dist/` scored 3 green here), so the
+ * scan must first prove it has a page to scan. Same guard as the one in
+ * a11y.spec.ts.
+ */
+async function assertPilotPostIsLive(page: import('playwright/test').Page) {
+  await expect(page.locator('main'), 'pilot post must render a <main> landmark').toBeVisible();
+  await expect(
+    page.locator('a.remarque-sidenote-ref').first(),
+    'pilot post must render sidenote markup'
+  ).toBeVisible();
+}
+
 // 1280px (== 80rem at the platform default 16px root) is the module's own
 // breakpoint (essay.css's single `@media (min-width: 80rem)` block, same
 // threshold this site used before the migration) — worth checking in
@@ -143,6 +158,7 @@ test.describe('sidenotes — wide viewport (margin rail)', () => {
 
   test('no GFM footnotes section remains on the pilot post', async ({ page }) => {
     await page.goto(PILOT_POST);
+    await assertPilotPostIsLive(page);
     await expect(page.locator('section[data-footnotes]')).toHaveCount(0);
   });
 
@@ -153,12 +169,23 @@ test.describe('sidenotes — wide viewport (margin rail)', () => {
 
     const refs = page.locator('a.remarque-sidenote-ref');
     const refCount = await refs.count();
+
+    // Precondition. Everything below used to hang off `if (isRepeat)`, and
+    // no post in the corpus has a repeated citation (verified with
+    // `rg -c 'remarque-sidenote-ref--repeat' dist/posts/*/index.html` —
+    // zero matches site-wide), so the loop body never executed: the test
+    // passed on a page with no sidenote markup at all, an empty `dist/`
+    // included. Assert there is something to check before checking it.
+    expect(refCount, 'pilot post must render sidenote references').toBeGreaterThan(0);
+
     const hrefs: string[] = [];
     for (let i = 0; i < refCount; i++) {
       hrefs.push((await refs.nth(i).getAttribute('href')) ?? '');
     }
     const notes = page.locator('aside.remarque-sidenote');
     const noteCount = await notes.count();
+    expect(noteCount, 'pilot post must render sidenote asides').toBeGreaterThan(0);
+
     const noteIds = new Set<string>();
     for (let i = 0; i < noteCount; i++) {
       noteIds.add((await notes.nth(i).getAttribute('id')) ?? '');
@@ -168,19 +195,33 @@ test.describe('sidenotes — wide viewport (margin rail)', () => {
     // duplicates even if a footnote is cited more than once).
     expect(noteIds.size).toBe(noteCount);
 
-    // If this pilot post has any repeated citation, its second-or-later
-    // ref must carry the --repeat modifier and its href must resolve to a
-    // note id that already exists exactly once.
+    // "...and does not insert a second note": exactly one aside per DISTINCT
+    // cited target, regardless of how many refs point at it.
+    expect(noteCount, 'one aside per distinct cited footnote').toBe(new Set(hrefs).size);
+
+    // The --repeat modifier must appear on exactly the second-or-later
+    // citation of a target and nowhere else. Asserted in BOTH directions and
+    // unconditionally, so a plugin that stamps every ref (or stops stamping)
+    // fails here even on a post whose citations happen to all be unique.
+    // The stamping path itself, on a fixture that does repeat, is covered by
+    // tests/unit/rehype-sidenotes.test.mjs.
     const seen = new Set<string>();
+    const expectedRepeatIndices: number[] = [];
     for (let i = 0; i < refCount; i++) {
-      const href = hrefs[i];
-      const isRepeat = seen.has(href);
-      seen.add(href);
-      if (isRepeat) {
-        const classes = (await refs.nth(i).getAttribute('class')) ?? '';
-        expect(classes).toContain('remarque-sidenote-ref--repeat');
+      if (seen.has(hrefs[i])) expectedRepeatIndices.push(i);
+      seen.add(hrefs[i]);
+    }
+    const actualRepeatIndices: number[] = [];
+    for (let i = 0; i < refCount; i++) {
+      const classes = (await refs.nth(i).getAttribute('class')) ?? '';
+      if (classes.split(/\s+/).includes('remarque-sidenote-ref--repeat')) {
+        actualRepeatIndices.push(i);
       }
     }
+    expect(
+      actualRepeatIndices,
+      'remarque-sidenote-ref--repeat must mark exactly the repeat citations'
+    ).toEqual(expectedRepeatIndices);
   });
 });
 
@@ -250,6 +291,7 @@ test.describe('sidenotes — accessibility', () => {
   test('axe: pilot post has no new violations at the wide-viewport (rail) layout', async ({ page }) => {
     await page.setViewportSize({ width: 1440, height: 1000 });
     await page.goto(PILOT_POST);
+    await assertPilotPostIsLive(page);
     const results = await new AxeBuilder({ page })
       .withTags(['wcag2a', 'wcag2aa', 'wcag21aa', 'wcag22aa'])
       .exclude('pre.astro-code span')
@@ -272,6 +314,7 @@ test.describe('sidenotes — accessibility', () => {
   test('axe: pilot post has no new violations at the narrow-viewport (inline) layout', async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 812 });
     await page.goto(PILOT_POST);
+    await assertPilotPostIsLive(page);
     const results = await new AxeBuilder({ page })
       .withTags(['wcag2a', 'wcag2aa', 'wcag21aa', 'wcag22aa'])
       .exclude('pre.astro-code span')

--- a/astro-site/tests/e2e/smoke.spec.ts
+++ b/astro-site/tests/e2e/smoke.spec.ts
@@ -24,11 +24,14 @@ for (const page of pages) {
 test('404 page renders correctly', async ({ page }) => {
   // 404.html exists at /404.html in the built output.
   // Astro preview server may not serve it at /404/ — test the direct path.
+  // No `if (response?.status() === 200)` guard: wrapping the body in one made
+  // this test pass when 404.html was missing from the build entirely, which is
+  // precisely the regression it exists to catch. The preview server does serve
+  // /404.html directly, so assert unconditionally.
   const response = await page.goto('/404.html');
-  if (response?.status() === 200) {
-    await expect(page.locator('text=Page not found')).toBeVisible();
-    await expect(page.locator('text=Recent Posts')).toBeVisible();
-  }
+  expect(response?.status()).toBe(200);
+  await expect(page.locator('text=Page not found')).toBeVisible();
+  await expect(page.locator('text=Recent Posts')).toBeVisible();
   // On live GitHub Pages, 404.html is served for missing routes automatically
 });
 
@@ -36,13 +39,27 @@ test('dark mode toggle switches theme', async ({ page }) => {
   await page.goto('/');
   const html = page.locator('html');
 
+  // The root element always carries `class="scroll-smooth"`, so the old
+  // `expect(classAfter).toBeTruthy()` was satisfied before the toggle was
+  // even clicked — removing ThemeToggle.astro's click listener outright
+  // still passed. Assert the *theme* class specifically, and that it moved.
+  const classBefore = (await html.getAttribute('class')) ?? '';
+  expect(classBefore, 'a fresh load must not already be pinned dark').not.toMatch(/\bdark\b/);
+
   // Click dark mode toggle (aria-label is "Switch to dark/light theme")
   const toggle = page.locator('button[aria-label*="theme"]');
   await toggle.first().click();
 
-  // Verify theme class changed
-  const classAfter = await html.getAttribute('class');
-  expect(classAfter).toBeTruthy();
+  await expect(html).toHaveClass(/\bdark\b/);
+  expect(await html.getAttribute('class'), 'theme class must change on click').not.toBe(
+    classBefore
+  );
+
+  // Round-trip: a second click must go back to light, so a toggle that only
+  // ever adds `dark` fails here rather than passing the first assertion.
+  await toggle.first().click();
+  await expect(html).toHaveClass(/\blight\b/);
+  await expect(html).not.toHaveClass(/\bdark\b/);
 });
 
 test('search dialog opens and closes', async ({ page }) => {
@@ -53,10 +70,19 @@ test('search dialog opens and closes', async ({ page }) => {
   await searchButton.first().click();
 
   // Dialog should be visible
-  await expect(page.locator('[role="dialog"], dialog').first()).toBeVisible();
+  const dialog = page.locator('[role="dialog"], dialog');
+  await expect(dialog.first()).toBeVisible();
+  // Search.svelte focuses the input on a 50ms timer after mount. Waiting for
+  // that settles the open before the Escape below, and is itself the modal's
+  // focus-management contract.
+  await expect(dialog.locator('input').first()).toBeFocused();
 
-  // Close with Escape
+  // Close with Escape. The test is named "opens AND closes" but used to end
+  // on the keypress with nothing asserted after it, so a broken/absent
+  // Escape handler passed. Search.svelte's `{#if isOpen}` unmounts the
+  // overlay, so a real close means the node is gone.
   await page.keyboard.press('Escape');
+  await expect(dialog).toHaveCount(0);
 });
 
 test('primary nav is visible on small viewport', async ({ page }) => {


### PR DESCRIPTION
Does the bulk of #511. Every fix ships with a negative-control matrix — planted violations that previously passed, plus cases that must *not* fire.

## axe was green against a site that does not exist

```
ORIGINAL spec, empty dist  ->  18 passed, exit 0     <- the vacuity
FIXED spec, empty dist     ->  18 failed, exit 1
FIXED spec, dist restored  ->  18 passed, exit 0
```

`expect(results.violations).toEqual([])` is satisfied by a page that isn't there. Every scan now asserts the navigation returned 200 and `<main>` is visible before running axe. Three tests in `sidenotes.spec.ts` had the same defect — assertions satisfied by absence — and got the same precondition.

## Three more tests asserted nothing

| test | why it passed | mutation | before → after |
|---|---|---|---|
| dark-mode toggle | `toBeTruthy()` on a class string that always contains `scroll-smooth` | removed the toggle's click listener | 0 → 1 |
| 404 page | body inside `if (response?.status() === 200)` | deleted `src/pages/404.astro` | 0 → 1 |
| search dialog | pressed Escape as its last statement, asserted nothing | broke the Escape handler | 0 → 1 |
| repeated citation | body inside `if (isRepeat)`, never executed | made the repeat stamp unconditional | 0 → 1 |

## The design audits caught the naive violation and nothing else

All three were per-line regexes with no notion of CSS syntax.

**typography-audit — 12/12 controls.** Only the *first* `font-size` on a line was tested; the `font:` shorthand was never matched; `clamp()` was invisible (11 real declarations ship, so the floor was unenforced for the entire fluid-type system); a `*` rule line was read as a comment continuation; units were case-sensitive and `pt` was unknown.

**color-token-audit — 18/18 controls.** The early return on `var(--color-` discarded the whole declaration, so a hardcoded fallback was invisible. `.ts` wasn't scanned at all. And the header had claimed named colours were flagged, with nothing implementing it.

**accent-font-audit — 6/6 controls.** A *comment* mentioning `.hand-note` and containing a brace opened the allowlist gate for everything after it. And naming `"Shantell Sans"` directly bypassed the token entirely — achieving exactly what the restriction exists to prevent.

All three now strip comments properly instead of guessing per line.

## An empty walk is not a clean pass

None of the five audits counted the files it scanned, so a walk over zero files was byte-identical to a clean run. All five now fail on that. The two advisory audits keep their **findings** advisory but exit 1 on a **broken** run — being unable to look is not the same as finding nothing.

## Five real defects the fixed audits immediately found

Three hardcoded colours in `PizzaOps.svelte` hidden behind `var(--color-x, #hex)` fallbacks — and, once the typography audit could see fallbacks, `font-size: var(--text-micro, 0.75rem)` in `Search.svelte` and `ThemeDeck.astro`.

**`--text-micro` is defined at `0.8125rem` — which *is* the 13px floor.** So both fallbacks were dead *and* 1px under the floor they exist to enforce.

All five removed. Verified all four tokens resolve on `:root` in a real browser (`--text-micro` computes to `.8125rem`), 92 OG cards still generate, pizza-ops status lights still render.

## `og/card.ts`

satori renders an object tree straight to SVG with no CSS cascade, so `var()` genuinely cannot resolve — literals are required there. Rather than leave that silent, the audit now **does** scan hex literals in `.ts`, and the six constants carry `allow-raw-color` markers with the reason. The exemption is reviewed rather than structural: delete a marker and the build fails.

## Two false alarms worth recording

A review agent reported that `--text-micro` "is not defined anywhere (0 definitions in node_modules)". It is — in `remarque-tokens/tokens-core.css:27`. **`remarque-tokens` is a pnpm symlink, and `rg` does not follow symlinks by default**, so searching `node_modules/` misses every dependency. `rg -L` finds it. Same family as the ugrep trap in #509, and worth knowing for any future dependency search here.

`visual-baselines.spec.ts` failures are pre-existing, not caused by this: its snapshots are **untracked and dated 2026-07-19**, and the spec is `test.skip`'d on CI. Already noted in #511.

## Not in this PR

`grain-contrast-audit` reports **4 live WCAG failures** in `solarized-dark-higher-contrast` (grain compositing drags 4.54:1 → 4.18:1). Flipping its exit needs the design call first — retune the deck, drop it, or accept and document. Left open in #511.

## Verification

59/59 Playwright · all 5 audits · build · `astro check` · eslint · unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AvTumDxQ2ntLDwsSefHtf
