### PR TITLE
fix(gists): correct the wrong-fact defects in the published examples

### DIFF
--- a/gists/README.md
+++ b/gists/README.md
@@ -103,6 +103,10 @@ The corrected `grype-config.yaml` is the model:
 - Complete — error handling and edge cases are elided on purpose
 - Safe to run unmodified
 
+Every shell file now uses `#` headers, and every `.sh` here passes `bash -n`.
+That is a low bar and it is the point: an excerpt that does not parse is not
+demonstrating anything.
+
 ## Quick Start by Category
 
 ### Security Scanning Pipeline

--- a/gists/proxmox-ha/backup-config.sh
+++ b/gists/proxmox-ha/backup-config.sh
@@ -1,15 +1,13 @@
 #!/bin/bash
-"""
-Proxmox Backup Server Integration and Automated Backup
-
-Source: https://williamzujkowski.github.io/posts/proxmox-high-availability-homelab/
-Purpose: Configure PBS integration and automated backup schedules with offsite sync
-Prerequisites: Proxmox Backup Server installed on separate hardware
-Usage:
-    bash backup-config.sh
-
-License: MIT
-"""
+# Proxmox Backup Server Integration and Automated Backup
+#
+# Source: https://williamzujkowski.github.io/posts/proxmox-high-availability-homelab/
+# Purpose: Configure PBS integration and automated backup schedules with offsite sync
+# Prerequisites: Proxmox Backup Server installed on separate hardware
+# Usage:
+#     bash backup-config.sh
+#
+# License: MIT
 
 BACKUP_DIR="/mnt/backup/proxmox"
 DATE=$(date +%Y%m%d_%H%M%S)
@@ -20,8 +18,8 @@ pvesm add pbs pbs-backup \
     --server 10.0.10.50 \
     --datastore homelab-backups \
     --username backup@pbs \
-    --password <password> \
-    --fingerprint <fingerprint>
+    --password "<password>" \
+    --fingerprint "<fingerprint>"
 
 # Configure backup schedule (daily at 2 AM)
 pvesh create /cluster/backup --schedule "0 2 * * *" \
@@ -48,11 +46,21 @@ tar -czf "$BACKUP_DIR/cluster-config_$DATE.tar.gz" \
 ceph config dump > "$BACKUP_DIR/ceph-config_$DATE.txt"
 ceph osd tree > "$BACKUP_DIR/ceph-osd-tree_$DATE.txt"
 
-# Sync to offsite location
-rclone sync "$BACKUP_DIR" remote:proxmox-backups/
+# Sync to offsite location.
+#
+# NOT `rclone sync`. sync makes the destination MATCH the source -- rclone's
+# own docs: "Destination is updated to match source, including deleting files
+# if necessary... If you don't want to delete files from destination, use the
+# copy command instead." Paired with the local prune below, that made offsite
+# retention converge on local retention: 7 days, not the 90 this repo's
+# README claims and not the 30 this comment used to claim.
+rclone copy "$BACKUP_DIR" remote:proxmox-backups/
 
-# Retention: Keep 7 days local, 30 days offsite
+# Retention: 7 days local, 90 days offsite (matches README.md).
+# Each side is pruned on its own schedule, which is the only way the two can
+# differ at all.
 find "$BACKUP_DIR" -name "*.tar.gz" -mtime +7 -delete
+rclone delete remote:proxmox-backups/ --min-age 90d
 SCRIPT
 
 chmod +x /usr/local/bin/cluster-backup.sh

--- a/gists/proxmox-ha/ceph-install.sh
+++ b/gists/proxmox-ha/ceph-install.sh
@@ -1,15 +1,13 @@
 #!/bin/bash
-"""
-Ceph Installation and Monitor Setup
-
-Source: https://williamzujkowski.github.io/posts/proxmox-high-availability-homelab/
-Purpose: Install Ceph distributed storage and create monitors on all nodes
-Prerequisites: Proxmox cluster created, storage network configured
-Usage:
-    bash ceph-install.sh
-
-License: MIT
-"""
+# Ceph Installation and Monitor Setup
+#
+# Source: https://williamzujkowski.github.io/posts/proxmox-high-availability-homelab/
+# Purpose: Install Ceph distributed storage and create monitors on all nodes
+# Prerequisites: Proxmox cluster created, storage network configured
+# Usage:
+#     bash ceph-install.sh
+#
+# License: MIT
 
 # On all nodes
 pveceph install --repository no-subscription --version quincy

--- a/gists/proxmox-ha/ceph-osd-setup.sh
+++ b/gists/proxmox-ha/ceph-osd-setup.sh
@@ -1,15 +1,13 @@
 #!/bin/bash
-"""
-Ceph OSD Creation and Pool Configuration
-
-Source: https://williamzujkowski.github.io/posts/proxmox-high-availability-homelab/
-Purpose: Create OSDs on each node and configure storage pools with replication
-Prerequisites: Ceph installed, monitors running, dedicated disks available
-Usage:
-    bash ceph-osd-setup.sh
-
-License: MIT
-"""
+# Ceph OSD Creation and Pool Configuration
+#
+# Source: https://williamzujkowski.github.io/posts/proxmox-high-availability-homelab/
+# Purpose: Create OSDs on each node and configure storage pools with replication
+# Prerequisites: Ceph installed, monitors running, dedicated disks available
+# Usage:
+#     bash ceph-osd-setup.sh
+#
+# License: MIT
 
 # On each node, for each disk:
 # Identify disks

--- a/gists/proxmox-ha/cluster-create.sh
+++ b/gists/proxmox-ha/cluster-create.sh
@@ -1,16 +1,14 @@
 #!/bin/bash
-"""
-Proxmox Cluster Creation Script
-
-Source: https://williamzujkowski.github.io/posts/proxmox-high-availability-homelab/
-Purpose: Create Proxmox cluster on primary node and join additional nodes
-Prerequisites: Node preparation completed on all nodes
-Usage:
-    # On Node 1: bash cluster-create.sh create
-    # On Node 2/3: bash cluster-create.sh join 10.0.10.11
-
-License: MIT
-"""
+# Proxmox Cluster Creation Script
+#
+# Source: https://williamzujkowski.github.io/posts/proxmox-high-availability-homelab/
+# Purpose: Create Proxmox cluster on primary node and join additional nodes
+# Prerequisites: Node preparation completed on all nodes
+# Usage:
+#     # On Node 1: bash cluster-create.sh create
+#     # On Node 2/3: bash cluster-create.sh join 10.0.10.11
+#
+# License: MIT
 
 if [ "$1" == "create" ]; then
     # On Node 1 (create cluster)

--- a/gists/proxmox-ha/disaster-recovery.sh
+++ b/gists/proxmox-ha/disaster-recovery.sh
@@ -1,17 +1,15 @@
 #!/bin/bash
-"""
-Proxmox HA Disaster Recovery Procedures
-
-Source: https://williamzujkowski.github.io/posts/proxmox-high-availability-homelab/
-Purpose: DR procedures for cluster rebuild, node recovery, and data restoration
-Prerequisites: Valid backups, documented configuration
-Usage:
-    # Full cluster rebuild: bash disaster-recovery.sh rebuild
-    # Single node recovery: bash disaster-recovery.sh node <node_name>
-    # Restore from backup: bash disaster-recovery.sh restore <backup_file>
-
-License: MIT
-"""
+# Proxmox HA Disaster Recovery Procedures
+#
+# Source: https://williamzujkowski.github.io/posts/proxmox-high-availability-homelab/
+# Purpose: DR procedures for cluster rebuild, node recovery, and data restoration
+# Prerequisites: Valid backups, documented configuration
+# Usage:
+#     # Full cluster rebuild: bash disaster-recovery.sh rebuild
+#     # Single node recovery: bash disaster-recovery.sh node <node_name>
+#     # Restore from backup: bash disaster-recovery.sh restore <backup_file>
+#
+# License: MIT
 
 BACKUP_DIR="/mnt/backup/proxmox"
 

--- a/gists/proxmox-ha/ha-manager-setup.sh
+++ b/gists/proxmox-ha/ha-manager-setup.sh
@@ -1,50 +1,69 @@
 #!/bin/bash
-"""
-Proxmox HA Manager Configuration
+# Proxmox HA Manager Configuration
+#
+# Source: https://williamzujkowski.github.io/posts/proxmox-high-availability-homelab/
+# Purpose: Enable HA and configure fencing for failover
+# Requires: an operational Proxmox VE cluster with shared storage
+#
+# Illustrative excerpt, not a turnkey script.
+#
+# The previous version configured IPMI fence agents:
+#
+#     ha-manager add fence-pve1 --type=ipmilan --ip=... --username=... \
+#         --password=... --lanplus=1
+#
+# None of that is real. Per ha-manager(1), the synopsis is
+# `ha-manager add <sid> [OPTIONS]`; <sid> is a RESOURCE id of the form
+# `vm:100` or `ct:100`, `--type` takes `<ct|vm>`, and --ip / --username /
+# --password / --lanplus do not exist. `ha-manager add` registers a VM or
+# container as an HA resource. It has nothing to do with fencing.
+#
+# Proxmox VE does not use external fence agents at all. From the HA wiki:
+# "we wanted to integrate a simpler fencing method, which does not require
+# additional external hardware. This can be done using watchdog timers."
+# ha-manager resets the watchdog during normal operation; if it stops, the
+# timer elapses and the node reboots itself. There is nothing to install and
+# no credentials to store.
 
-Source: https://williamzujkowski.github.io/posts/proxmox-high-availability-homelab/
-Purpose: Enable HA manager and configure fencing for failover
-Prerequisites: Proxmox cluster operational, shared storage configured
-Usage:
-    bash ha-manager-setup.sh
+set -euo pipefail
 
-License: MIT
-"""
-
-# HA is enabled by default with cluster setup
-# Verify HA services are running
-systemctl status pve-ha-lrm
-systemctl status pve-ha-crm
-
-# Check HA status
+# ---------------------------------------------------------------------------
+# 1. HA services. Enabled with the cluster; this just confirms they are up.
+# ---------------------------------------------------------------------------
+systemctl status pve-ha-lrm --no-pager
+systemctl status pve-ha-crm --no-pager
 ha-manager status
 
-# Install fence agents
-apt install -y fence-agents-all
+# ---------------------------------------------------------------------------
+# 2. Fencing = watchdog self-fencing.
+#
+# The default is the kernel softdog. A hardware watchdog is better, but all
+# hardware watchdog modules are blocked by default for safety and must be
+# named explicitly. Find yours (iTCO_wdt on most Intel server boards) and set
+# it in /etc/default/pve-ha-manager, which watchdog-mux reads at startup.
+# ---------------------------------------------------------------------------
+# cat /etc/default/pve-ha-manager
+#   # select watchdog module (default is softdog)
+#   WATCHDOG_MODULE=iTCO_wdt
+#
+# systemctl restart watchdog-mux
+systemctl status watchdog-mux --no-pager
 
-# Configure IPMI-based fencing for each node
-ha-manager add fence-pve1 --type=ipmilan \
-    --ip=10.0.10.21 \
-    --username=admin \
-    --password=secure-password \
-    --lanplus=1
+# ---------------------------------------------------------------------------
+# 3. Register the resources you actually want kept alive.
+#
+# This is what `ha-manager add` is for. Note the sid form.
+# ---------------------------------------------------------------------------
+ha-manager add vm:100 --state started --max_restart 2 --max_relocate 2
+ha-manager add ct:200 --state started
 
-ha-manager add fence-pve2 --type=ipmilan \
-    --ip=10.0.10.22 \
-    --username=admin \
-    --password=secure-password \
-    --lanplus=1
-
-ha-manager add fence-pve3 --type=ipmilan \
-    --ip=10.0.10.23 \
-    --username=admin \
-    --password=secure-password \
-    --lanplus=1
-
-# Test fencing
-fence_ipmilan -a 10.0.10.21 -l admin -p secure-password -o status
-
-# Configure HA groups (optional)
+# ---------------------------------------------------------------------------
+# 4. Node preference (optional).
+#
+# Higher number = higher priority. nofailback=0 lets a service migrate back
+# once its preferred node returns.
+# ---------------------------------------------------------------------------
 ha-manager groupadd critical_services --nodes "pve1:2,pve2:1,pve3:1" --nofailback 0
+ha-manager set vm:100 --group critical_services
 
-echo "HA Manager configured successfully. Fencing agents active."
+echo "HA configured. Fencing is watchdog-based -- verify with: ha-manager status"

--- a/gists/proxmox-ha/ha-manager-setup.sh
+++ b/gists/proxmox-ha/ha-manager-setup.sh
@@ -63,7 +63,15 @@ ha-manager add ct:200 --state started
 # Higher number = higher priority. nofailback=0 lets a service migrate back
 # once its preferred node returns.
 # ---------------------------------------------------------------------------
-ha-manager groupadd critical_services --nodes "pve1:2,pve2:1,pve3:1" --nofailback 0
-ha-manager set vm:100 --group critical_services
+# HA Groups are deprecated: "HA Groups are deprecated and migrated to HA
+# Node Affinity rules since Proxmox VE 9.0."
+ha-manager rules add node-affinity critical-services \
+    --resources vm:100,ct:200 \
+    --nodes "pve1:2,pve2:1,pve3:1"
+
+# On Proxmox VE 8 and earlier this was:
+#   ha-manager groupadd critical_services \
+#       --nodes "pve1:2,pve2:1,pve3:1" --nofailback 0
+#   ha-manager set vm:100 --group critical_services
 
 echo "HA configured. Fencing is watchdog-based -- verify with: ha-manager status"

--- a/gists/proxmox-ha/node-prep.sh
+++ b/gists/proxmox-ha/node-prep.sh
@@ -1,15 +1,13 @@
 #!/bin/bash
-"""
-Proxmox Node Preparation Script
-
-Source: https://williamzujkowski.github.io/posts/proxmox-high-availability-homelab/
-Purpose: Prepare each Proxmox node for cluster membership with proper networking and packages
-Prerequisites: Fresh Proxmox VE 8.x installation
-Usage:
-    bash node-prep.sh
-
-License: MIT
-"""
+# Proxmox Node Preparation Script
+#
+# Source: https://williamzujkowski.github.io/posts/proxmox-high-availability-homelab/
+# Purpose: Prepare each Proxmox node for cluster membership with proper networking and packages
+# Prerequisites: Fresh Proxmox VE 8.x installation
+# Usage:
+#     bash node-prep.sh
+#
+# License: MIT
 
 # On each node: Update and prepare
 apt update && apt full-upgrade -y

--- a/gists/proxmox-ha/vm-ha-config.sh
+++ b/gists/proxmox-ha/vm-ha-config.sh
@@ -1,15 +1,13 @@
 #!/bin/bash
-"""
-VM High Availability Configuration
-
-Source: https://williamzujkowski.github.io/posts/proxmox-high-availability-homelab/
-Purpose: Enable HA for VMs with automatic failover and migration settings
-Prerequisites: HA manager configured, VMs running on shared storage
-Usage:
-    bash vm-ha-config.sh <vm_id>
-
-License: MIT
-"""
+# VM High Availability Configuration
+#
+# Source: https://williamzujkowski.github.io/posts/proxmox-high-availability-homelab/
+# Purpose: Enable HA for VMs with automatic failover and migration settings
+# Prerequisites: HA manager configured, VMs running on shared storage
+# Usage:
+#     bash vm-ha-config.sh <vm_id>
+#
+# License: MIT
 
 if [ -z "$1" ]; then
     echo "Usage: bash vm-ha-config.sh <vm_id>"

--- a/gists/security-scanning/workflows/auto-remediate-vulnerabilities.yml
+++ b/gists/security-scanning/workflows/auto-remediate-vulnerabilities.yml
@@ -9,6 +9,12 @@ on:
   schedule:
     - cron: '0 3 * * 1'  # Weekly on Monday
 
+# Least privilege. peter-evans/create-pull-request needs to push a branch
+# and open the PR, so both writes are required and nothing else is.
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update-dependencies:
     runs-on: ubuntu-latest

--- a/gists/security-scanning/workflows/sbom-generation-workflow.yml
+++ b/gists/security-scanning/workflows/sbom-generation-workflow.yml
@@ -9,6 +9,11 @@ on:
   release:
     types: [published]
 
+# Least privilege. Attaching a release asset writes to the repository.
+permissions:
+  contents: write
+  id-token: write   # OIDC federation for the AWS step below
+
 jobs:
   sbom:
     runs-on: ubuntu-latest
@@ -26,17 +31,25 @@ jobs:
       - name: Scan SBOM
         run: grype sbom:./sbom.cyclonedx.json -o sarif > grype-sbom.sarif
 
+      # actions/upload-release-asset was ARCHIVED by GitHub in March 2021 and
+      # is read-only; it should not be used in new workflows. `gh release
+      # upload` is the maintained path and needs no action at all.
       - name: Upload SBOM to release
-        uses: actions/upload-release-asset@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ github.event.release.tag_name }}" sbom.cyclonedx.json --clobber
+
+      # Requires credentials. `aws s3 cp` will fail without them, and the
+      # OIDC route below is preferable to a long-lived access key: it needs
+      # `id-token: write` added to the permissions block above and a role
+      # trusting this repository.
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./sbom.cyclonedx.json
-          asset_name: sbom.cyclonedx.json
-          asset_content_type: application/json
+          role-to-assume: arn:aws:iam::<account-id>:role/<sbom-upload-role>
+          aws-region: <region>
 
       - name: Store SBOM for future comparison
         run: |
           aws s3 cp sbom.cyclonedx.json \
-            s3://mybucket/sboms/${{ github.repository }}/${{ github.ref_name }}.json
+            s3://<your-bucket>/sboms/${{ github.repository }}/${{ github.ref_name }}.json

--- a/gists/security-scanning/workflows/scheduled-security-scans.yml
+++ b/gists/security-scanning/workflows/scheduled-security-scans.yml
@@ -9,6 +9,11 @@ on:
   schedule:
     - cron: '0 6 * * *'  # Daily at 6 AM UTC
 
+# Least privilege. This job only reads the repo and reports; it performs no
+# writes, so the default token is narrowed rather than widened.
+permissions:
+  contents: read
+
 jobs:
   scan-production:
     runs-on: ubuntu-latest

--- a/gists/security-scanning/workflows/security-scan-workflow-complete.yml
+++ b/gists/security-scanning/workflows/security-scan-workflow-complete.yml
@@ -13,6 +13,16 @@ on:
   schedule:
     - cron: '0 2 * * *'  # Daily at 2 AM
 
+# Least privilege. github/codeql-action/upload-sarif requires
+# security-events: write -- the docs state it is "required for all workflows"
+# (docs.github.com, "Uploading a SARIF file to GitHub"). actions: read and
+# contents: read are only needed in a private repository; both are listed
+# here because this is meant to be copied into either.
+permissions:
+  security-events: write
+  actions: read
+  contents: read
+
 jobs:
   dependency-scan:
     name: Scan Dependencies (OSV)

--- a/gists/vlan-segmentation/mdns-reflector-config.conf
+++ b/gists/vlan-segmentation/mdns-reflector-config.conf
@@ -2,16 +2,30 @@
 # Source: https://williamzujkowski.github.io/posts/zero-trust-vlan-segmentation-homelab/
 # Purpose: Allow service discovery across VLANs without full L2 connectivity
 # Location: /etc/avahi/avahi-daemon.conf
+# Requires: adjust allow-interfaces= to your own VLAN interface names
+#
+# IMPORTANT: the reflector keys belong in [reflector], NOT [server].
+# An earlier version of this file put enable-reflector / reflect-ipv /
+# reflect-filters under [server]. avahi treats an unknown key in a section as
+# FATAL, not something to ignore -- avahi-daemon/main.c's load_config_file()
+# logs `Invalid configuration key "..." in group "..."` and jumps to its
+# cleanup label with r = -1, so main() exits 255 and the daemon never starts.
+# See avahi-daemon.conf(5): SECTION [SERVER] vs SECTION [REFLECTOR].
 
 [server]
 use-ipv4=yes
 use-ipv6=no
-# Specify which interfaces to reflect mDNS traffic between
+# Which interfaces avahi will use at all. Traffic on others is ignored.
 allow-interfaces=eth1.20,eth1.40
-enable-reflector=yes
-reflect-ipv=yes
 
-# Only reflect specific services (AirPlay, Chromecast, HomeKit)
+[reflector]
+enable-reflector=yes
+# Forward mDNS between IPv4 and IPv6. Only meaningful with use-ipv6=yes
+# above, so it is a no-op in this IPv4-only example -- kept to show where
+# the key lives.
+reflect-ipv=no
+# Reflect only these service types. Omit the key entirely to reflect
+# everything; an empty value is not the same thing.
 reflect-filters=_airplay._tcp.local,_raop._tcp.local,_homekit._tcp.local,_googlecast._tcp.local
 
 [wide-area]

--- a/gists/vlan-segmentation/netflow-vlan-analysis.sh
+++ b/gists/vlan-segmentation/netflow-vlan-analysis.sh
@@ -1,40 +1,51 @@
 #!/bin/bash
-"""
-NetFlow VLAN Traffic Analysis Configuration
+# NetFlow analysis for cross-VLAN traffic
+#
+# Source: https://williamzujkowski.github.io/posts/zero-trust-vlan-segmentation-homelab/
+# Purpose: Spot IoT devices reaching outside their VLAN, and port-scan shapes
+# Requires: nfdump on the collector; a NetFlow exporter pointed at it
+#
+# Illustrative excerpt. Three things in the previous version were wrong:
+#
+#   1. It opened with `configure` / `set system flow-accounting ...` /
+#      `commit` under the heading "Enable NetFlow on UDM Pro". That is
+#      EdgeOS syntax; UniFi OS has no configuration mode. Export is set up in
+#      the UniFi Network application, or you mirror the uplink instead.
+#   2. `nfcapd -T all` does nothing. Current nfcapd prints "Option -T no
+#      longer supported and ignored" (src/nfcapd/nfcapd.c) and the man page's
+#      SYNOPSIS has no -T at all; extension selection is -X. `-l` is also a
+#      legacy alias -- nfcapd logs that it "may get removed in future. Please
+#      use -w to set output directory".
+#   3. `flags S` does NOT mean SYN-only. nfdump(1): "Flags not mentioned are
+#      treated as don't care... In order to get those flows with only the SYN
+#      flag set, use the syntax `flags S and not flags AFRPU`". The old
+#      port-scan query therefore matched every SYN-ACK too -- i.e. the normal
+#      second packet of every successful handshake.
+#
+# One more, easy to miss: nfdump takes the filter expression AFTER all
+# options. The old port-scan line put it in the middle, which only worked
+# because glibc's getopt permutes argv; it breaks on BSD and macOS.
 
-Source: https://williamzujkowski.github.io/posts/zero-trust-vlan-segmentation-homelab/
-Purpose: Configure NetFlow v9 for VLAN traffic monitoring and analysis
-Prerequisites: nfdump, nfcapd installed
-Usage:
-    bash netflow-vlan-analysis.sh
+set -euo pipefail
 
-License: MIT
-"""
+FLOWDIR=/var/cache/nfdump
+IOT_NET=10.0.40.0/24
 
-# Enable NetFlow on UDM Pro
-configure
-set system flow-accounting interface eth1
-set system flow-accounting netflow version 9
-set system flow-accounting netflow server 10.0.10.5 port 2055
-set system flow-accounting netflow timeout expiry-interval 60
-set system flow-accounting netflow timeout flow-generic 3600
-commit
-save
+# Collector. -w is the output directory; there is no -T.
+nfcapd -D -w "$FLOWDIR" -p 2055 -P /var/run/nfcapd.pid
 
-# Start nfcapd collector on monitoring server
-nfcapd -D -l /var/cache/nfdump -p 2055 -T all -P /var/run/nfcapd.pid
-
-# Analyze cross-VLAN traffic (IoT VLAN attempting to reach other VLANs)
+# --- Cross-VLAN traffic: IoT reaching outside its own subnet -----------------
 echo "=== Cross-VLAN Traffic Analysis ==="
-nfdump -R /var/cache/nfdump -s srcip/bytes -n 20 \
-  'src net 10.0.40.0/24 and not (dst net 10.0.40.0/24 or dst port 53 or dst port 123)'
+nfdump -R "$FLOWDIR" -s srcip/bytes -n 20 \
+  "src net $IOT_NET and not (dst net $IOT_NET or dst port 53 or dst port 123)"
 
-# Top bandwidth consumers
+# --- Top bandwidth consumers ------------------------------------------------
 echo "=== Top Bandwidth Consumers ==="
-nfdump -R /var/cache/nfdump -s srcip/bytes -n 10
+nfdump -R "$FLOWDIR" -s srcip/bytes -n 10
 
-# Suspicious port scans
+# --- Port-scan shapes: SYN-only, not SYN-ACK --------------------------------
 echo "=== Potential Port Scans ==="
-nfdump -R /var/cache/nfdump 'flags S and packets < 5' -s srcip -n 10
+nfdump -R "$FLOWDIR" -s srcip -n 10 \
+  'flags S and not flags AFRPU and packets < 5'
 
 echo "NetFlow analysis complete"

--- a/gists/vlan-segmentation/pihole-vlan-filtering.sh
+++ b/gists/vlan-segmentation/pihole-vlan-filtering.sh
@@ -1,39 +1,98 @@
 #!/bin/bash
-"""
-Pi-hole VLAN-Specific DNS Filtering
+# Pi-hole VLAN-Specific DNS Filtering
+#
+# Source: https://williamzujkowski.github.io/posts/zero-trust-vlan-segmentation-homelab/
+# Purpose: Apply different DNS blocklists per VLAN, and actually force IoT
+#          devices onto Pi-hole instead of their hardcoded resolvers.
+# Requires: Pi-hole v6 (checked against v6.4.3), root on the Pi-hole host,
+#           and a firewall you control on the inter-VLAN gateway.
+#
+# Illustrative excerpt, not a turnkey script -- substitute your own VLANs,
+# interfaces and domains.
+#
+# This replaces an earlier version that was wrong in four ways, all of which
+# are worth stating because each one FAILS SILENTLY:
+#
+#   1. It wrote a hosts-format blocklist to /etc/pihole/iot-blocklist.list.
+#      Pi-hole never reads that path. v6 emits `hostsdir=/etc/pihole/hosts`
+#      (FTL src/config/dnsmasq_config.c), so a hosts file has to live in that
+#      DIRECTORY to be loaded at all.
+#   2. It used `bogus-nxdomain=` to "block DNS requests to external
+#      resolvers". That is not what the directive does. dnsmasq(8):
+#      "Transform replies which contain the specified address or subnet into
+#      'No such domain' replies." It rewrites ANSWERS, so it blocks nothing
+#      outbound -- and pointing it at 8.8.8.8/1.1.1.1 NXDOMAINs dns.google
+#      and one.one.one.one for every client on the network.
+#   3. It wrote conditional forwarding into /etc/dnsmasq.d/. In v6 that
+#      directory is only read when `misc.etc_dnsmasq_d` is enabled, and its
+#      default is false (FTL src/config/config.c: `.d.b = false`).
+#   4. It ended with `pihole restartdns`, which v6 removed.
 
-Source: https://williamzujkowski.github.io/posts/zero-trust-vlan-segmentation-homelab/
-Purpose: Apply different DNS blocklists per VLAN with conditional forwarding
-Location: /etc/pihole/custom.list and /etc/dnsmasq.d/custom.conf
-Prerequisites: Pi-hole installed, access to configuration
-Usage:
-    bash pihole-vlan-filtering.sh
+set -euo pipefail
 
-License: MIT
-"""
+IOT_IFACE="eth1.40"          # the IoT VLAN interface on the gateway
+PIHOLE_IP="10.0.30.5"
 
-# Block telemetry domains for IoT VLAN
-cat > /etc/pihole/iot-blocklist.list <<EOF
-0.0.0.0 phone-home.camera-vendor.com
-0.0.0.0 telemetry.iot-vendor.com
-0.0.0.0 stats.smart-device.com
-0.0.0.0 tracking.xiaomi.com
-0.0.0.0 analytics.tp-link.com
-EOF
+# ---------------------------------------------------------------------------
+# 1. Block telemetry domains.
+#
+# Use the CLI so the entries land in Pi-hole's gravity database, where the
+# web UI and Group Management can see them. `--wild` covers subdomains.
+# ---------------------------------------------------------------------------
+pihole deny \
+  phone-home.camera-vendor.com \
+  telemetry.iot-vendor.com \
+  stats.smart-device.com
 
-# Conditional forwarding for internal domains
-cat > /etc/dnsmasq.d/vlan-conditional.conf <<EOF
-# Forward internal domain queries to appropriate DNS servers
-server=/lab.home/10.0.30.5
-server=/mgmt.home/10.0.10.5
-server=/servers.home/10.0.30.5
+pihole deny --wild tracking.xiaomi.com analytics.tp-link.com
 
-# Block DNS requests from IoT to external resolvers (force Pi-hole)
-bogus-nxdomain=8.8.8.8
-bogus-nxdomain=1.1.1.1
-EOF
+# Per-VLAN scoping is Group Management, not a per-VLAN file: create a group,
+# assign the IoT clients to it by IP or MAC, and attach these deny entries to
+# that group. There is no supported way to bind a blocklist file to a subnet.
 
-# Restart Pi-hole to apply changes
-pihole restartdns
+# ---------------------------------------------------------------------------
+# 2. Local DNS records, if you need them.
+#
+# v6's custom list is /etc/pihole/hosts/custom.list, and everything else in
+# /etc/pihole/hosts is loaded too via hostsdir=. This is the only place a
+# hosts-format file does anything.
+# ---------------------------------------------------------------------------
+cat > /etc/pihole/hosts/vlan-local.list <<'HOSTS'
+10.0.30.5 dns.lab.home
+10.0.10.5 mgmt.lab.home
+HOSTS
+
+# ---------------------------------------------------------------------------
+# 3. Conditional forwarding.
+#
+# Supported route in v6 is `misc.dnsmasq_lines` in pihole.toml (or the web
+# UI's "Additional dnsmasq settings"), NOT a file in /etc/dnsmasq.d.
+# ---------------------------------------------------------------------------
+pihole-FTL --config misc.dnsmasq_lines '[
+  "server=/lab.home/10.0.30.5",
+  "server=/mgmt.home/10.0.10.5",
+  "server=/servers.home/10.0.30.5"
+]'
+
+# ---------------------------------------------------------------------------
+# 4. Actually force IoT devices onto Pi-hole.
+#
+# This is a FIREWALL job, on the gateway -- DNS has no mechanism to refuse
+# queries it never receives. Redirect port 53 to Pi-hole and drop DoT so a
+# device cannot simply bypass you on 853.
+# ---------------------------------------------------------------------------
+iptables -t nat -A PREROUTING -i "$IOT_IFACE" -p udp --dport 53 \
+  ! -d "$PIHOLE_IP" -j DNAT --to-destination "$PIHOLE_IP:53"
+iptables -t nat -A PREROUTING -i "$IOT_IFACE" -p tcp --dport 53 \
+  ! -d "$PIHOLE_IP" -j DNAT --to-destination "$PIHOLE_IP:53"
+
+# DNS-over-TLS. DoH rides on 443 and cannot be separated by port alone --
+# blocking it needs a resolver blocklist or SNI filtering.
+iptables -A FORWARD -i "$IOT_IFACE" -p tcp --dport 853 -j REJECT
+
+# ---------------------------------------------------------------------------
+# 5. Apply.
+# ---------------------------------------------------------------------------
+pihole reloadlists   # `restartdns` was removed in v6
 
 echo "VLAN-specific DNS filtering configured"

--- a/gists/vlan-segmentation/pihole-vlan-filtering.sh
+++ b/gists/vlan-segmentation/pihole-vlan-filtering.sh
@@ -74,6 +74,12 @@ pihole-FTL --config misc.dnsmasq_lines '[
   "server=/servers.home/10.0.30.5"
 ]'
 
+# A CONFIG change needs a restart. The docs are explicit that neither reload
+# command re-reads configuration: `pihole reloadlists` is "Reload DNS lists.
+# Note: This will NOT re-read any *.conf files", and `pihole reloaddns` says
+# the same. Only list changes are covered by a reload.
+systemctl restart pihole-FTL
+
 # ---------------------------------------------------------------------------
 # 4. Actually force IoT devices onto Pi-hole.
 #
@@ -93,6 +99,8 @@ iptables -A FORWARD -i "$IOT_IFACE" -p tcp --dport 853 -j REJECT
 # ---------------------------------------------------------------------------
 # 5. Apply.
 # ---------------------------------------------------------------------------
-pihole reloadlists   # `restartdns` was removed in v6
+# Lists only. `restartdns` was removed in v6; reloadlists/reloaddns do not
+# re-read config, which is why the restart above is separate.
+pihole reloadlists
 
 echo "VLAN-specific DNS filtering configured"

--- a/gists/vlan-segmentation/pvlan-iot-isolation.sh
+++ b/gists/vlan-segmentation/pvlan-iot-isolation.sh
@@ -1,29 +1,58 @@
 #!/bin/bash
-"""
-Private VLAN (PVLAN) IoT Isolation
+# Private VLAN isolation for the IoT VLAN
+#
+# Source: https://williamzujkowski.github.io/posts/zero-trust-vlan-segmentation-homelab/
+# Purpose: Stop IoT devices from talking to each other while still reaching
+#          the gateway
+#
+# Illustrative reference. The commands below are Cisco IOS configuration-mode
+# lines for a Catalyst switch -- paste them at a `configure terminal` prompt.
+# They are not shell commands and this file will not "run".
+#
+# The previous version could not work on any device. It wrapped Cisco
+# `switchport private-vlan ...` keywords inside Vyatta/EdgeOS operators
+# (`configure`, `set interfaces ethernet eth1 vif 40 ...`, `commit`, `save`).
+# Cisco IOS has no `set interfaces` and no `commit`/`save`; EdgeOS and VyOS
+# have no `private-vlan` node. No platform accepts both.
+#
+# It was also malformed as Cisco. `switchport private-vlan host-association`
+# takes TWO NUMERIC VLAN IDs -- <primary> <secondary> -- not the literal word
+# `isolated`; and `switchport private-vlan mapping` takes <primary>
+# <secondary-list>, not `promiscuous`. Port mode is a separate command from
+# the mapping. Nothing in the old file ever associated a primary with a
+# secondary, so no private VLAN existed to isolate anything.
+#
+# VLAN 40 is the primary; VLAN 41 is the isolated secondary.
 
-Source: https://williamzujkowski.github.io/posts/zero-trust-vlan-segmentation-homelab/
-Purpose: Isolate IoT devices from each other while allowing gateway access
-Prerequisites: Managed switch with PVLAN support
-Usage:
-    bash pvlan-iot-isolation.sh
+cat <<'IOS'
+! Private VLANs require VTP transparent mode on VTP v1/v2.
+! (VTP v3 supports them in all modes.)
+vtp mode transparent
 
-License: MIT
-"""
+! Define the secondary first, then the primary, then associate them.
+vlan 41
+ private-vlan isolated
+vlan 40
+ private-vlan primary
+ private-vlan association 41
 
-# Create isolated ports within IoT VLAN
-configure
-set interfaces ethernet eth1 vif 40 private-vlan isolated
-set interfaces ethernet eth2 switchport private-vlan host-association 40 isolated
-set interfaces ethernet eth3 switchport private-vlan host-association 40 isolated
-set interfaces ethernet eth4 switchport private-vlan host-association 40 isolated
-set interfaces ethernet eth5 switchport private-vlan host-association 40 isolated
+! Layer 3 gateway for the private-VLAN domain.
+interface Vlan40
+ ip address 10.0.40.1 255.255.255.0
+ private-vlan mapping 41
 
-# Create promiscuous port for gateway (allows communication with all isolated ports)
-set interfaces ethernet eth1 switchport private-vlan mapping 40 promiscuous
+! IoT device ports: host ports in the isolated secondary.
+! host-association takes <primary> <secondary>, both numeric.
+interface range GigabitEthernet1/0/2 - 5
+ switchport mode private-vlan host
+ switchport private-vlan host-association 40 41
 
-commit
-save
+! Uplink toward the router: promiscuous port.
+! Mode first, then the mapping -- two separate commands.
+interface GigabitEthernet1/0/1
+ switchport mode private-vlan promiscuous
+ switchport private-vlan mapping 40 41
+IOS
 
-echo "PVLAN isolation configured for IoT VLAN"
-echo "Devices on eth2-eth5 can reach gateway but not each other"
+echo
+echo "Devices on Gi1/0/2-5 reach the promiscuous uplink but not each other."

--- a/gists/vlan-segmentation/udm-pro-vlan-config.sh
+++ b/gists/vlan-segmentation/udm-pro-vlan-config.sh
@@ -1,39 +1,55 @@
 #!/bin/bash
-"""
-UDM Pro VLAN Creation and Configuration
+# UDM Pro VLAN Configuration
+#
+# Source: https://williamzujkowski.github.io/posts/zero-trust-vlan-segmentation-homelab/
+# Purpose: Define the seven-VLAN homelab layout the post describes
+#
+# Illustrative reference, not a runnable script -- and deliberately so, because
+# on a UDM Pro there is no CLI to run.
+#
+# The previous version of this file was EdgeRouter (EdgeOS) syntax:
+#
+#     configure
+#     set interfaces ethernet eth1 vif 10 address 10.0.10.1/24
+#     commit ; save
+#
+# That is verbatim the shape in Ubiquiti's own EdgeRouter VLAN article, for a
+# different product family. A UDM Pro runs UniFi OS: SSH gives a Linux root
+# shell (disabled by default after setup, and Ubiquiti advises against it
+# outside Support-directed troubleshooting). There is no Vyatta configuration
+# mode, so `configure` / `set` / `commit` / `save` are not commands that exist
+# there. The file also issued `set system advanced enable` BEFORE `configure`,
+# which could not work even on EdgeOS, where `set` only exists inside
+# configuration mode.
+#
+# VLANs are defined in the UniFi Network application:
+#   Settings > Networks > New Virtual Network
+# setting Name, VLAN ID, Gateway IP/Subnet, and DHCP mode/range for each.
+#
+#   VLAN ID   Name         Gateway
+#   -------   ----------   ---------------
+#   10        Management   10.0.10.1/24
+#   20        Trusted      10.0.20.1/24
+#   30        Servers      10.0.30.1/24
+#   40        IoT          10.0.40.1/24
+#   50        Guest        10.0.50.1/24
+#   60        Lab          10.0.60.1/24
+#   70        DMZ          10.0.70.1/24
+#
+# If you want this automated rather than clicked, the supported route is the
+# UniFi Network API, not SSH:
+#   POST /proxy/network/api/s/<site>/rest/networkconf
+# with a JSON body carrying name, vlan, ip_subnet and dhcpd settings.
 
-Source: https://williamzujkowski.github.io/posts/zero-trust-vlan-segmentation-homelab/
-Purpose: Create VLANs with proper tagging and trunk port configuration on Ubiquiti Dream Machine Pro
-Prerequisites: SSH access to UDM Pro, admin credentials
-Usage:
-    bash udm-pro-vlan-config.sh
+cat <<'EOF'
+VLANs on a UDM Pro are created in the UniFi Network application:
+  Settings > Networks > New Virtual Network
 
-License: MIT
-"""
+  10 Management  10.0.10.1/24      50 Guest   10.0.50.1/24
+  20 Trusted     10.0.20.1/24      60 Lab     10.0.60.1/24
+  30 Servers     10.0.30.1/24      70 DMZ     10.0.70.1/24
+  40 IoT         10.0.40.1/24
 
-# SSH into UDM Pro
-# ssh admin@10.0.0.1
-
-# Enable advanced features
-set system advanced enable
-
-# Configure VLANs
-configure
-set interfaces ethernet eth1 vif 10 description "Management"
-set interfaces ethernet eth1 vif 10 address 10.0.10.1/24
-set interfaces ethernet eth1 vif 20 description "Trusted"
-set interfaces ethernet eth1 vif 20 address 10.0.20.1/24
-set interfaces ethernet eth1 vif 30 description "Servers"
-set interfaces ethernet eth1 vif 30 address 10.0.30.1/24
-set interfaces ethernet eth1 vif 40 description "IoT"
-set interfaces ethernet eth1 vif 40 address 10.0.40.1/24
-set interfaces ethernet eth1 vif 50 description "Guest"
-set interfaces ethernet eth1 vif 50 address 10.0.50.1/24
-set interfaces ethernet eth1 vif 60 description "Lab"
-set interfaces ethernet eth1 vif 60 address 10.0.60.1/24
-set interfaces ethernet eth1 vif 70 description "DMZ"
-set interfaces ethernet eth1 vif 70 address 10.0.70.1/24
-commit
-save
-
-echo "VLANs configured successfully on UDM Pro"
+There is no EdgeOS-style CLI on UniFi OS. For automation use the
+UniFi Network API endpoint /rest/networkconf.
+EOF

--- a/gists/vlan-segmentation/vlan-breakout-tests.sh
+++ b/gists/vlan-segmentation/vlan-breakout-tests.sh
@@ -1,16 +1,14 @@
 #!/bin/bash
-"""
-VLAN Breakout Penetration Testing
-
-Source: https://williamzujkowski.github.io/posts/zero-trust-vlan-segmentation-homelab/
-Purpose: Test VLAN isolation with controlled penetration testing
-WARNING: Only run on your own network with proper authorization
-Prerequisites: nmap, metasploit (optional)
-Usage:
-    bash vlan-breakout-tests.sh
-
-License: MIT
-"""
+# VLAN Breakout Penetration Testing
+#
+# Source: https://williamzujkowski.github.io/posts/zero-trust-vlan-segmentation-homelab/
+# Purpose: Test VLAN isolation with controlled penetration testing
+# WARNING: Only run on your own network with proper authorization
+# Prerequisites: nmap, metasploit (optional)
+# Usage:
+#     bash vlan-breakout-tests.sh
+#
+# License: MIT
 
 echo "=== VLAN Breakout Testing ==="
 echo "WARNING: Only run on authorized networks"

--- a/gists/vlan-segmentation/vlan-connectivity-tests.sh
+++ b/gists/vlan-segmentation/vlan-connectivity-tests.sh
@@ -1,15 +1,13 @@
 #!/bin/bash
-"""
-VLAN Segmentation Connectivity Test Suite
-
-Source: https://williamzujkowski.github.io/posts/zero-trust-vlan-segmentation-homelab/
-Purpose: Validate VLAN segmentation is working correctly
-Prerequisites: nmap, ping access
-Usage:
-    bash vlan-connectivity-tests.sh
-
-License: MIT
-"""
+# VLAN Segmentation Connectivity Test Suite
+#
+# Source: https://williamzujkowski.github.io/posts/zero-trust-vlan-segmentation-homelab/
+# Purpose: Validate VLAN segmentation is working correctly
+# Prerequisites: nmap, ping access
+# Usage:
+#     bash vlan-connectivity-tests.sh
+#
+# License: MIT
 
 # Test connectivity between VLANs
 declare -A vlans=(


### PR DESCRIPTION
Closes #512. **These changes are published to the live gists as well as this mirror** — de-linking a post doesn't retract an artifact, so the fix had to land where readers actually find it. Drift check: **45/45 in sync**.

Every correction is cited to upstream source or documentation, because the whole problem was that the previous content was *plausible* and wrong.

## The nine wrong-fact defects

| file | what it claimed | what is true |
|---|---|---|
| `mdns-reflector-config.conf` | reflector keys under `[server]` | they're `[reflector]`; an unknown key is **fatal** — avahi logs `Invalid configuration key` and exits 255, so the daemon never started |
| `pihole-vlan-filtering.sh` | `bogus-nxdomain` blocks egress DNS | dnsmasq(8): *"Transform replies which contain the specified address... into 'No such domain' replies"* — rewrites answers, blocks nothing outbound, and NXDOMAINs `dns.google` for every client |
| ″ | blocklist at `/etc/pihole/iot-blocklist.list` | never read; v6 emits `hostsdir=/etc/pihole/hosts` |
| ″ | conditional forwarding via `/etc/dnsmasq.d/` | only read when `misc.etc_dnsmasq_d` is on — default `false` |
| ″ | `pihole restartdns` | removed in v6 |
| `ha-manager-setup.sh` | `ha-manager add fence-pve1 --type=ipmilan --lanplus=1` | `<sid>` is a *resource* id (`vm:100`), `--type` is `<ct\|vm>`, those flags don't exist. PVE **self-fences with a watchdog** — no fence agents at all |
| `udm-pro-vlan-config.sh` | EdgeOS `configure`/`vif`/`commit` on a UDM Pro | that's EdgeRouter syntax; UniFi OS has no configuration mode |
| `pvlan-iot-isolation.sh` | `host-association 40 isolated` | takes two **numeric** VLAN IDs; also mixed Cisco keywords inside Vyatta operators, which no device accepts |
| `netflow-vlan-analysis.sh` | `-T all`, and `flags S` = SYN-only | `-T` prints *"no longer supported and ignored"*; `flags S` matches SYN-ACK too — every successful handshake |
| `backup-config.sh` | "7 days local, 30 days offsite" | `rclone sync` deletes at the destination, so offsite converged on local: **7 days** — neither the 30 the script said nor the 90 the README said |
| 4 × `workflows/*.yml` | — | none declared `permissions:` at all; `upload-sarif` needs `security-events: write` |

Also: `actions/upload-release-asset` is **archived** (verified via the API — `"archived": true`, last push 2021-03-03), and the `aws s3 cp` step had no credentials, so it could only fail.

## I had to correct two of my own fixes

The upstream verification caught both:

- I applied a Pi-hole config change then ran `pihole reloadlists`. The docs are explicit: *"This will NOT re-read any `*.conf` files"* — and `reloaddns` says the same. A config change needs an FTL restart.
- I used `ha-manager groupadd`. Valid, but *"HA Groups are deprecated and migrated to HA Node Affinity rules since Proxmox VE 9.0."*

## One claim I did *not* make

The review asserted `set system advanced enable` "exists in no node index". That's an unprovable negative and verification returned **UNVERIFIED**. The line is still wrong for a different, provable reason: it runs `set` *before* `configure`, and `set` only exists inside configuration mode. I flagged it on that basis.

Similarly, the review said Pi-hole has "no wildcard include". **Partly wrong** — v6 does have a directory include, just not at the path the script used. The correction reflects what's actually true.

## Consistency

Converted the remaining 9 shell headers from Python docstrings to `#` comments — it was the README's own universal-docstring template that produced them. Every `.sh` under `gists/` now passes `bash -n`. A low bar, and the point: an excerpt that doesn't parse isn't demonstrating anything.

Placeholders, elided error handling and example IPs are untouched. These are pseudocode; that was never the defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AvTumDxQ2ntLDwsSefHtf