### PR TITLE
fix(ci): check internal links on disk, where they actually resolve

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -54,6 +54,8 @@ jobs:
           node-version: '22'
           cache: 'pnpm'
           cache-dependency-path: astro-site/pnpm-lock.yaml
+      - name: Install UV (for the internal-link check)
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
       - name: Install deps
         run: cd astro-site && pnpm install --frozen-lockfile
       - name: Install Playwright chromium
@@ -74,6 +76,14 @@ jobs:
       # Those are fixed; this is a gate now. It is the only check in the repo
       # that measures real composited pixels rather than token values, so it
       # catches what the generator's contrast solver structurally cannot.
+      # Internal links resolve against files on disk, so they are checked
+      # there rather than over HTTP (issue #502). link-monitor.yml could never
+      # catch these: aiohttp raises InvalidURL on a relative path, which is
+      # recorded as `needs_manual`, and the gate only counts `broken`.
+      # Deterministic and offline, so unlike the network check it can block.
+      - name: Internal link + anchor check (blocking)
+        run: uv run python scripts/link-validation/internal-link-check.py
+
       - name: Grain composited-contrast audit (real screenshot pixel sample — blocking)
         run: cd astro-site && pnpm audit:grain
       - name: Upload report on failure

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   push:
     branches: [main]
+  workflow_dispatch:   # re-run on demand without an empty commit
 
 permissions:
   contents: read

--- a/.github/workflows/audits.yml
+++ b/.github/workflows/audits.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   push:
     branches: [main]
+  workflow_dispatch:   # re-run on demand without an empty commit
 
 permissions:
   contents: read

--- a/.github/workflows/link-monitor.yml
+++ b/.github/workflows/link-monitor.yml
@@ -135,36 +135,44 @@ jobs:
             f.write(f'internal_broken={len(internal_broken)}\n')
             f.write(f'external_broken={len(external_broken)}\n')
 
-        event = os.environ.get('GITHUB_EVENT_NAME', '')
-        is_pr = event == 'pull_request'
+        # INTERNAL links are not this workflow's job any more (issue #502).
+        # They resolve against files on disk, and aiohttp cannot even express
+        # a relative path -- it raises InvalidURL, which is recorded as
+        # 'needs_manual', so the old `status == broken` test could never see
+        # them. 182 links, ~12% of the corpus, were exempt by construction.
+        # scripts/link-validation/internal-link-check.py checks them properly
+        # in a11y.yml, offline and blocking. The count is still reported here
+        # because a non-zero value would mean the two disagree.
+        if internal_broken:
+            print(f'NOTE: {len(internal_broken)} absolute own-domain links look broken. '
+                  'internal-link-check.py in a11y.yml is authoritative for these.')
 
-        # For PRs: only fail on internal broken links (> 5)
-        # External failures are often transient (rate limits, timeouts)
-        if is_pr:
-            if len(internal_broken) > 5:
-                print(f'ERROR: {len(internal_broken)} internal broken links')
-                exit(1)
-            elif len(external_broken) > 0:
-                print(f'WARNING: {len(external_broken)} external links failed (non-blocking for PRs)')
-        else:
-            # For scheduled runs: warn but don't fail on external-only issues
-            if len(internal_broken) > 5:
-                print(f'ERROR: {len(internal_broken)} internal broken links')
-                exit(1)
-            elif broken_pct > 50:
-                print(f'WARNING: High external failure rate ({broken_pct:.1f}%) - possible network issue')
+        # EXTERNAL rot stays advisory: it is a property of the network, not of
+        # this commit, so it must never fail a build. It DOES need somewhere to
+        # surface -- previously a >50% failure rate printed a warning and
+        # exited 0, so the issue-filing step (gated on `failure()`) could never
+        # fire and external rot was reported to nobody.
+        print(f'External failures: {len(external_broken)} ({broken_pct:.1f}% of all links)')
         "
 
+    # Fires on the scheduled run when external rot crosses the threshold --
+    # NOT on `failure()`, which never happened because nothing exits non-zero
+    # for external links. The job stays green; the issue is the output.
     - name: Create Issue for Broken Links
-      if: failure() && github.event_name == 'schedule'
+      if: >-
+        always() && github.event_name == 'schedule' &&
+        fromJSON(steps.check_critical.outputs.external_broken || '0') > 5
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
       with:
         script: |
           const fs = require('fs');
           const report = fs.readFileSync('reports/summary.md', 'utf8');
 
-          const title = `🔗 Link Health Alert: ${process.env.broken_count} broken links found`;
-          const body = `## Automated Link Health Check Failed\n\n` +
+          const title = `🔗 External link rot: ${process.env.external_broken} link(s) not resolving`;
+          const body = `## External link health report\n\n` +
+                `_Advisory. The job did not fail — external availability is a property of\n`+
+                `the network, not of any commit. Internal links and anchors are checked\n`+
+                `separately and blockingly by internal-link-check.py in a11y.yml._\n\n` +
                 `**Date:** ${new Date().toISOString()}\n` +
                 `**Broken Links:** ${process.env.broken_count}/${process.env.total_count} (${process.env.broken_percent}%)\n\n` +
                 `### Summary Report\n\n${report}\n\n` +
@@ -204,6 +212,7 @@ jobs:
         broken_count: ${{ steps.check_critical.outputs.broken_count }}
         total_count: ${{ steps.check_critical.outputs.total_count }}
         broken_percent: ${{ steps.check_critical.outputs.broken_percent }}
+        external_broken: ${{ steps.check_critical.outputs.external_broken }}
 
     - name: Comment on PR
       if: github.event_name == 'pull_request'

--- a/scripts/link-validation/internal-link-check.py
+++ b/scripts/link-validation/internal-link-check.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Verify every internal link and in-page anchor in the built site.
+
+Why this exists (issue #502): `link-monitor.yml`'s only failure condition
+counts results whose status is `broken`. Relative paths never reach that
+status -- simple-validator hands them to aiohttp, which raises `InvalidURL`,
+which is recorded as `needs_manual`. So 182 relative links, about 12% of the
+corpus, were structurally exempt from the one classification the gate reads.
+A deliberately nonexistent internal post URL was not "broken".
+
+HTTP was the wrong tool. Internal links resolve against files on disk, so
+this walks `dist/` and checks them there: deterministic, offline,
+sub-second, and able to fail the build -- unlike everything previously
+pointed at links.
+
+What it checks:
+  * root-relative hrefs (`/posts/x/`) resolve to a file in dist/
+  * in-page fragments (`#notes`) match an id or a name in that page
+  * cross-page fragments (`/about/#contact`) resolve on the target page
+
+What it deliberately does NOT check: external URLs (that is link-monitor's
+job, over the network, and it must stay advisory because the network is not
+a property of this commit).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+
+# href/src values. Skips anything with a scheme and protocol-relative URLs.
+LINK_RE = re.compile(r'(?:href|src)\s*=\s*"([^"]+)"', re.I)
+ID_RE = re.compile(r'\bid\s*=\s*"([^"]+)"', re.I)
+NAME_RE = re.compile(r'<a\b[^>]*\bname\s*=\s*"([^"]+)"', re.I)
+
+# Emitted by the build for the search index and similar; not page links.
+IGNORE_PREFIXES = ("/pagefind/",)
+
+
+def page_ids(html: str) -> set[str]:
+    return set(ID_RE.findall(html)) | set(NAME_RE.findall(html))
+
+
+def resolve(dist: Path, path: str) -> Path | None:
+    """Map a site-absolute path to the file that serves it, or None."""
+    rel = unquote(path).lstrip("/")
+    if rel == "":
+        rel = "index.html"
+    candidates = [dist / rel]
+    if not rel.endswith(".html"):
+        candidates += [dist / rel / "index.html", dist / (rel + ".html")]
+    for c in candidates:
+        if c.is_file():
+            return c
+    return None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--dist", type=Path, default=Path("astro-site/dist"))
+    ap.add_argument("--quiet", action="store_true", help="only print failures")
+    args = ap.parse_args()
+
+    dist: Path = args.dist
+    if not dist.is_dir():
+        print(f"ERROR: dist not found at {dist}. Run `pnpm build` first.", file=sys.stderr)
+        return 1
+
+    pages = sorted(dist.rglob("*.html"))
+    if not pages:
+        print(f"ERROR: no HTML under {dist}. An empty walk is not a clean pass.", file=sys.stderr)
+        return 1
+
+    ids_cache: dict[Path, set[str]] = {}
+    failures: dict[str, list[str]] = defaultdict(list)
+    checked_links = 0
+    checked_anchors = 0
+
+    for page in pages:
+        html = page.read_text(encoding="utf-8", errors="replace")
+        here = "/" + str(page.relative_to(dist)).removesuffix("index.html").removesuffix("/")
+
+        for raw in LINK_RE.findall(html):
+            value = raw.strip()
+            if not value or value.startswith(("//", "data:", "mailto:", "tel:")):
+                continue
+            if urlsplit(value).scheme:
+                continue
+            if not value.startswith(("/", "#")):
+                continue  # genuinely relative; the site does not emit these
+            if value.startswith(IGNORE_PREFIXES):
+                continue
+
+            parts = urlsplit(value)
+            target_page = page
+            if parts.path:
+                checked_links += 1
+                found = resolve(dist, parts.path)
+                if found is None:
+                    failures[here].append(f"dead path  {value}")
+                    continue
+                target_page = found
+
+            if parts.fragment:
+                checked_anchors += 1
+                if target_page not in ids_cache:
+                    ids_cache[target_page] = page_ids(
+                        target_page.read_text(encoding="utf-8", errors="replace")
+                    )
+                if unquote(parts.fragment) not in ids_cache[target_page]:
+                    failures[here].append(f"dead anchor {value}")
+
+    total = sum(len(v) for v in failures.values())
+    if not args.quiet:
+        print(
+            f"internal-link-check: {len(pages)} pages, {checked_links} links, "
+            f"{checked_anchors} anchors"
+        )
+
+    if not failures:
+        print("All internal links and anchors resolve.")
+        return 0
+
+    print(f"\n{total} broken internal reference(s) across {len(failures)} page(s):\n")
+    for src in sorted(failures):
+        print(f"  {src}")
+        for f in sorted(set(failures[src])):
+            print(f"      {f}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #502.

## The gate could not see 12% of the corpus

`link-monitor.yml`'s only failure condition counts results whose status is `broken`. Relative paths can never reach it — `simple-validator` hands them to aiohttp, which raises `InvalidURL`, recorded as `needs_manual`:

```
/posts/THIS-PAGE-DOES-NOT-EXIST  ->  needs_manual | connection_error
```

**182 relative links were structurally exempt** from the one classification the gate reads. A deliberately nonexistent internal post URL was not "broken".

## HTTP was the wrong tool

Internal links resolve against files on disk. `scripts/link-validation/internal-link-check.py` checks them there — deterministic, offline, sub-second, and therefore able to **block**, unlike everything previously pointed at links.

```
internal-link-check: 210 pages, 6488 links, 2525 anchors
All internal links and anchors resolve.
```

Clean today, so it gates from day one rather than starting as a warning. It handles root-relative hrefs, in-page fragments, and cross-page fragments (`/about/#contact` must resolve to an id *on that page*), and ignores external URLs, mailto/tel, protocol-relative and data URIs.

Eleven negative controls:

| planted | exit |
|---|---|
| clean dist | 0 |
| dead path `/NOPE-posts/` | 1 |
| dead in-page anchor | 1 |
| dead **cross-page** anchor `/about/#…` | 1 |
| target page deleted | 1 |
| empty dist | 1 |
| missing dist | 1 |
| external / mailto / protocol-relative / valid | 0 |

Wired into `a11y.yml`, whose `axe` job already builds `dist` and is a required check.

## The other half: external rot was reported to nobody

The scheduled run printed `WARNING: High external failure rate` and exited 0. The issue-filing step was gated on `failure()`. Since nothing exits non-zero for external links, **that step could never fire** — the check ran nightly and told no one.

It now fires on `always() && schedule && external_broken > 5`, so the job stays green (external availability is a property of the network, not of a commit) while the rot actually surfaces. The issue text was rewritten too — it used to say *"Automated Link Health Check Failed"* for a check that hadn't failed and couldn't.

The internal-broken count is still computed and printed, because a non-zero value now means the two checkers **disagree**, which is worth knowing.

## Verification

62 pytest · ruff clean · 62/62 Playwright · `astro check` · all 7 workflows parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AvTumDxQ2ntLDwsSefHtf