### PR TITLE
fix: duplicate titles, dead feed links, and a validator that never ran

### DIFF
--- a/.github/workflows/citation-validation.yml
+++ b/.github/workflows/citation-validation.yml
@@ -26,10 +26,25 @@ jobs:
       - name: Install UV
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
 
-      - name: Install dependencies
+      # `uv pip install --system` installs into the SYSTEM interpreter, but
+      # every step below runs `uv run`, which uses the project venv resolved
+      # from pyproject.toml + uv.lock. They are different interpreters, so
+      # this installed nothing the scripts could see (issue #496).
+      #
+      # The visible consequence: link-validator.py guards its playwright
+      # import in a try/except, so PLAYWRIGHT_AVAILABLE was ALWAYS False here.
+      # Its browser-based escalation at :252 — the path that re-checks links
+      # plain HTTP could not validate, i.e. JS-rendered pages and anti-bot
+      # walls — never ran, and this workflow auto-files an issue telling the
+      # author to replace citations it classified as broken. Meanwhile
+      # `playwright install chromium` downloaded a browser every Monday for
+      # nothing.
+      #
+      # `uv run --with` injects into the environment the script actually runs
+      # in. requests and beautifulsoup4 are dropped: no script imports either.
+      - name: Install Playwright + browser
         run: |
-          uv pip install --system requests beautifulsoup4 playwright aiohttp certifi
-          playwright install chromium
+          uv run --with playwright playwright install --with-deps chromium
 
       - name: Extract citation links
         id: extract
@@ -47,7 +62,7 @@ jobs:
       - name: Validate citation links
         id: validate
         run: |
-          uv run python scripts/link-validation/link-validator.py \
+          uv run --with playwright python scripts/link-validation/link-validator.py \
             --input citation-links.json \
             --output citation-validation.json \
             --max-retries 3 \

--- a/astro-site/package.json
+++ b/astro-site/package.json
@@ -53,6 +53,7 @@
     "colorparsley": "^0.1.8",
     "eslint": "^10.8.1",
     "eslint-plugin-astro": "^3.1.0",
+    "markdown-it-footnote": "^4.0.0",
     "pagefind": "^1.5.2",
     "playwright": "^1.62.1",
     "prettier": "^3.9.6",

--- a/astro-site/pnpm-lock.yaml
+++ b/astro-site/pnpm-lock.yaml
@@ -88,6 +88,9 @@ importers:
       eslint-plugin-astro:
         specifier: ^3.1.0
         version: 3.1.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@typescript-eslint/parser@8.67.0(eslint@10.8.1)(typescript@6.0.3))(eslint@10.8.1)
+      markdown-it-footnote:
+        specifier: ^4.0.0
+        version: 4.0.0
       pagefind:
         specifier: ^1.5.2
         version: 1.5.2
@@ -2088,6 +2091,9 @@ packages:
 
   magicast@0.5.4:
     resolution: {integrity: sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==}
+
+  markdown-it-footnote@4.0.0:
+    resolution: {integrity: sha512-WYJ7urf+khJYl3DqofQpYfEYkZKbmXmwxQV8c8mO/hGIhgZ1wOe7R4HLFNwqx7TjILbnC98fuyeSsin19JdFcQ==}
 
   markdown-it@14.3.0:
     resolution: {integrity: sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==}
@@ -4960,6 +4966,8 @@ snapshots:
       '@babel/parser': 7.29.8
       '@babel/types': 7.29.8
       source-map-js: 1.2.1
+
+  markdown-it-footnote@4.0.0: {}
 
   markdown-it@14.3.0:
     dependencies:

--- a/astro-site/scripts/run-unit-tests.mjs
+++ b/astro-site/scripts/run-unit-tests.mjs
@@ -19,7 +19,7 @@
  */
 import { spawnSync } from 'node:child_process';
 
-const MIN_TESTS = 7;
+const MIN_TESTS = 10;
 const GLOB = '../tests/unit/**/*.test.mjs';
 
 const result = spawnSync(process.execPath, ['--test', GLOB], {

--- a/astro-site/src/lib/feedContent.ts
+++ b/astro-site/src/lib/feedContent.ts
@@ -1,0 +1,54 @@
+import sanitizeHtml from 'sanitize-html';
+import MarkdownIt from 'markdown-it';
+import footnote from 'markdown-it-footnote';
+
+/**
+ * Render a post body for syndication.
+ *
+ * Both feeds previously did this inline with a bare `new MarkdownIt()`, which
+ * produced two defects (issue #499):
+ *
+ *   1. **Relative URLs.** Feed content is resolved against the READER's base
+ *      URI, not the site's, so all 75 root-relative cross-links in the corpus
+ *      were dead for every subscriber. markdown-it has no base-URL option and
+ *      nothing rewrote them.
+ *
+ *   2. **Raw footnote syntax.** The site pipeline runs remark-gfm via Astro;
+ *      this parser was stock, so `[^id]` markers rendered as literal text and
+ *      the definitions became an orphan paragraph with no referents.
+ *
+ * Shared so the two feeds cannot drift apart again — they had already diverged
+ * from the site's own rendering, which is how both defects survived.
+ */
+const parser = new MarkdownIt().use(footnote);
+
+/** Absolutise root-relative href/src values against the site origin. */
+export function absolutiseUrls(html: string, siteUrl: string): string {
+  const base = siteUrl.replace(/\/$/, '');
+  // Only `/path` — never `//host` (protocol-relative) and never `/` inside an
+  // already-absolute URL, since the attribute value must START with the slash.
+  return html.replace(
+    /(\s(?:href|src)=)(["'])(\/(?!\/)[^"']*)\2/g,
+    (_m, attr, quote, path) => `${attr}${quote}${base}${path}${quote}`,
+  );
+}
+
+export function renderPostForFeed(body: string, siteUrl: string): string {
+  const html = sanitizeHtml(parser.render(body ?? ''), {
+    allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),
+    allowedAttributes: {
+      ...sanitizeHtml.defaults.allowedAttributes,
+      // Footnotes are only useful if the jump works. The default schema
+      // strips id/class, which left a numbered marker linking to nothing.
+      // Scoped to the elements the footnote plugin actually emits.
+      a: [...(sanitizeHtml.defaults.allowedAttributes.a ?? []), 'id', 'class'],
+      li: ['id', 'class'],
+      sup: ['class'],
+      section: ['class'],
+      ol: ['class'],
+      hr: ['class'],
+      img: ['src', 'alt', 'title'],
+    },
+  });
+  return absolutiseUrls(html, siteUrl);
+}

--- a/astro-site/src/pages/feed.json.ts
+++ b/astro-site/src/pages/feed.json.ts
@@ -1,10 +1,7 @@
 import { getCollection } from 'astro:content';
 import type { APIContext } from 'astro';
-import sanitizeHtml from 'sanitize-html';
-import MarkdownIt from 'markdown-it';
+import { renderPostForFeed } from '@/lib/feedContent';
 import { SITE_CONFIG } from '@/lib/siteConfig';
-
-const parser = new MarkdownIt();
 
 // JSON Feed 1.1 — https://jsonfeed.org/version/1.1
 // Mirrors feed.xml.ts: same post set, same full (non-truncated) content_html.
@@ -15,9 +12,7 @@ export async function GET(context: APIContext) {
 
   const items = sortedPosts.map((post) => {
     const url = `${siteUrl}/posts/${post.id}/`;
-    const contentHtml = sanitizeHtml(parser.render(post.body ?? ''), {
-      allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),
-    });
+    const contentHtml = renderPostForFeed(post.body ?? '', siteUrl);
 
     return {
       id: url,

--- a/astro-site/src/pages/feed.xml.ts
+++ b/astro-site/src/pages/feed.xml.ts
@@ -1,11 +1,9 @@
 import rss from '@astrojs/rss';
 import { getCollection } from 'astro:content';
 import type { APIContext } from 'astro';
-import sanitizeHtml from 'sanitize-html';
-import MarkdownIt from 'markdown-it';
+import { renderPostForFeed } from '@/lib/feedContent';
 import { SITE_CONFIG } from '@/lib/siteConfig';
 
-const parser = new MarkdownIt();
 
 export async function GET(context: APIContext) {
   const posts = await getCollection('posts', ({ data }) => !data.draft);
@@ -21,9 +19,7 @@ export async function GET(context: APIContext) {
     },
     customData: `<atom:link href="${siteUrl}/feed.xml" rel="self" type="application/rss+xml"/><lastBuildDate>${new Date().toUTCString()}</lastBuildDate>`,
     items: sortedPosts.map((post) => {
-      const renderedContent = sanitizeHtml(parser.render(post.body ?? ''), {
-        allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),
-      });
+      const renderedContent = renderPostForFeed(post.body ?? '', siteUrl);
 
       return {
         title: post.data.title,

--- a/astro-site/src/types/markdown-it-footnote.d.ts
+++ b/astro-site/src/types/markdown-it-footnote.d.ts
@@ -1,0 +1,7 @@
+// markdown-it-footnote ships no type declarations. It is a plain markdown-it
+// plugin, so the only shape we need is "something you can pass to .use()".
+declare module 'markdown-it-footnote' {
+  import type MarkdownIt from 'markdown-it';
+  const footnotePlugin: MarkdownIt.PluginSimple;
+  export default footnotePlugin;
+}

--- a/scripts/link-validation/link-validator.py
+++ b/scripts/link-validation/link-validator.py
@@ -147,7 +147,10 @@ class LinkValidator:
             playwright = await async_playwright().start()
             self.browser = await playwright.chromium.launch(
                 headless=True,
-                args=['--disable-dev-shm-usage', '--no-sandbox']
+                # --no-sandbox removed: this navigates to URLs that FAILED plain
+                # HTTP validation, i.e. the suspicious ones, and GitHub-hosted
+                # runners support the renderer sandbox fine.
+                args=['--disable-dev-shm-usage']
             )
             self.context = await self.browser.new_context(
                 user_agent=self.USER_AGENTS['browser'],

--- a/scripts/zine-art/ink-mask.py
+++ b/scripts/zine-art/ink-mask.py
@@ -16,6 +16,12 @@ Usage: ink-mask.py IN.png OUT.png [--threshold 128] [--width 640] [--pad 12]
 import argparse
 from pathlib import Path
 
+# Pillow is NOT in pyproject.toml's dependencies, which declares three
+# (aiohttp, certifi, tqdm) for the CI link pipeline. This is author-local
+# doodle tooling that never runs in CI, so it is invoked as:
+#     uv run --with pillow python scripts/zine-art/ink-mask.py ...
+# Recorded here because "3 deps" read as complete and this import did not
+# appear anywhere in it (issue #496).
 from PIL import Image
 
 

--- a/src/posts/2024-01-30-python-vulnerability-scanner-automation.md
+++ b/src/posts/2024-01-30-python-vulnerability-scanner-automation.md
@@ -7,8 +7,6 @@ tags: [python, security, automation, vulnerability-management, homelab, cve, nvd
 post_type: tutorial
 ---
 
-# Building a Python Vulnerability Scanner with NVD API Integration
-
 Manual vulnerability tracking doesn't scale. I built a Python scanner that monitors 47 homelab services using the National Vulnerability Database API. It detects vulnerabilities in installed packages, sends alerts for critical CVEs, and integrates with existing Prometheus monitoring.
 
 Here's how to automate vulnerability management for your homelab.

--- a/src/posts/2024-06-11-zero-knowledge-authentication-homelab.md
+++ b/src/posts/2024-06-11-zero-knowledge-authentication-homelab.md
@@ -7,8 +7,6 @@ tags: [privacy, zero-knowledge, authentication, cryptography, homelab, security,
 post_type: tutorial
 ---
 
-# Zero-Knowledge Proof Authentication for Homelab Services
-
 Passwords travel networks. Even with TLS, credentials exist in logs, memory dumps, and database records. I implemented zero-knowledge proof authentication for my homelab SSO, eliminating password transmission entirely. Users prove identity cryptographically without revealing credentials.
 
 Here's how ZK-SNARKs enable password-less authentication at homelab scale.

--- a/src/posts/2025-01-22-llm-security-alert-triage-local.md
+++ b/src/posts/2025-01-22-llm-security-alert-triage-local.md
@@ -7,8 +7,6 @@ tags: [llm, security, incident-response, automation, ollama, homelab, python, ai
 post_type: tutorial
 ---
 
-# LLM-Powered Security Alert Triage with Local Models
-
 SOC teams field an average of 4,484 alerts a day ([Vectra AI, 2023 State of Threat Detection](https://www.vectra.ai/resources/2023-state-of-threat-detection)) — that's the team total, not per analyst. I automated 78% of triage decisions using local LLMs running on Ollama. No cloud API calls, no data exfiltration. Llama 3.1 (8B parameter model) classifies alert severity, correlates events, and generates incident summaries entirely in my homelab.
 
 Here's how local LLM triage reduces alert fatigue while preserving data privacy.

--- a/src/posts/2025-08-18-docker-lsm-security-hardening.md
+++ b/src/posts/2025-08-18-docker-lsm-security-hardening.md
@@ -7,8 +7,6 @@ tags: [docker, security, apparmor, selinux, container-security, homelab, linux, 
 post_type: tutorial
 ---
 
-# Docker Runtime Security Hardening with Linux Security Modules
-
 Container escapes happen, usually to whoever assumed namespaces were the whole security model. CVE-2025-52881 (disclosed 2025) bypasses AppArmor and SELinux via procfs writes, enabling full host compromise — the kind of finding that turns "we run everything in containers" into an aspiration rather than a control. I hardened 23 Docker containers in my homelab using layered LSM security: AppArmor profiles + seccomp filters + capability dropping + read-only root filesystems. Zero successful escapes in 6 months of red team testing.
 
 Here's how to lock down Docker without orchestration complexity.

--- a/src/posts/2025-11-05-siem-homelab-wazuh-graylog-comparison.md
+++ b/src/posts/2025-11-05-siem-homelab-wazuh-graylog-comparison.md
@@ -7,8 +7,6 @@ tags: [siem, wazuh, graylog, security, monitoring, homelab, python, observabilit
 post_type: tutorial
 ---
 
-# SIEM for Homelab: Wazuh vs Graylog Performance Comparison
-
 Security monitoring needs centralized log analysis. I deployed both Wazuh and Graylog in my homelab to compare performance, resource usage, and detection capabilities. Wazuh excelled at threat detection (9.0 seconds mean across all five scenarios; on the two attacks both tools caught, 5.7 seconds against Graylog's 14.0), Graylog dominated log search speed (1.4 seconds vs 4.2 seconds).
 
 Here's how to choose and deploy the right SIEM for your homelab.

--- a/src/posts/2025-11-19-promsketch-prometheus-optimization.md
+++ b/src/posts/2025-11-19-promsketch-prometheus-optimization.md
@@ -7,8 +7,6 @@ tags: [prometheus, monitoring, observability, performance, grafana, homelab, opt
 post_type: tutorial
 ---
 
-# PromSketch: What Sketch Algorithms Can and Cannot Do for Prometheus
-
 PromQL queries fall over on high-cardinality metrics, and the failure mode is familiar to anyone running a homelab Prometheus: the dashboard takes longer to load than the incident it was supposed to help diagnose. Every panel is a full scan over a window, every scan touches every matching series, and the cost grows with cardinality whether or not you actually needed sample-level precision.
 
 [PromSketch](https://arxiv.org/abs/2505.10560) (PVLDB vol. 18) is a research answer to that. It is worth understanding precisely, because it is narrower than the pitch implies and the narrowness is the interesting part.

--- a/src/posts/2025-11-23-nodeshield-runtime-sbom-enforcement.md
+++ b/src/posts/2025-11-23-nodeshield-runtime-sbom-enforcement.md
@@ -7,8 +7,6 @@ tags: [supply-chain, sbom, nodejs, security, docker, homelab, container-security
 post_type: tutorial
 ---
 
-# NodeShield: Runtime SBOM Enforcement Stops 98% of Supply Chain Attacks
-
 SolarWinds compromised 18,000 organizations through a single malicious dependency update in 2020. Four years later, npm still sees 1,000+ malicious packages monthly. Static SBOMs don't prevent this — they just document, in exhaustive detail, exactly who you trusted right before they burned you.
 
 I tested NodeShield, a runtime SBOM enforcement system, in my Docker homelab. It blocked 98.3% of supply chain attacks with <1ms overhead.

--- a/src/posts/2025-12-17-docker-container-hardening-homelab.md
+++ b/src/posts/2025-12-17-docker-container-hardening-homelab.md
@@ -9,8 +9,6 @@ seriesOrder: 2
 post_type: experience
 ---
 
-# Hardening Docker Containers in Your Homelab: A Defense-in-Depth Approach
-
 Four container escapes in six months taught me that single-layer security fails. I hardened my homelab's 47 Docker containers using eight defensive layers: minimal base images, user namespaces, seccomp profiles, AppArmor, capability dropping, read-only filesystems, network segmentation, and resource limits. Zero successful escapes in the last 8 months.
 
 Here's how each layer stopped real attacks and why you need all of them.

--- a/tests/unit/post-structure.test.mjs
+++ b/tests/unit/post-structure.test.mjs
@@ -1,0 +1,58 @@
+// Structural invariants over the post corpus (issue #498).
+//
+// These are not style opinions — they are things that render visibly wrong
+// and that no existing gate could see. `PostLayout.astro` emits the <h1> from
+// frontmatter, so a `# Title` in the body renders the title TWICE at display
+// size and puts two top-level headings in the accessibility outline.
+//
+// Eight posts had it. axe's `heading-order` does not fire (no level JUMP,
+// just a repeat) and there is no "exactly one h1" rule in the wcag2a/wcag2aa
+// tag set the axe suite selects, so CI was green on all eight.
+//
+// Lives here rather than in the advisory compliance script because this runs
+// in audits.yml's `check-lint` job, which is a required check.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const postsDir = resolve(dirname(fileURLToPath(import.meta.url)), '../../src/posts');
+const posts = readdirSync(postsDir).filter((f) => f.endsWith('.md'));
+
+/** Body text with frontmatter and fenced code blocks removed. */
+function bodyLines(raw) {
+  const parts = raw.split('---');
+  const body = parts.length >= 3 ? parts.slice(2).join('---') : raw;
+  const out = [];
+  let inFence = false;
+  for (const line of body.split('\n')) {
+    if (line.trim().startsWith('```')) { inFence = !inFence; continue; }
+    if (!inFence) out.push(line);
+  }
+  return out;
+}
+
+test('the corpus is non-empty (an empty walk is not a passing suite)', () => {
+  assert.ok(posts.length > 50, `found only ${posts.length} posts under ${postsDir}`);
+});
+
+test('no post carries a body-level H1 — the layout already renders the title', () => {
+  const offenders = [];
+  for (const name of posts) {
+    const bad = bodyLines(readFileSync(join(postsDir, name), 'utf8')).find((l) =>
+      /^#\s+\S/.test(l),
+    );
+    if (bad) offenders.push(`${name}: ${bad.trim().slice(0, 60)}`);
+  }
+  assert.deepEqual(
+    offenders,
+    [],
+    `PostLayout.astro emits <h1>{title}</h1>, so these render the title twice:\n  ${offenders.join('\n  ')}`,
+  );
+});
+
+test('every post has frontmatter delimiters', () => {
+  const offenders = posts.filter((n) => !readFileSync(join(postsDir, n), 'utf8').startsWith('---'));
+  assert.deepEqual(offenders, [], `missing opening frontmatter: ${offenders.join(', ')}`);
+});


### PR DESCRIPTION
Closes #496, #498, #499.

## #498 — eight posts rendered their title twice

`PostLayout.astro` emits `<h1>{title}</h1>` from frontmatter, and eight posts *also* carried a `# Title` in the body. Both rendered, verbatim, at `--text-display` (36–56px), with two top-level headings in the a11y outline.

CI was green on all eight because axe's `heading-order` doesn't fire on a *repeat* — only on a level jump — and there's no "exactly one h1" rule in the `wcag2a`/`wcag2aa` tag set `a11y.spec.ts` selects.

Removed from all eight, plus `tests/unit/post-structure.test.mjs` so it can't come back. That suite runs in `check-lint`, which is a **required check**. Negative control: re-adding one H1 fails the suite (exit 1); removing it passes. `MIN_TESTS` raised 7 → 10.

This also removes the invalid `padding-left: -1rem` those posts produced in the TOC.

## #499 — both feeds shipped 75 dead links and raw footnote syntax

Each feed re-parsed `post.body` with its own bare `new MarkdownIt()`:

- **75 distinct root-relative URLs**, resolved against the *reader's* base URI rather than the site's — essentially every internal cross-link the blog makes, dead in every reader.
- **`[^id]` markers rendered as literal text**, definitions becoming an orphan paragraph, because the site pipeline runs `remark-gfm` via Astro and this parser did not.

Extracted `src/lib/feedContent.ts`, shared by both feeds so they can't drift apart again — divergence from the site's own rendering is *how* both defects survived.

```
literal [^id] markers : 10 -> 0
footnote-ref spans    :  0 -> 5  (with 5 matching backrefs)
root-relative refs    : 75 -> 0
```

Worth noting: `sanitize-html`'s default schema strips `class` and `id`, which would have left a numbered footnote marker linking to nothing. The attribute allowlist is widened **scoped to the elements the footnote plugin emits**, not opened globally. And `markdown-it-footnote` ships no types, so there's a one-line `.d.ts` shim rather than a suppressed error.

## #496 — the weekly citation audit ran without its browser escalation

`citation-validation.yml` installed playwright with `uv pip install --system`, then ran every script with `uv run`. Different interpreters.

`link-validator.py` guards its playwright import in a `try/except`, so **`PLAYWRIGHT_AVAILABLE` was always `False` in CI** and the escalation at `:252` never ran — the path that re-checks links plain HTTP couldn't validate, i.e. JS-rendered pages and anti-bot walls. This workflow then **auto-files an issue telling you to find replacement sources** for citations it classified as broken. Meanwhile `playwright install chromium` downloaded a browser every Monday for nothing.

Proven both ways:

```
PLAYWRIGHT_AVAILABLE with `uv run --with playwright` = True
PLAYWRIGHT_AVAILABLE without                         = False
```

`requests` and `beautifulsoup4` dropped from the install — no script imports either.

Also removed `--no-sandbox` from the Chromium launch (security review L6): that code navigates to URLs which *failed* plain HTTP validation — the suspicious ones — and GitHub runners support the renderer sandbox.

And documented Pillow in `scripts/zine-art/ink-mask.py`, which imports it while `pyproject.toml` declares three deps. "3 deps" read as complete; this didn't appear in it.

## Verification

62 pytest · 59/59 Playwright · all 6 audits · `astro check` · eslint · 10 unit tests · ruff · all seven workflows parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AvTumDxQ2ntLDwsSefHtf
